### PR TITLE
fix(release): preserve npm CLI binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "git+https://github.com/vincentkoc/agentrinse.git"
   },
   "bin": {
-    "agentrinse": "./dist/cli.js"
+    "agentrinse": "dist/cli.js"
   },
   "files": [
     "dist",
@@ -46,7 +46,7 @@
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",
     "lint": "oxlint src test",
-    "pack:check": "pnpm build && pnpm schemas:check && publint && pnpm pack --dry-run",
+    "pack:check": "pnpm build && pnpm schemas:check && node scripts/check-package-manifest.mjs && publint && npm pack --dry-run",
     "schemas:check": "pnpm build && node scripts/generate-schemas.mjs --check",
     "schemas:generate": "pnpm build && node scripts/generate-schemas.mjs",
     "smoke": "pnpm build && node scripts/smoke.mjs",

--- a/scripts/check-package-manifest.mjs
+++ b/scripts/check-package-manifest.mjs
@@ -1,0 +1,32 @@
+import { execFile } from "node:child_process";
+import { cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const root = process.cwd();
+const packagePath = join(root, "package.json");
+const source = await readFile(packagePath, "utf8");
+const packageJson = JSON.parse(source);
+
+if (packageJson.bin?.agentrinse !== "dist/cli.js") {
+  throw new Error('package.json bin.agentrinse must be "dist/cli.js"');
+}
+
+const temporaryRoot = await mkdtemp(join(tmpdir(), "agentrinse-package-manifest-"));
+
+try {
+  await writeFile(join(temporaryRoot, "package.json"), source);
+  await cp(join(root, "dist"), join(temporaryRoot, "dist"), { recursive: true });
+  await execFileAsync("npm", ["pkg", "fix"], { cwd: temporaryRoot });
+
+  const normalized = await readFile(join(temporaryRoot, "package.json"), "utf8");
+  if (normalized !== source) {
+    throw new Error("npm pkg fix would rewrite package.json");
+  }
+} finally {
+  await rm(temporaryRoot, { recursive: true, force: true });
+}
+
+process.stdout.write("verified npm package manifest\n");

--- a/scripts/check-package-manifest.mjs
+++ b/scripts/check-package-manifest.mjs
@@ -19,7 +19,13 @@ const temporaryRoot = await mkdtemp(join(tmpdir(), "agentrinse-package-manifest-
 try {
   await writeFile(join(temporaryRoot, "package.json"), source);
   await cp(join(root, "dist"), join(temporaryRoot, "dist"), { recursive: true });
-  await execFileAsync("npm", ["pkg", "fix"], { cwd: temporaryRoot });
+  if (process.platform === "win32") {
+    await execFileAsync(process.env.ComSpec ?? "cmd.exe", ["/d", "/s", "/c", "npm pkg fix"], {
+      cwd: temporaryRoot,
+    });
+  } else {
+    await execFileAsync("npm", ["pkg", "fix"], { cwd: temporaryRoot });
+  }
 
   const normalized = await readFile(join(temporaryRoot, "package.json"), "utf8");
   if (normalized !== source) {


### PR DESCRIPTION
## Summary

- use npm-valid `bin` metadata so the published package keeps the `agentrinse` executable
- validate package metadata by running `npm pkg fix` against an isolated copy
- use npm itself for the final pack dry run

## Why

The first 0.0.0 publish attempt was cancelled before authentication because npm 11 warned that it would remove `bin.agentrinse`. No package was published, and the temporary `v0.0.0` tag was removed.

## Verification

- npm package normalizer leaves `package.json` unchanged
- packed manifest contains `bin.agentrinse = dist/cli.js`
- tarball install exposes `agentrinse --version` as `0.0.0`
- format, lint, typecheck, 121 tests, schema check, publint, and reservation smoke pass
- structured autoreview clean after Windows invocation fix
