### PR TITLE
ci(release): add unprivileged tag validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing release tag to validate or publish
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -14,10 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: npm
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
@@ -40,13 +50,11 @@ jobs:
           pnpm pack:check
 
       - name: Verify release version
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           test "$RELEASE_TAG" = "v$(node -p "require('./package.json').version")"
 
       - name: Verify bootstrap package
-        if: github.event.release.tag_name == 'v0.0.0'
+        if: env.RELEASE_TAG == 'v0.0.0'
         run: |
           bootstrap_root="$RUNNER_TEMP/agentrinse-bootstrap"
           mkdir -p \
@@ -73,5 +81,5 @@ jobs:
           rm -rf "$bootstrap_root"
 
       - name: Publish to npm
-        if: github.event.release.tag_name != 'v0.0.0'
+        if: env.RELEASE_TAG != 'v0.0.0'
         run: npm publish --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,27 +13,24 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   npm:
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: npm
+    permissions:
+      contents: read
+      id-token: write
     env:
-      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'release' && github.sha || format('refs/tags/{0}', inputs.release_tag) }}
-
-      - name: Verify selected tag
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          git show-ref --verify --quiet "refs/tags/$RELEASE_TAG"
-          test "$(git rev-parse HEAD)" = "$(git rev-list -n 1 "$RELEASE_TAG")"
+          ref: ${{ github.sha }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
@@ -87,5 +84,76 @@ jobs:
           rm -rf "$bootstrap_root"
 
       - name: Publish to npm
-        if: github.event_name == 'release' && env.RELEASE_TAG != 'v0.0.0'
+        if: env.RELEASE_TAG != 'v0.0.0'
         run: npm publish --access public
+
+  validate:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          ref: refs/tags/${{ inputs.release_tag }}
+
+      - name: Verify selected tag
+        run: |
+          git show-ref --verify --quiet "refs/tags/$RELEASE_TAG"
+          test "$(git rev-parse HEAD)" = "$(git rev-list -n 1 "$RELEASE_TAG")"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install verification npm
+        run: npm install --global npm@11.18.0
+
+      - name: Verify source and package
+        run: |
+          pnpm check
+          pnpm pack:check
+
+      - name: Verify release version
+        run: |
+          test "$RELEASE_TAG" = "v$(node -p "require('./package.json').version")"
+
+      - name: Verify bootstrap package
+        if: env.RELEASE_TAG == 'v0.0.0'
+        run: |
+          bootstrap_root="$RUNNER_TEMP/agentrinse-bootstrap"
+          mkdir -p \
+            "$bootstrap_root/local-pack" \
+            "$bootstrap_root/local-tree" \
+            "$bootstrap_root/registry-pack" \
+            "$bootstrap_root/registry-tree"
+
+          npm pack --json \
+            --pack-destination "$bootstrap_root/local-pack" \
+            > "$bootstrap_root/local.json"
+          npm pack agentrinse@0.0.0 --json \
+            --pack-destination "$bootstrap_root/registry-pack" \
+            > "$bootstrap_root/registry.json"
+
+          local_file="$(node -p "JSON.parse(require('node:fs').readFileSync(process.argv[1], 'utf8'))[0].filename" "$bootstrap_root/local.json")"
+          registry_file="$(node -p "JSON.parse(require('node:fs').readFileSync(process.argv[1], 'utf8'))[0].filename" "$bootstrap_root/registry.json")"
+          tar -xzf "$bootstrap_root/local-pack/$local_file" -C "$bootstrap_root/local-tree"
+          tar -xzf "$bootstrap_root/registry-pack/$registry_file" -C "$bootstrap_root/registry-tree"
+
+          diff -qr \
+            "$bootstrap_root/local-tree/package" \
+            "$bootstrap_root/registry-tree/package"
+          rm -rf "$bootstrap_root"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: Existing release tag to validate or publish
+        description: Existing release tag to validate without publishing
         required: true
         type: string
 
@@ -27,7 +27,12 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: refs/tags/${{ env.RELEASE_TAG }}
+
+      - name: Verify selected tag
+        run: |
+          git show-ref --verify --quiet "refs/tags/$RELEASE_TAG"
+          test "$(git rev-parse HEAD)" = "$(git rev-list -n 1 "$RELEASE_TAG")"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
@@ -81,5 +86,5 @@ jobs:
           rm -rf "$bootstrap_root"
 
       - name: Publish to npm
-        if: env.RELEASE_TAG != 'v0.0.0'
+        if: github.event_name == 'release' && env.RELEASE_TAG != 'v0.0.0'
         run: npm publish --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,10 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
         with:
-          ref: refs/tags/${{ env.RELEASE_TAG }}
+          ref: ${{ github.event_name == 'release' && github.sha || format('refs/tags/{0}', inputs.release_tag) }}
 
       - name: Verify selected tag
+        if: github.event_name == 'workflow_dispatch'
         run: |
           git show-ref --verify --quiet "refs/tags/$RELEASE_TAG"
           test "$(git rev-parse HEAD)" = "$(git rev-list -n 1 "$RELEASE_TAG")"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -48,5 +48,10 @@ provenance and avoids a long-lived publish secret.
 
 The workflow refuses tags that do not exactly match `package.json`.
 
+If a release-triggered run fails because its tagged commit contains obsolete
+release automation, rerun the current workflow manually with `release_tag` set
+to that existing tag. The workflow checks out the selected tag before
+verification or publishing.
+
 The first supported release is `0.1.0`. Never advertise `0.0.0` for cleanup
 against real developer state.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -50,8 +50,8 @@ The workflow refuses tags that do not exactly match `package.json`.
 
 If a release-triggered run contains obsolete verification automation, run the
 current workflow manually with `release_tag` set to the existing tag. Manual
-dispatches validate tag contents but never publish because their provenance is
-bound to the dispatch ref. Publishing remains release-event-only.
+dispatches run in a separate validation job without the `npm` environment or
+OIDC permission. Publishing remains release-event-only.
 
 The first supported release is `0.1.0`. Never advertise `0.0.0` for cleanup
 against real developer state.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -48,10 +48,10 @@ provenance and avoids a long-lived publish secret.
 
 The workflow refuses tags that do not exactly match `package.json`.
 
-If a release-triggered run fails because its tagged commit contains obsolete
-release automation, rerun the current workflow manually with `release_tag` set
-to that existing tag. The workflow checks out the selected tag before
-verification or publishing.
+If a release-triggered run contains obsolete verification automation, run the
+current workflow manually with `release_tag` set to the existing tag. Manual
+dispatches validate tag contents but never publish because their provenance is
+bound to the dispatch ref. Publishing remains release-event-only.
 
 The first supported release is `0.1.0`. Never advertise `0.0.0` for cleanup
 against real developer state.


### PR DESCRIPTION
## Summary

- add manual validation for an existing immutable release tag
- keep release-event checkout pinned to `github.sha`
- isolate manual validation from the `npm` environment, OIDC permission, and publish step

## Why

The 0.0.0 tag predates the corrected cross-platform package verifier. GitHub executes release workflows from the tagged commit, so the current verifier needs a safe way to validate that tag without moving it or publishing from a dispatch identity.

## Verification

- release events remain SHA-pinned and are the only path with npm OIDC
- dispatch resolves only `refs/tags/<release_tag>` and verifies detached HEAD
- dispatch job has read-only contents permission and no npm environment
- YAML and formatting checks pass
- structured autoreview clean after privilege and provenance fixes
