### PR TITLE
chore(release): prepare 0.0.0 reservation package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,11 +48,12 @@ jobs:
       - name: Verify bootstrap package
         if: github.event.release.tag_name == 'v0.0.0'
         run: |
-          npm pack --json > package.json.out
-          package_file="$(node -p "require('./package.json.out')[0].filename")"
-          local_integrity="$(node -p "require('./package.json.out')[0].integrity")"
+          pack_metadata="$RUNNER_TEMP/agentrinse-pack.json"
+          npm pack --json > "$pack_metadata"
+          package_file="$(node -p "JSON.parse(require('node:fs').readFileSync(process.argv[1], 'utf8'))[0].filename" "$pack_metadata")"
+          local_integrity="$(node -p "JSON.parse(require('node:fs').readFileSync(process.argv[1], 'utf8'))[0].integrity" "$pack_metadata")"
           registry_integrity="$(npm view agentrinse@0.0.0 dist.integrity)"
-          rm "$package_file" package.json.out
+          rm "$package_file" "$pack_metadata"
           test "$local_integrity" = "$registry_integrity"
 
       - name: Publish to npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,5 +45,16 @@ jobs:
         run: |
           test "$RELEASE_TAG" = "v$(node -p "require('./package.json').version")"
 
+      - name: Verify bootstrap package
+        if: github.event.release.tag_name == 'v0.0.0'
+        run: |
+          npm pack --json > package.json.out
+          package_file="$(node -p "require('./package.json.out')[0].filename")"
+          local_integrity="$(node -p "require('./package.json.out')[0].integrity")"
+          registry_integrity="$(npm view agentrinse@0.0.0 dist.integrity)"
+          rm "$package_file" package.json.out
+          test "$local_integrity" = "$registry_integrity"
+
       - name: Publish to npm
+        if: github.event.release.tag_name != 'v0.0.0'
         run: npm publish --access public

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ coverage/
 .env.*
 !.env.example
 .agentrinse/
+.crabbox/
 tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/
+node_modules
 dist/
 coverage/
 .DS_Store
@@ -9,4 +9,3 @@ coverage/
 !.env.example
 .agentrinse/
 tmp/
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 All notable changes to AgentRinse will be documented in this file.
 
-The project follows semantic versioning after its first published release.
+The project follows semantic versioning after its first supported release.
 
-## [0.1.0] - 2026-07-23
+## [Unreleased]
 
 ### Added
 
@@ -35,3 +35,12 @@ The project follows semantic versioning after its first published release.
   expired plans, changed configuration, and concurrent runs fail closed
 - no process killing, `sudo`, generic force flag, wildcard deletion, or
   unfiltered Docker prune
+
+## [0.0.0] - 2026-07-24
+
+### Added
+
+- reserved the public `agentrinse` npm package name
+- linked the package to the public source repository
+- documented that the reservation release is unsupported for operational
+  cleanup

--- a/README.md
+++ b/README.md
@@ -6,9 +6,13 @@ AgentRinse inventories agent state and developer residue, explains why
 resources are protected, produces content-addressed cleanup plans, and applies
 only actions that still pass every safety check.
 
-## Version 0.1
+> [!IMPORTANT]
+> `0.0.0` is a package-reservation release. It is not supported for cleanup
+> against real developer state. The first supported release will be `0.1.0`.
 
-The first production mutation boundary is intentionally narrow:
+## Reservation Release
+
+The implemented mutation boundary under development is intentionally narrow:
 
 - removes only exact rebuildable artifact directories declared in config
 - supports `node_modules`, `dist`, `dist-runtime`, `build`, `.next`, `.turbo`,
@@ -28,16 +32,19 @@ The first production mutation boundary is intentionally narrow:
 Codex, Claude Code, Cursor, GitHub Copilot CLI, Zed, OpenCode, Grok Build, Git,
 and Docker are report-only. Provider state, worktrees, images, containers,
 volumes, branches, stashes, credentials, configuration, plugins, skills, and
-memories are never removed by version 0.1.
+memories are not cleanup targets.
 
 ## Install
