### PR TITLE
fix(release): compare bootstrap package contents

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,13 +48,29 @@ jobs:
       - name: Verify bootstrap package
         if: github.event.release.tag_name == 'v0.0.0'
         run: |
-          pack_metadata="$RUNNER_TEMP/agentrinse-pack.json"
-          npm pack --json > "$pack_metadata"
-          package_file="$(node -p "JSON.parse(require('node:fs').readFileSync(process.argv[1], 'utf8'))[0].filename" "$pack_metadata")"
-          local_integrity="$(node -p "JSON.parse(require('node:fs').readFileSync(process.argv[1], 'utf8'))[0].integrity" "$pack_metadata")"
-          registry_integrity="$(npm view agentrinse@0.0.0 dist.integrity)"
-          rm "$package_file" "$pack_metadata"
-          test "$local_integrity" = "$registry_integrity"
+          bootstrap_root="$RUNNER_TEMP/agentrinse-bootstrap"
+          mkdir -p \
+            "$bootstrap_root/local-pack" \
+            "$bootstrap_root/local-tree" \
+            "$bootstrap_root/registry-pack" \
+            "$bootstrap_root/registry-tree"
+
+          npm pack --json \
+            --pack-destination "$bootstrap_root/local-pack" \
+            > "$bootstrap_root/local.json"
+          npm pack agentrinse@0.0.0 --json \
+            --pack-destination "$bootstrap_root/registry-pack" \
+            > "$bootstrap_root/registry.json"
+
+          local_file="$(node -p "JSON.parse(require('node:fs').readFileSync(process.argv[1], 'utf8'))[0].filename" "$bootstrap_root/local.json")"
+          registry_file="$(node -p "JSON.parse(require('node:fs').readFileSync(process.argv[1], 'utf8'))[0].filename" "$bootstrap_root/registry.json")"
+          tar -xzf "$bootstrap_root/local-pack/$local_file" -C "$bootstrap_root/local-tree"
+          tar -xzf "$bootstrap_root/registry-pack/$registry_file" -C "$bootstrap_root/registry-tree"
+
+          diff -qr \
+            "$bootstrap_root/local-tree/package" \
+            "$bootstrap_root/registry-tree/package"
+          rm -rf "$bootstrap_root"
 
       - name: Publish to npm
         if: github.event.release.tag_name != 'v0.0.0'

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -18,8 +18,8 @@ npm publish --access public
 Verify that `npm view agentrinse@0.0.0` succeeds and that a clean global install
 reports `0.0.0`. This is the only release that should require local registry
 credentials. Create the `v0.0.0` GitHub release only after that verification.
-The release workflow compares the registry tarball integrity with the tagged
-source instead of trying to publish the reservation package again.
+The release workflow compares every extracted registry package file with the
+tagged source instead of trying to publish the reservation package again.
 
 ## Trusted Publisher
 


### PR DESCRIPTION
## Summary

- compare extracted package trees for the 0.0.0 bootstrap verification
- ignore archive metadata that legitimately differs across macOS and Linux
- retain full detection of missing, extra, or changed shipped files

## Context

The published npm package and installed CLI are correct. The first GitHub release run failed because it compared tarball integrity produced on macOS with a tarball rebuilt on Linux.

## Verification

- local extracted package comparison against `agentrinse@0.0.0` passes
- AWS Crabbox run `run_ff789ef6e274` passes the same comparison on Linux
- package manifest check and publint pass
- structured autoreview clean