+
+Do not install `0.0.0` for operational cleanup. Maintainers may verify the
+reservation package with:
 
 ```bash
 npm install --global agentrinse
 agentrinse --version
 ```
 
-Node.js 22 or newer is required.
+The command must report `0.0.0`. Node.js 22 or newer is required.
 
 ## Configure
 
@@ -138,7 +145,8 @@ pnpm pack:check
 ```
 
 Development, tests, smoke runs, and destructive proof use temporary synthetic
-homes only. Never point an unreleased development build at a workstation home.
+homes only. Never point `0.0.0` or an unreleased development build at a
+workstation home.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,8 +23,9 @@ High-impact classes include:
 
 ## Current Status
 
-Version 0.1 can remove only exact configured rebuildable artifact directories
-through a content-addressed, locked, revalidated, and journaled apply path.
+The implemented cleanup boundary can remove only exact configured rebuildable
+artifact directories through a content-addressed, locked, revalidated, and
+journaled apply path.
 Provider state, Git worktrees, and Docker resources remain report-only.
 
 Reports involving unintended removal, path or symlink escape, plan bypass,

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -1,7 +1,7 @@
 # Adapter Matrix
 
-All provider, Git, and Docker adapters are read-only in version 0.1. Artifact
-cleanup is separately scoped to explicitly configured rebuildable directories.
+All provider, Git, and Docker adapters are read-only. Artifact cleanup is
+separately scoped to explicitly configured rebuildable directories.
 
 | Adapter        | Current capability                                         | Protected state |
 | -------------- | ---------------------------------------------------------- | --------------- |

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -1,10 +1,12 @@
 # AgentRinse Product and Engineering Specification
 
-Status: proposed
+Status: active implementation
 
-Version: 0.1
+Target version: 0.3.0
 
-Date: 2026-07-23
+Created: 2026-07-23
+
+Updated: 2026-07-24
 
 Owner: Vincent Koc
 
@@ -106,17 +108,19 @@ Brand guidance:
 This section records the evidence used to shape the specification. It is
 non-normative and should be refreshed before implementation begins.
 
-Research date: 2026-07-23.
+Research date: 2026-07-23. Release-state refresh: 2026-07-24.
 
 ### Name availability snapshot
 
-At the time of research:
+At the initial research snapshot:
 
 - the public npm registry returned `E404` for `agentrinse`
 - Verisign RDAP returned HTTP `404` for `agentrinse.com`
 
-This is an availability signal, not a reservation or ownership guarantee.
-Register the domain and reserve/publish the package before public announcement.
+The 2026-07-24 release-state refresh found the name still unclaimed on npm,
+the domain still unregistered, and the public GitHub repository available at
+the target URL. Registry and domain availability are signals, not ownership
+guarantees. Reserve both before announcing the supported `0.1.0` release.
 
 ### Local motivating evidence
 
@@ -2546,7 +2550,7 @@ compression mean sums may not equal actual free-space change.
 
 ### Tier 1: macOS
 
-Required for 0.1 and 1.0:
+Required for 0.1.0 and later:
 
 - APFS and common local filesystems
 - `lsof` ownership proof
@@ -2556,17 +2560,19 @@ Required for 0.1 and 1.0:
 
 ### Tier 2: Linux
 
-Target for 0.4 or 1.0:
+Supported from 0.1.0 with packaged Linux proof:
 
 - `/proc` process ownership
+- `lsof` fallback when hardened procfs prevents a complete scan
 - standard XDG paths
 - Docker Engine
 - Codex and Claude layouts
 - no Mole adapter
+- mutation remains blocked if neither `/proc` nor `lsof` proves ownership
 
 ### Tier 3: Windows
 
-Post-1.0:
+Audit-only before 1.0:
 
 - audit-only first
 - WSL treated as Linux within the WSL filesystem
@@ -2747,15 +2753,25 @@ Recommended:
 
 ### Distribution
 
-Initial:
+Reservation release:
 
-- npm
+- publish `0.0.0` once from an authenticated maintainer machine
+- make no supported-use claim for `0.0.0`
+- use the package only to reserve the unscoped npm name and unlock trusted
+  publisher configuration
+
+Supported `0.1.0` release:
+
+- publish through GitHub Actions trusted publishing
+- `npm install --global agentrinse`
 - `npx agentrinse audit`
+- attach a checksummed source/package archive to the GitHub release
 
-After CLI stability:
+By `0.3.0`:
 
-- Homebrew tap
-- signed/checksummed tarballs
+- Homebrew formula in `vincentkoc/tap`
+- formula installation and upgrade smoke tests
+- signed or provenance-backed checksummed release artifacts
 
 Later:
 
@@ -2770,6 +2786,7 @@ Required:
 - npm provenance
 - no long-lived npm token in CI
 - protected release environment
+- a one-time `0.0.0` bootstrap before trusted publishing is configured
 - public repository metadata matching the publisher
 - generated checksums for release archives
 - dependency review and lockfile
@@ -2785,6 +2802,9 @@ Before 1.0:
 
 - schema and action contracts may evolve, but every release documents changes
 - plans are executable only by declared compatible versions
+- `0.0.0` is a reservation release and is not a supported product version
+- each supported minor release must satisfy its complete milestone exit
+  criteria before its tag is published
 
 At 1.0:
 
@@ -2809,92 +2829,115 @@ marketing-heavy landing page.
 
 ## Milestones
 
-### Phase 0: repository and contract foundation
+### `0.0.0`: package reservation
 
 Deliver:
 
-- package scaffold
-- CLI parser
-- config loader
-- XDG state layout
-- contracts and JSON schemas
-- deterministic canonical JSON
-- plan/run journaling
-- output renderer
-- doctor command
-- CI, trusted publishing dry run, and packed-package smoke
+- public npm package record for `agentrinse`
+- package metadata pointing to the public repository
+- explicit unsupported reservation-release messaging
+- locally authenticated bootstrap publish with 2FA
+- no long-lived npm token committed or stored in GitHub
 
 Exit criteria:
 
-- commands install and run from packed npm artifact
-- audit can return an empty valid report
-- plan digest and journal fault tests pass
+- anonymous `npm view agentrinse@0.0.0` succeeds
+- the package contains only intended files
+- the installed binary reports `0.0.0`
+- npm trusted publishing can be configured for the repository and release
+  workflow
 
-### Phase 1: audit-only release `0.1`
+### `0.1.0`: operational safe-artifact release
 
 Deliver:
 
-- Git worktree discovery
-- process ownership
-- Codex roots and storage diagnostics
-- Claude roots and retention reporting
-- Cursor workspace-storage and database diagnostics
-- GitHub Copilot CLI session/log inventory
-- Zed database/log inventory
-- OpenCode database and snapshot inventory
-- Grok Build version-gated inventory
-- Docker inventory and daemon-unavailable handling
-- runtime inventory
-- Mole detection/handoff suggestions
-- JSON, NDJSON, and redacted reports
-
-No mutation.
+- existing provider, Git, Docker, and artifact inventory
+- exact configured rebuildable-artifact removal
+- content-addressed plans, expiry, locks, revalidation, isolation, and durable
+  run journals
+- `agentrinse config init` and config validation
+- `agentrinse doctor` with platform, dependency, configuration, state, and
+  stale-lock diagnostics
+- `agentrinse history` and `agentrinse show`
+- explicit stale-lock inspection and owned recovery command
+- actionable partial-run recovery guidance
+- JSON, NDJSON, and redacted audit output
+- shell completion generation
+- clear macOS, Linux, WSL, and native Windows support contract
+- checksummed GitHub release artifact
+- trusted npm publish with provenance
+- real read-only workstation dogfood plus one disposable-project canary apply
 
 Exit criteria:
 
-- representative local audit explains all protected worktrees
+- fresh npm and `npx` installs work
+- operator setup does not require hand-authoring the first config file
+- doctor identifies every missing prerequisite without mutating
+- history and show explain completed, skipped, failed, and partial actions
+- representative local audit inventories provider state without transcript
+  content
 - no transcript content appears in outputs
-- unsupported provider versions fail closed
 - Docker unavailability is isolated
+- macOS and Linux packaged proof pass
+- all artifact actions remain `safe`
+- no worktree, provider store, Docker resource, branch, stash, credential,
+  plugin, skill, memory, or volume is removed
 
-### Phase 2: safe cleanup release `0.2`
+### `0.2.0`: agent-aware reachability
 
 Deliver:
 
-- artifact removal
-- Docker dangling image cleanup
-- Docker build-cache cleanup
-- history cleanup
-- plan/apply revalidation
-- locks and interruption-safe journal
+- complete Git worktree state collection: main, clean, dirty, staged,
+  untracked, locked, prunable, detached, and in-progress operations
+- local and configured-remote reachability proof for worktree HEADs
+- explicit unpushed and unknown-remote protection
+- live process cwd and file-descriptor roots
+- Codex and Claude session-to-worktree roots without reading transcript
+  content
+- provider-managed worktree and pin roots
+- deterministic root explanations and candidate suppression
+- agent closeout audit profile that scopes one repository/task without
+  inferring task completion
+- Mole availability probe and external handoff suggestions on macOS
+- no new mutating action types
 
 Exit criteria:
 
-- all actions are `safe`
-- fault-injection matrix passes
-- actual free-space change is reported honestly
-- no whole-worktree removal yet
+- every dirty, active, pinned, locked, unpushed, detached-risk, or
+  insufficiently understood worktree is protected
+- representative Codex and Claude fixtures link sessions to worktrees without
+  emitting transcript content
+- adding a root can never make a resource more cleanable
+- changing provider/session state after audit invalidates affected candidates
+- worktree removal remains unavailable
 
-### Phase 3: recoverable worktrees release `0.3`
+### `0.3.0`: recoverable worktrees
 
 Deliver:
 
-- worktree quarantine
+- explicit `worktree.quarantine` recoverable action
 - Git recovery refs
-- Git prune/repair integration
-- undo
-- quarantine purge
-- agent closeout command profile
+- same-filesystem quarantine with durable recovery manifests
+- `agentrinse undo`
+- `agentrinse purge`
+- interrupted-quarantine inspection and deterministic recovery instructions
+- Git worktree prune/repair integration through Git commands
+- expiry policy that never removes live recovery metadata
+- Homebrew formula in `vincentkoc/tap`
+- Homebrew install, audit, plan, quarantine, undo, and upgrade smoke proof
 
 Exit criteria:
 
 - dirty, active, pinned, locked, unpushed, and detached-risk fixtures are never
   selected
-- quarantine and undo pass across supported macOS filesystems
+- quarantine and undo pass across supported macOS filesystems and packaged
+  Linux proof
 - interrupted cleanup has deterministic recovery instructions
 - recovery is exercised from the packed artifact
+- Homebrew installs the exact released version and passes its formula test
+- no Docker mutation or provider-state deletion is introduced
 
-### Phase 4: maintenance operations release `0.4`
+### `0.4.0`: owner-managed maintenance
 
 Deliver:
 
@@ -2902,15 +2945,15 @@ Deliver:
 - old agent runtime removal
 - a decision and proof for labeled stopped-container cleanup; keep it
   report-only if reliable recreation cannot be demonstrated
-- Linux Tier 2
+- filtered Docker build-cache cleanup only after current owner-contract proof
 
 Exit criteria:
 
 - database compaction retains verified rollback
 - active provider processes block mutation
-- Linux process ownership and path safety pass
+- exact Docker context and object identity are revalidated before mutation
 
-### Phase 5: stable release `1.0`
+### `1.0.0`: stable contracts
 
 Deliver:
 
@@ -2919,7 +2962,7 @@ Deliver:
 - performance budgets
 - security review
 - complete docs
-- Homebrew distribution
+- npm and Homebrew long-term release support
 
 Exit criteria:
 
@@ -3195,7 +3238,27 @@ MVP. A database is not justified yet.
 
 ### 2026-07-23: macOS first
 
-macOS is Tier 1, Linux Tier 2, native Windows later.
+macOS is Tier 1. Linux is Tier 2 from `0.1.0` after packaged proof. Native
+Windows mutation remains blocked before 1.0.
+
+### 2026-07-24: staged public release sequence
+
+Publish `0.0.0` only to reserve the npm name and configure trusted publishing.
+The first supported release is `0.1.0`. Release `0.2.0` adds agent-aware
+reachability without expanding mutation. Release `0.3.0` adds recoverable
+worktree quarantine and undo.
+
+### 2026-07-24: operational UX precedes mutation growth
+
+Configuration generation, doctor diagnostics, run inspection, stale-lock
+handling, partial-run recovery guidance, and real dogfood are required before
+the supported `0.1.0` release. More cleanup targets are not a substitute for a
+safe operator loop.
+
+### 2026-07-24: Homebrew by 0.3.0
+
+The supported npm release remains the first distribution target. A formula in
+`vincentkoc/tap` and install/upgrade proof are required before `0.3.0`.
 
 ## Specification Maintenance
 
@@ -3267,48 +3330,59 @@ decision-log entry. They must not be smuggled in as adapter fixes.
 
 ### Repository
 
-- [ ] register `agentrinse.com`
-- [ ] reserve npm package
-- [ ] create repository
-- [ ] add MIT license
-- [ ] configure pnpm and Node 22
-- [ ] add TypeScript ESM build
-- [ ] add Vitest, oxfmt, oxlint, publint
-- [ ] add package artifact smoke
-- [ ] add npm trusted publishing
-- [ ] add security policy and contribution guide
+- [ ] register `agentrinse.com` and publish documentation
+- [ ] reserve npm package with `0.0.0`
+- [x] create public repository
+- [x] add MIT license
+- [x] configure pnpm and Node 22
+- [x] add TypeScript ESM build
+- [x] add Vitest, oxfmt, oxlint, and publint
+- [x] add package artifact smoke
+- [ ] configure and prove npm trusted publishing
+- [x] add security policy and contribution guide
+- [ ] protect `main` with required CI
+- [ ] protect the GitHub `npm` release environment
 
 ### Contracts
 
-- [ ] define config schema
-- [ ] define resource/finding schema
-- [ ] define plan/run schema
-- [ ] define diagnostic codes
-- [ ] define exit codes
-- [ ] implement canonical JSON
-- [ ] implement schema compatibility tests
+- [x] define config schema
+- [x] define resource/finding schema
+- [x] define plan/run schema
+- [x] define diagnostic codes
+- [x] define initial exit codes
+- [x] implement canonical JSON hashing
+- [x] implement initial schema compatibility tests
+- [ ] define `0.2.0` reachability facts and roots
+- [ ] define `0.3.0` quarantine, recovery, undo, and purge records
 
 ### Core safety
 
-- [ ] implement path guards
-- [ ] implement process identity
-- [ ] implement global/resource locks
-- [ ] implement atomic journal
-- [ ] implement revalidation
-- [ ] implement cancellation
-- [ ] implement redaction
-- [ ] add destructive-test root guard
+- [x] implement path guards
+- [x] implement process ownership proof
+- [x] implement global apply lock
+- [x] implement atomic run journal
+- [x] implement artifact revalidation and isolation
+- [ ] implement command cancellation and interrupted-run reporting
+- [ ] implement redacted export
+- [x] keep destructive tests inside synthetic temporary roots
+- [ ] add explicit runtime destructive-test root guard
+- [ ] add stale-lock inspection and owned recovery
+- [ ] add partial-run recovery inspection
 
 ### Adapters
 
-- [ ] Git audit
-- [ ] process ownership
-- [ ] Codex audit
-- [ ] Claude audit
-- [ ] Docker audit
+- [x] initial report-only Git worktree audit
+- [x] process ownership
+- [x] initial Codex inventory
+- [x] initial Claude inventory
+- [x] initial Docker inventory
+- [x] Cursor, Copilot CLI, Zed, OpenCode, and Grok inventory
 - [ ] runtime audit
 - [ ] Mole probe
-- [ ] artifact removal
+- [x] exact configured artifact removal
+- [ ] Git dirty, staged, untracked, operation, detached, and push-state proof
+- [ ] Codex and Claude session-to-worktree roots
+- [ ] provider-managed worktree and pin roots
 - [ ] Docker safe cleanup
 - [ ] worktree quarantine
 - [ ] worktree undo
@@ -3316,14 +3390,18 @@ decision-log entry. They must not be smuggled in as adapter fixes.
 
 ### Documentation and release
 
-- [ ] safety guide
+- [x] safety guide
 - [ ] automation guide
 - [ ] recovery guide
-- [ ] adapter capability matrix
+- [x] adapter capability matrix
 - [ ] config reference
 - [ ] website docs
 - [ ] npm provenance proof
 - [ ] Homebrew formula
+- [ ] real workstation read-only audit proof
+- [ ] disposable real-project apply canary
+- [ ] npm and `npx` install smoke
+- [ ] Homebrew install and upgrade smoke
 - [ ] 1.0 security review
 
 ## Reference Links

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,12 +1,13 @@
 # Releasing
 
-## First Publish
+## Reservation Publish
 
-The unscoped `agentrinse` name was unclaimed when version 0.1 was prepared.
+The unscoped `agentrinse` name was unclaimed when `0.0.0` was prepared.
 Registry availability must be checked again immediately before publishing.
 
 Trusted publishing cannot be configured until the package exists. Bootstrap
-the package once from a maintainer machine with npm account 2FA:
+the unsupported reservation package once from a maintainer machine with npm
+account 2FA:
 
 ```bash
 pnpm check
@@ -14,7 +15,9 @@ pnpm pack:check
 npm publish --access public
 ```
 
-This is the only release that should require local registry credentials.
+Verify that `npm view agentrinse@0.0.0` succeeds and that a clean global install
+reports `0.0.0`. This is the only release that should require local registry
+credentials.
 
 ## Trusted Publisher
 
@@ -29,11 +32,10 @@ After the first publish:
 The workflow uses GitHub-hosted runners, OIDC `id-token: write`, and npm
 11.18.0. It does not require a long-lived npm token.
 
-The repository is private, so npm provenance is unavailable until the source
-repository is public. Trusted publishing authentication still avoids a
-long-lived publish secret.
+The repository is public. Trusted publishing automatically emits npm
+provenance and avoids a long-lived publish secret.
 
-## Subsequent Releases
+## Supported Releases
 
 1. update `package.json`, `src/version.ts`, and `CHANGELOG.md`
 2. run `pnpm check`, `pnpm smoke`, and `pnpm pack:check`
@@ -43,3 +45,6 @@ long-lived publish secret.
 6. verify the Release workflow, npm version, package contents, and CLI smoke
 
 The workflow refuses tags that do not exactly match `package.json`.
+
+The first supported release is `0.1.0`. Never advertise `0.0.0` for cleanup
+against real developer state.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -17,7 +17,9 @@ npm publish --access public
 
 Verify that `npm view agentrinse@0.0.0` succeeds and that a clean global install
 reports `0.0.0`. This is the only release that should require local registry
-credentials.
+credentials. Create the `v0.0.0` GitHub release only after that verification.
+The release workflow compares the registry tarball integrity with the tagged
+source instead of trying to publish the reservation package again.
 
 ## Trusted Publisher
 

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -3,7 +3,7 @@
 AgentRinse is designed around refusal. A resource becomes cleanable only after
 its scope, identity, inactivity, and effect are positively known.
 
-## Version 0.1 Mutation Boundary
+## Safe Artifact Mutation Boundary
 
 Only `artifacts.remove` mutates:
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,18 @@
 {
   "name": "agentrinse",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "private": false,
-  "description": "Safe, local-first cleanup for agentic development.",
-  "homepage": "https://agentrinse.com",
+  "description": "Reservation release for safe agentic-development cleanup.",
+  "keywords": [
+    "agents",
+    "cleanup",
+    "cli",
+    "developer-tools",
+    "docker",
+    "git",
+    "worktrees"
+  ],
+  "homepage": "https://github.com/vincentkoc/agentrinse",
   "bugs": {
     "url": "https://github.com/vincentkoc/agentrinse/issues"
   },

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
+const packageJson = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"));
 const root = await realpath(await mkdtemp(join(tmpdir(), "agentrinse-smoke-")));
 const home = join(root, "home");
 const auditPath = join(root, "audit.json");
@@ -73,44 +74,84 @@ if (!Array.isArray(plan.actions) || plan.actions.length !== 1) {
 }
 
 await access(artifact);
-const apply = await execFileAsync(
-  process.execPath,
-  [
-    "dist/cli.js",
-    "apply",
-    "--plan",
-    planPath,
-    "--config",
-    configPath,
-    "--state-dir",
-    statePath,
-    "--yes",
-    "--json",
-  ],
-  { cwd: process.cwd() },
-);
-const run = JSON.parse(apply.stdout);
-
-if (run.status !== "completed" || run.actions?.[0]?.status !== "applied") {
-  throw new Error("smoke apply did not complete");
-}
-await access(join(project, "source.ts"));
-try {
-  await access(artifact);
-  throw new Error("smoke apply left the planned artifact in place");
-} catch (error) {
-  if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") {
-    throw error;
+if (packageJson.version === "0.0.0") {
+  try {
+    await execFileAsync(
+      process.execPath,
+      [
+        "dist/cli.js",
+        "apply",
+        "--plan",
+        planPath,
+        "--config",
+        configPath,
+        "--state-dir",
+        statePath,
+        "--yes",
+        "--json",
+      ],
+      { cwd: process.cwd() },
+    );
+    throw new Error("reservation smoke apply unexpectedly succeeded");
+  } catch (error) {
+    if (
+      !(error instanceof Error) ||
+      !("stderr" in error) ||
+      !String(error.stderr).includes("apply is unavailable in the unsupported 0.0.0")
+    ) {
+      throw error;
+    }
   }
-}
+  await access(artifact);
+  await access(join(project, "source.ts"));
+  process.stdout.write(
+    `${JSON.stringify({
+      syntheticRoot: root,
+      findings: audit.findings.length,
+      protected: 2,
+      planActions: plan.actions.length,
+      apply: "blocked-reservation",
+    })}\n`,
+  );
+} else {
+  const apply = await execFileAsync(
+    process.execPath,
+    [
+      "dist/cli.js",
+      "apply",
+      "--plan",
+      planPath,
+      "--config",
+      configPath,
+      "--state-dir",
+      statePath,
+      "--yes",
+      "--json",
+    ],
+    { cwd: process.cwd() },
+  );
+  const run = JSON.parse(apply.stdout);
 
-process.stdout.write(
-  `${JSON.stringify({
-    syntheticRoot: root,
-    findings: audit.findings.length,
-    protected: 2,
-    planActions: plan.actions.length,
-    applied: 1,
-    reclaimedBytes: run.reclaimedBytes,
-  })}\n`,
-);
+  if (run.status !== "completed" || run.actions?.[0]?.status !== "applied") {
+    throw new Error("smoke apply did not complete");
+  }
+  await access(join(project, "source.ts"));
+  try {
+    await access(artifact);
+    throw new Error("smoke apply left the planned artifact in place");
+  } catch (error) {
+    if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") {
+      throw error;
+    }
+  }
+  process.stdout.write(
+    `${JSON.stringify({
+      syntheticRoot: root,
+      findings: audit.findings.length,
+      protected: 2,
+      planActions: plan.actions.length,
+      applied: 1,
+      reclaimedBytes: run.reclaimedBytes,
+    })}\n`,
+  );
+}

--- a/src/adapters/docker/adapter.ts
+++ b/src/adapters/docker/adapter.ts
@@ -140,7 +140,7 @@ export class DockerAuditAdapter implements AuditAdapter {
           code: "docker-audit-only",
           source: "docker",
           observedAt,
-          detail: "The Docker adapter inventories resources but version 0.1 cannot prune them.",
+          detail: "The Docker adapter inventories resources but cannot prune them.",
         },
       ],
       facts: resource.facts,

--- a/src/adapters/provider-adapter.ts
+++ b/src/adapters/provider-adapter.ts
@@ -199,7 +199,7 @@ export class ProviderAuditAdapter implements AuditAdapter {
           code: "provider-owned-report-only",
           source: this.id,
           observedAt,
-          detail: "This adapter inventories provider state but version 0.1 does not clean it.",
+          detail: "This adapter inventories provider state but does not clean it.",
         },
       ],
       facts: resource.facts,

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -7,6 +7,7 @@ import type { CleanupRun } from "../contracts/run.js";
 import { applyCleanupPlan } from "../core/apply.js";
 import { readJsonFile } from "../state/json-file.js";
 import { resolveStateRoot } from "../state/layout.js";
+import { VERSION } from "../version.js";
 
 export type ApplyCommandOptions = {
   plan: string;
@@ -57,6 +58,9 @@ export async function executeApplyCommand(
 ): Promise<ApplyCommandResult> {
   if (options.json && !options.yes) {
     throw new Error("apply --json requires --yes");
+  }
+  if (VERSION === "0.0.0") {
+    throw new Error("apply is unavailable in the unsupported 0.0.0 reservation release");
   }
 
   const input = await readJsonFile(resolve(options.plan));

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.1.0";
+export const VERSION = "0.0.0";

--- a/test/commands/apply.test.ts
+++ b/test/commands/apply.test.ts
@@ -23,7 +23,7 @@ describe("executeApplyCommand", () => {
     ).rejects.toThrow("apply --json requires --yes");
   });
 
-  it("requires non-interactive authorization and emits JSON", async () => {
+  it("refuses mutation in the reservation release", async () => {
     const home = await realpath(await mkdtemp(join(tmpdir(), "agentrinse-command-")));
     const project = join(home, "project");
     const target = join(project, "node_modules");
@@ -83,15 +83,16 @@ describe("executeApplyCommand", () => {
       planId: cleanupPlanId(content),
     });
 
-    const result = await executeApplyCommand({
-      plan: planPath,
-      config: configPath,
-      stateDir,
-      yes: true,
-      json: true,
-    });
+    await expect(
+      executeApplyCommand({
+        plan: planPath,
+        config: configPath,
+        stateDir,
+        yes: true,
+        json: true,
+      }),
+    ).rejects.toThrow("apply is unavailable in the unsupported 0.0.0 reservation release");
 
-    expect(result.run.status).toBe("completed");
-    expect(JSON.parse(result.output)).toEqual(result.run);
+    await expect(stat(target)).resolves.toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

- define the staged 0.0.0 through 0.3.0 release contract
- publish 0.0.0 as an explicitly unsupported name-reservation build
- block CLI cleanup mutation in 0.0.0 and verify the bootstrap package by registry integrity

## Safety boundary

- Resource owner: AgentRinse-owned cleanup plans and disposable project artifacts.
- Discovery evidence: existing artifact and provider adapters; no new collector or mutation surface.
- Protection roots: provider sessions remain report-only; the 0.0.0 CLI refuses every authorized apply before filesystem mutation.
- Risk class: release/bootstrap metadata plus a fail-closed mutation gate.
- Revalidation: the existing apply authorization and plan verification remain intact; 0.0.0 exits before execution.
- Recovery: no cleanup can run in this release, so planned artifacts remain unchanged.

## Verification

- local format, lint, typecheck, schema check, build, and 121 tests
- clean structured autoreview
- AWS Crabbox `run_777e0dc4f3a0`: Linux package lint and installed-tarball audit/plan/apply refusal; artifact preserved
- `npm pack --dry-run` confirms `agentrinse@0.0.0` contents
