### PR TITLE
feat(release): ship AgentRinse 0.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,6 @@ jobs:
 
       - name: Smoke synthetic audit, plan, and apply
         run: pnpm smoke
+
+      - name: Smoke installed package
+        run: pnpm smoke:package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,10 +164,47 @@ jobs:
 
       - name: Upload package and checksum
         run: |
-          gh release upload "$RELEASE_TAG" \
-            release/agentrinse-*.tgz \
-            release/agentrinse-*.tgz.sha256 \
-            --repo "$GITHUB_REPOSITORY"
+          asset_exists() {
+            gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" \
+              --jq '.assets[].name' |
+              grep -Fxq "$1"
+          }
+
+          verify_existing_asset() {
+            local asset="$1"
+            local name
+            local directory
+            name="$(basename "$asset")"
+            directory="$(mktemp -d)"
+            gh release download "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --pattern "$name" \
+              --dir "$directory"
+            cmp --silent "$asset" "$directory/$name"
+            rm -rf "$directory"
+          }
+
+          upload_asset() {
+            local asset="$1"
+            local name
+            name="$(basename "$asset")"
+
+            if asset_exists "$name"; then
+              verify_existing_asset "$asset"
+              return
+            fi
+
+            if gh release upload "$RELEASE_TAG" "$asset" --repo "$GITHUB_REPOSITORY"; then
+              return
+            fi
+
+            asset_exists "$name"
+            verify_existing_asset "$asset"
+          }
+
+          for asset in release/agentrinse-*.tgz release/agentrinse-*.tgz.sha256; do
+            upload_asset "$asset"
+          done
 
   validate:
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
           )
 
       - name: Smoke exact release package
+        if: env.RELEASE_TAG != 'v0.0.0'
         run: pnpm smoke:package -- release/agentrinse-*.tgz
 
       - name: Store release package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,6 +225,7 @@ jobs:
           )
 
       - name: Smoke exact release package
+        if: env.RELEASE_TAG != 'v0.0.0'
         run: pnpm smoke:package -- release/agentrinse-*.tgz
 
       - name: Verify bootstrap package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,9 @@ jobs:
 
   release-assets:
     if: github.event_name == 'release'
-    needs: package
+    needs:
+      - package
+      - npm
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -164,8 +166,7 @@ jobs:
           gh release upload "$RELEASE_TAG" \
             release/agentrinse-*.tgz \
             release/agentrinse-*.tgz.sha256 \
-            --repo "$GITHUB_REPOSITORY" \
-            --clobber
+            --repo "$GITHUB_REPOSITORY"
 
   validate:
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,9 @@ jobs:
             sha256sum --check *.sha256
           )
 
+      - name: Smoke exact release package
+        run: pnpm smoke:package -- release/agentrinse-*.tgz
+
       - name: Store release package
         uses: actions/upload-artifact@v7
         with:
@@ -218,6 +221,9 @@ jobs:
             sha256sum agentrinse-*.tgz > agentrinse-$(node -p "require('../package.json').version").tgz.sha256
             sha256sum --check *.sha256
           )
+
+      - name: Smoke exact release package
+        run: pnpm smoke:package -- release/agentrinse-*.tgz
 
       - name: Verify bootstrap package
         if: env.RELEASE_TAG == 'v0.0.0'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,22 +15,25 @@ permissions:
   contents: read
 
 jobs:
-  npm:
+  package:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    environment: npm
     permissions:
       contents: read
-      id-token: write
     env:
       RELEASE_TAG: ${{ github.event.release.tag_name }}
 
     steps:
-      - name: Check out repository
+      - name: Check out release source
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.sha }}
+          ref: refs/tags/${{ github.event.release.tag_name }}
+
+      - name: Verify selected tag
+        run: |
+          git show-ref --verify --quiet "refs/tags/$RELEASE_TAG"
+          test "$(git rev-parse HEAD)" = "$(git rev-list -n 1 "$RELEASE_TAG")"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
@@ -44,38 +47,81 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install OIDC-capable npm
-        run: npm install --global npm@11.18.0
-
       - name: Verify source and package
         run: |
           pnpm check
+          pnpm smoke
           pnpm pack:check
 
       - name: Verify release version
         run: |
           test "$RELEASE_TAG" = "v$(node -p "require('./package.json').version")"
 
+      - name: Build checksummed release package
+        run: |
+          mkdir release
+          npm pack --pack-destination release
+          test "$(find release -maxdepth 1 -name 'agentrinse-*.tgz' | wc -l | tr -d ' ')" = "1"
+          (
+            cd release
+            sha256sum agentrinse-*.tgz > agentrinse-$(node -p "require('../package.json').version").tgz.sha256
+            sha256sum --check *.sha256
+          )
+
+      - name: Store release package
+        uses: actions/upload-artifact@v7
+        with:
+          name: agentrinse-release-package
+          path: |
+            release/agentrinse-*.tgz
+            release/agentrinse-*.tgz.sha256
+          if-no-files-found: error
+
+  npm:
+    if: github.event_name == 'release'
+    needs: package
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
+
+    steps:
+      - name: Download release package
+        uses: actions/download-artifact@v8
+        with:
+          name: agentrinse-release-package
+          path: release
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Install OIDC-capable npm
+        run: npm install --global npm@11.18.0
+
+      - name: Verify package checksum
+        run: |
+          cd release
+          sha256sum --check *.sha256
+
       - name: Verify bootstrap package
         if: env.RELEASE_TAG == 'v0.0.0'
         run: |
           bootstrap_root="$RUNNER_TEMP/agentrinse-bootstrap"
-          mkdir -p \
-            "$bootstrap_root/local-pack" \
-            "$bootstrap_root/local-tree" \
-            "$bootstrap_root/registry-pack" \
-            "$bootstrap_root/registry-tree"
+          mkdir -p "$bootstrap_root/local-tree" "$bootstrap_root/registry-pack" "$bootstrap_root/registry-tree"
 
-          npm pack --json \
-            --pack-destination "$bootstrap_root/local-pack" \
-            > "$bootstrap_root/local.json"
           npm pack agentrinse@0.0.0 --json \
             --pack-destination "$bootstrap_root/registry-pack" \
             > "$bootstrap_root/registry.json"
 
-          local_file="$(node -p "JSON.parse(require('node:fs').readFileSync(process.argv[1], 'utf8'))[0].filename" "$bootstrap_root/local.json")"
           registry_file="$(node -p "JSON.parse(require('node:fs').readFileSync(process.argv[1], 'utf8'))[0].filename" "$bootstrap_root/registry.json")"
-          tar -xzf "$bootstrap_root/local-pack/$local_file" -C "$bootstrap_root/local-tree"
+          tar -xzf release/agentrinse-0.0.0.tgz -C "$bootstrap_root/local-tree"
           tar -xzf "$bootstrap_root/registry-pack/$registry_file" -C "$bootstrap_root/registry-tree"
 
           diff -qr \
@@ -85,7 +131,38 @@ jobs:
 
       - name: Publish to npm
         if: env.RELEASE_TAG != 'v0.0.0'
-        run: npm publish --access public
+        run: npm publish release/agentrinse-*.tgz --access public
+
+  release-assets:
+    if: github.event_name == 'release'
+    needs: package
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
+
+    steps:
+      - name: Download release package
+        uses: actions/download-artifact@v8
+        with:
+          name: agentrinse-release-package
+          path: release
+
+      - name: Verify package checksum
+        run: |
+          cd release
+          sha256sum --check *.sha256
+
+      - name: Upload package and checksum
+        run: |
+          gh release upload "$RELEASE_TAG" \
+            release/agentrinse-*.tgz \
+            release/agentrinse-*.tgz.sha256 \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber
 
   validate:
     if: github.event_name == 'workflow_dispatch'
@@ -125,32 +202,35 @@ jobs:
       - name: Verify source and package
         run: |
           pnpm check
+          pnpm smoke
           pnpm pack:check
 
       - name: Verify release version
         run: |
           test "$RELEASE_TAG" = "v$(node -p "require('./package.json').version")"
 
+      - name: Build and verify checksum
+        run: |
+          mkdir release
+          npm pack --pack-destination release
+          (
+            cd release
+            sha256sum agentrinse-*.tgz > agentrinse-$(node -p "require('../package.json').version").tgz.sha256
+            sha256sum --check *.sha256
+          )
+
       - name: Verify bootstrap package
         if: env.RELEASE_TAG == 'v0.0.0'
         run: |
           bootstrap_root="$RUNNER_TEMP/agentrinse-bootstrap"
-          mkdir -p \
-            "$bootstrap_root/local-pack" \
-            "$bootstrap_root/local-tree" \
-            "$bootstrap_root/registry-pack" \
-            "$bootstrap_root/registry-tree"
+          mkdir -p "$bootstrap_root/local-tree" "$bootstrap_root/registry-pack" "$bootstrap_root/registry-tree"
 
-          npm pack --json \
-            --pack-destination "$bootstrap_root/local-pack" \
-            > "$bootstrap_root/local.json"
           npm pack agentrinse@0.0.0 --json \
             --pack-destination "$bootstrap_root/registry-pack" \
             > "$bootstrap_root/registry.json"
 
-          local_file="$(node -p "JSON.parse(require('node:fs').readFileSync(process.argv[1], 'utf8'))[0].filename" "$bootstrap_root/local.json")"
           registry_file="$(node -p "JSON.parse(require('node:fs').readFileSync(process.argv[1], 'utf8'))[0].filename" "$bootstrap_root/registry.json")"
-          tar -xzf "$bootstrap_root/local-pack/$local_file" -C "$bootstrap_root/local-tree"
+          tar -xzf release/agentrinse-0.0.0.tgz -C "$bootstrap_root/local-tree"
           tar -xzf "$bootstrap_root/registry-pack/$registry_file" -C "$bootstrap_root/registry-tree"
 
           diff -qr \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The project follows semantic versioning after its first supported release.
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-07-24
+
 ### Added
 
 - TypeScript npm package and `agentrinse` CLI
@@ -24,6 +26,14 @@ The project follows semantic versioning after its first supported release.
 - durable per-action run journals and partial-apply recovery paths
 - versioned JSON Schemas
 - packaged audit, plan, and apply smoke test
+- configuration initialization and validation
+- environment doctor, run history, record inspection, and owned stale-lock
+  recovery
+- versioned JSON envelopes, NDJSON audit events, and non-executable redacted
+  audit output
+- bash, zsh, and fish completion generation
+- cooperative SIGINT handling with durable interrupted-run journals
+- runtime guards for every destructive synthetic fixture
 
 ### Safety
 

--- a/README.md
+++ b/README.md
@@ -2,53 +2,39 @@
 
 Safe, local-first cleanup for agentic development.
 
-AgentRinse inventories agent state and developer residue, explains why
-resources are protected, produces content-addressed cleanup plans, and applies
-only actions that still pass every safety check.
+AgentRinse inventories agent state and developer residue, explains why each
+resource is protected or eligible, creates content-addressed cleanup plans,
+and applies only actions that still pass every safety check.
 
-> [!IMPORTANT]
-> `0.0.0` is a package-reservation release. It is not supported for cleanup
-> against real developer state. The first supported release will be `0.1.0`.
-
-## Reservation Release
-
-The implemented mutation boundary under development is intentionally narrow:
-
-- removes only exact rebuildable artifact directories declared in config
-- supports `node_modules`, `dist`, `dist-runtime`, `build`, `.next`, `.turbo`,
-  `.cache`, `coverage`, `target`, and `.venv`
-- revalidates path, realpath, inode, device, recursive metadata fingerprint,
-  newest descendant mtime, measured bytes, configured scope, current working
-  directory, and process ownership after acquiring the apply lock
-- rejects artifact roots and descendants that cross filesystem mount
-  boundaries
-- rejects sockets, pipes, devices, and other non-regular filesystem entries
-- rechecks size, age, and plan expiration immediately before each mutation
-- atomically renames an artifact to a same-parent tombstone before recursive
-  removal, repeats fingerprint and process checks on the isolated tree, and
-  performs a final synchronous inode check at the deletion boundary
-- journals every transition and records the recovery path for partial actions
-
-Codex, Claude Code, Cursor, GitHub Copilot CLI, Zed, OpenCode, Grok Build, Git,
-and Docker are report-only. Provider state, worktrees, images, containers,
-volumes, branches, stashes, credentials, configuration, plugins, skills, and
-memories are not cleanup targets.
+Version `0.1.0` supports one mutating action: removing exact rebuildable
+artifact directories declared under explicit project roots. Provider state,
+Git worktrees, and Docker resources remain report-only.
 
 ## Install
 
-Do not install `0.0.0` for operational cleanup. Maintainers may verify the
-reservation package with:
+Node.js 22 or newer is required.
 
 ```bash
 npm install --global agentrinse
 agentrinse --version
 ```
 
-The command must report `0.0.0`. Node.js 22 or newer is required.
+One-off use also works:
 
-## Configure
+```bash
+npx agentrinse@0.1.0 doctor
+```
 
-Artifact cleanup is disabled until project roots are explicitly declared.
+## Quickstart
+
+Create a default configuration without overwriting an existing file:
+
+```bash
+agentrinse config init
+agentrinse config path
+```
+
+Edit the generated JSON and add explicit artifact roots:
 
 ```json
 {
@@ -71,69 +57,129 @@ Artifact cleanup is disabled until project roots are explicitly declared.
 }
 ```
 
-Project roots must be unique canonical absolute real directories inside the
-audited home; paths reached through symlinked ancestors are rejected. Artifact
-targets cannot overlap. AgentRinse never discovers arbitrary projects or
-expands wildcards.
-
-## Use
-
-Audit and save immutable evidence:
+Run diagnostics before the first audit:
 
 ```bash
-agentrinse audit \
-  --home "$HOME" \
-  --config agentrinse.json \
-  --json \
-  --output audit.json
+agentrinse config validate
+agentrinse doctor
 ```
 
-Create a bounded cleanup plan:
+Audit and save exact evidence:
 
 ```bash
-agentrinse plan \
-  --audit audit.json \
-  --config agentrinse.json \
-  --output plan.json
+agentrinse audit --home "$HOME" --output audit.json
 ```
 
-Review `plan.json`, then apply it:
+Create and review a bounded plan:
 
 ```bash
-agentrinse apply \
-  --plan plan.json \
-  --config agentrinse.json \
-  --yes
+agentrinse plan --audit audit.json --output plan.json
+cat plan.json
 ```
 
-Without `--yes`, apply requires an interactive terminal confirmation. JSON
-output requires `--yes` so prompts can never corrupt stdout. A plan is rejected
-when it expires, changes, no longer matches the config, or contains inconsistent
-action totals. An action whose authorization expires during a run is recorded
-as `skipped-stale`, not deleted.
+Apply only after reviewing the plan:
 
-Run journals are stored under `$XDG_STATE_HOME/agentrinse/runs` or
-`$HOME/.local/state/agentrinse/runs`. Use `--state-dir` to select another
-location.
+```bash
+agentrinse apply --plan plan.json
+```
 
-## Safety
+Interactive apply asks for confirmation. Automation must pass `--yes`.
 
-- discovery and planning never mutate
-- unknown state is protected
-- symlinks are not followed
-- no process is killed
-- no `sudo`
-- no Docker volume deletion
-- no generic `--force`
-- no wildcard deletion
-- one apply run holds the exclusive state lock
-- AgentRinse never removes its own working directory, lock, or journal
+## Mutation Boundary
 
-AgentRinse fails closed around ordinary concurrent developer tools. It does not
-claim isolation from a hostile process already running as the same OS user;
-that process can directly alter the user's files and AgentRinse state.
+AgentRinse can remove only these configured artifact names:
 
-See `docs/safety.md` for the complete mutation contract.
+- `node_modules`
+- `dist`
+- `dist-runtime`
+- `build`
+- `.next`
+- `.turbo`
+- `.cache`
+- `coverage`
+- `target`
+- `.venv`
+
+Before removal it revalidates configured scope, canonical paths, device and
+inode identity, recursive metadata fingerprint, measured bytes, newest
+descendant age, mount boundaries, current working directory ownership,
+same-user processes, and plan expiration. The exact target is atomically moved
+to a same-parent tombstone and verified again before deletion.
+
+AgentRinse never removes provider sessions, transcripts, databases,
+credentials, configuration, plugins, skills, memories, Git branches, stashes,
+worktrees, Docker images, containers, networks, volumes, or build cache in
+`0.1.0`.
+
+## Operations
+
+```bash
+agentrinse history
+agentrinse show run <run-id>
+agentrinse show plan <plan-id>
+agentrinse show resource <resource-id>
+agentrinse lock status
+```
+
+A stale lock can be recovered only after AgentRinse proves the recorded local
+process identity no longer exists:
+
+```bash
+agentrinse lock status
+agentrinse lock recover --yes
+```
+
+Generate shell completion without modifying shell startup files:
+
+```bash
+agentrinse completion bash
+agentrinse completion zsh
+agentrinse completion fish
+```
+
+## Machine Output
+
+`agentrinse audit --json` emits a versioned command envelope. Long audits can
+emit incremental event records:
+
+```bash
+agentrinse audit --ndjson
+```
+
+Create a non-executable report for issue filing:
+
+```bash
+agentrinse audit --json --redact > audit-redacted.json
+```
+
+Redaction replaces paths, salts identifiers per report, removes host fields,
+and strips candidate actions. Persisted state and `--output` evidence remain
+exact so they can be used for planning.
+
+## Platform Support
+
+| Platform       | `0.1.0` support                                     |
+| -------------- | --------------------------------------------------- |
+| macOS          | audit and safe artifact apply                       |
+| Linux          | audit and safe artifact apply                       |
+| WSL            | Linux contract inside the WSL filesystem            |
+| native Windows | audit-only; mutation remains blocked before `1.0.0` |
+
+Git and `lsof` are required for the complete diagnostic and process-ownership
+contract. Docker is optional. Doctor can detect the optional external Mole
+tool on macOS.
+
+## Documentation
+
+- [Configuration](docs/configuration.md)
+- [Automation](docs/automation.md)
+- [Recovery](docs/recovery.md)
+- [Platform support](docs/platforms.md)
+- [Safety model](docs/safety.md)
+- [Adapter matrix](docs/adapters.md)
+- [Development](docs/development.md)
+- [Releasing](docs/releasing.md)
+- [Product specification](docs/product-spec.md)
 
 ## Development
 
@@ -144,9 +190,8 @@ pnpm smoke
 pnpm pack:check
 ```
 
-Development, tests, smoke runs, and destructive proof use temporary synthetic
-homes only. Never point `0.0.0` or an unreleased development build at a
-workstation home.
+Tests and smoke runs use guarded temporary synthetic roots. Never point an
+unreleased build at real developer state.
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,7 +47,7 @@ The apply engine:
 5. revalidates each action
 6. records the isolation path before mutation
 7. invokes the type-specific executor
-8. records applied, stale, rolled-back, failed, or partial outcomes
+8. records applied, stale, rolled-back, failed, partial, or interrupted outcomes
 9. stops after an execution failure
 10. finalizes the run and releases the owned lock
 
@@ -63,6 +63,8 @@ Default state:
 
 ```text
 $XDG_STATE_HOME/agentrinse/
+  audits/<audit-id>.json
+  plans/<plan-id>.json
   locks/apply.lock
   runs/<run-id>.json
 ```
@@ -70,5 +72,6 @@ $XDG_STATE_HOME/agentrinse/
 Without `XDG_STATE_HOME`, the root is
 `$HOME/.local/state/agentrinse`.
 
-All machine-readable output remains the source of truth. Human output is a
-projection of validated contracts.
+State records remain the execution source of truth. Audit JSON and NDJSON
+stdout use versioned public output contracts. Human output is a projection of
+validated records.

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -1,0 +1,106 @@
+# Automation
+
+AgentRinse keeps human output and machine contracts separate. Scripts must
+request JSON or NDJSON explicitly.
+
+## Saved Evidence
+
+`audit --output` and `plan --output` write exact schema-valid records:
+
+```bash
+agentrinse audit --home "$HOME" --output audit.json
+agentrinse plan --audit audit.json --output plan.json
+agentrinse apply --plan plan.json --yes --json
+```
+
+The saved audit is intentionally not wrapped because `plan` consumes it
+directly. State records under the AgentRinse state directory use the same raw
+schemas.
+
+## Audit JSON
+
+`audit --json` writes one command envelope to stdout:
+
+```json
+{
+  "schemaVersion": 1,
+  "command": "audit",
+  "agentrinseVersion": "0.1.0",
+  "startedAt": "2026-07-24T00:00:00.000Z",
+  "completedAt": "2026-07-24T00:00:01.000Z",
+  "status": "ok",
+  "data": {},
+  "diagnostics": []
+}
+```
+
+The public JSON Schemas are shipped under `schemas/`, including command
+envelopes, command events, audits, plans, runs, and doctor reports.
+
+## Audit NDJSON
+
+`audit --ndjson` streams one compact JSON object per line. Every event has:
+
+- `schemaVersion`
+- `event`
+- `timestamp`
+- `command`
+- `commandId`
+- monotonic `sequence`
+- optional `data`
+
+The stream begins with `command.started`, includes adapter, resource, and
+finding events as work completes, and ends with `command.completed`.
+
+```bash
+agentrinse audit --ndjson |
+  jq -c 'select(.event == "finding.completed")'
+```
+
+Do not parse human output.
+
+## Redacted Reports
+
+Redaction is available only with audit JSON or NDJSON:
+
+```bash
+agentrinse audit --json --redact > audit-redacted.json
+agentrinse audit --ndjson --redact > audit-redacted.ndjson
+```
+
+Redaction:
+
+- replaces the audit home with `$HOME`
+- replaces other absolute paths with salted opaque tokens
+- salts identifiers independently for each report
+- removes host and hostname fields
+- removes candidate actions
+- preserves adapters, resource kinds, sizes, states, reason codes, and
+  diagnostics
+
+Redirect stdout to create a shareable report. `--output` and persisted state
+remain exact and must not be attached to public issues.
+
+## Non-Interactive Apply
+
+Machine-readable apply requires explicit authorization:
+
+```bash
+agentrinse apply --plan plan.json --yes --json
+```
+
+Without `--yes`, a non-interactive apply is rejected. An expired or changed
+resource is skipped rather than substituted.
+
+## Exit Status
+
+Current `0.1.0` behavior:
+
+| Code  | Meaning                                      |
+| ----- | -------------------------------------------- |
+| `0`   | command completed                            |
+| `1`   | command, arguments, config, or safety failed |
+| `2`   | apply completed as failed or partial         |
+| `130` | apply was interrupted at a safe checkpoint   |
+
+The run journal remains the source of truth for apply outcomes.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,113 @@
+# Configuration
+
+AgentRinse is safe by default: provider adapters inventory state, while
+artifact cleanup remains disabled until project roots are explicitly listed.
+
+## Resolution
+
+Configuration is resolved in this order:
+
+1. `--config <path>`
+2. `$XDG_CONFIG_HOME/agentrinse/config.json`
+3. `$HOME/.config/agentrinse/config.json`
+
+Use the CLI to inspect or initialize the selected path:
+
+```bash
+agentrinse config path
+agentrinse config init
+agentrinse config show
+agentrinse config validate
+```
+
+`config init` uses an exclusive create and never overwrites an existing file.
+If the default path does not exist, audit uses safe built-in defaults.
+An explicitly requested missing or invalid file is an error.
+
+## Schema
+
+```json
+{
+  "schemaVersion": 1,
+  "adapters": {
+    "codex": { "enabled": true },
+    "claude": { "enabled": true },
+    "cursor": { "enabled": true },
+    "copilot": { "enabled": true },
+    "zed": { "enabled": true },
+    "opencode": { "enabled": true },
+    "grok": { "enabled": true },
+    "git": { "enabled": false, "root": "/absolute/repository" },
+    "docker": { "enabled": false }
+  },
+  "audit": {
+    "maxEntries": 100000,
+    "measureBytes": true
+  },
+  "artifacts": {
+    "projects": [
+      {
+        "root": "/absolute/project",
+        "names": ["node_modules", "dist"]
+      }
+    ],
+    "minAgeMinutes": 1440,
+    "minBytes": 67108864,
+    "processCheck": "required"
+  },
+  "plan": {
+    "ttlMinutes": 30,
+    "maxRisk": "safe"
+  }
+}
+```
+
+Unknown keys are discarded by the current schema. Project roots must be
+unique absolute paths. Cleanup targets from different project entries may not
+overlap.
+
+## Provider Adapters
+
+Codex, Claude Code, Cursor, GitHub Copilot CLI, Zed, OpenCode, and Grok Build
+are enabled for read-only inventory by default. Each accepts an optional
+`root`. Missing default roots mean the provider is absent, not broken. A
+missing explicit root is a doctor warning.
+
+Git is disabled by default and requires an explicit repository root. Docker is
+disabled by default and uses the active Docker context when enabled. Both
+adapters remain report-only in `0.1.0`.
+
+## Artifact Projects
+
+The supported names are:
+
+```text
+node_modules  dist  dist-runtime  build  .next  .turbo
+.cache        coverage  target    .venv
+```
+
+Names are fixed enums, not patterns. AgentRinse does not crawl for projects,
+expand globs, or run rebuild commands.
+
+An artifact becomes eligible only when:
+
+- its project root and target are canonical real directories inside the audit
+  home
+- the complete tree fits within `audit.maxEntries`
+- no unsupported special entries or mount boundaries exist
+- measured bytes meet `artifacts.minBytes`
+- the newest descendant age meets `artifacts.minAgeMinutes`
+- same-user process ownership is proven idle
+
+Apply repeats every check under the exclusive lock.
+
+## State
+
+State is resolved in this order:
+
+1. `--state-dir <path>`
+2. `$XDG_STATE_HOME/agentrinse`
+3. `$HOME/.local/state/agentrinse`
+
+The state root stores exact audits, plans, run journals, and the apply lock.
+Do not place it inside a configured cleanup target.

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,6 +7,7 @@ Development and CI use synthetic homes only.
 ```bash
 pnpm check
 pnpm smoke
+pnpm smoke:package
 pnpm pack:check
 ```
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -15,7 +15,7 @@ tests, and JSON Schema drift verification.
 
 `pnpm smoke` builds the CLI and:
 
-1. creates a temporary synthetic home
+1. creates a temporary synthetic home and passes the destructive-root guard
 2. writes synthetic provider resources and a project source file
 3. creates one configured `node_modules` artifact
 4. saves an audit and content-addressed plan
@@ -25,11 +25,15 @@ tests, and JSON Schema drift verification.
 8. verifies the project source file remains
 9. validates the completed run journal
 
-It never reads `$HOME`.
+It never reads data from `$HOME`.
 
 ## Fixture Rules
 
 - create fixtures with `mkdtemp`
+- call `assertDestructiveFixtureRoot` before any fixture can remove data
+- keep destructive roots below the resolved OS temporary directory
+- never use `/`, the temporary root itself, the real home, an ancestor of the
+  repository checkout, or a path reached through an escaping symlink
 - never copy real transcripts or provider databases into Git
 - replace personal paths with `/tmp` or `/fixture`
 - never preserve real hostnames, usernames, tokens, emails, or IP addresses

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -1,0 +1,60 @@
+# Platform Support
+
+AgentRinse separates read-only inventory from mutation capability. A platform
+can audit successfully while apply remains unavailable or blocked by missing
+ownership proof.
+
+## Requirements
+
+- Node.js 22 or newer
+- Git
+- `lsof`
+- local filesystem state directory with owner read/write access
+
+Docker is optional and isolated to its adapter. Mole is an optional external
+macOS handoff.
+
+Run `agentrinse doctor` to verify the current machine without mutating it.
+
+## macOS
+
+macOS is Tier 1 for `0.1.0`.
+
+- provider, Git, Docker, and configured artifact inventory
+- `lsof` process ownership proof
+- safe configured artifact apply
+- optional Mole detection through `mo --version`
+
+Mole remains external. AgentRinse does not embed or invoke Mole cleanup.
+
+## Linux
+
+Linux is Tier 2 for `0.1.0`.
+
+- provider, Git, Docker, and configured artifact inventory
+- same-user `/proc` process ownership inspection
+- `lsof` fallback when procfs is incomplete or restricted
+- safe configured artifact apply
+
+If neither `/proc` nor `lsof` can prove a target idle, apply skips it.
+
+## WSL
+
+WSL follows the Linux contract for paths and processes inside the WSL
+filesystem. Do not use `0.1.0` to mutate Windows-mounted project trees unless
+doctor and a disposable canary prove path identity, ownership, rename, and
+mount behavior for that exact setup.
+
+## Native Windows
+
+Native Windows is audit-only before `1.0.0`.
+
+Process start identity, descriptor ownership, path semantics, and atomic
+isolation have not reached the mutation proof bar. Doctor reports this
+limitation and recommends WSL for supported artifact apply.
+
+## Docker Isolation
+
+When enabled, Docker uses the current CLI context and structured output.
+Unavailable CLI, context, or daemon state degrades only Docker inventory.
+`0.1.0` does not remove any Docker resource.

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -9,6 +9,7 @@ ownership proof.
 - Node.js 22 or newer
 - Git
 - `lsof`
+- `lockf` on macOS or `flock` from `util-linux` on Linux
 - local filesystem state directory with owner read/write access
 
 Docker is optional and isolated to its adapter. Mole is an optional external
@@ -37,6 +38,10 @@ Linux is Tier 2 for `0.1.0`.
 - safe configured artifact apply
 
 If neither `/proc` nor `lsof` can prove a target idle, apply skips it.
+
+Stale-lock recovery uses the kernel-held `lockf` utility on macOS and `flock`
+from `util-linux` on Linux. A crashed recovery process releases the mutex
+automatically.
 
 ## WSL
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -2474,6 +2474,7 @@ Examples:
 ```text
 command.started
 adapter.probed
+diagnostic.reported
 resource.discovered
 finding.completed
 plan.action-selected

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -3331,14 +3331,14 @@ decision-log entry. They must not be smuggled in as adapter fixes.
 ### Repository
 
 - [ ] register `agentrinse.com` and publish documentation
-- [ ] reserve npm package with `0.0.0`
+- [x] reserve npm package with `0.0.0`
 - [x] create public repository
 - [x] add MIT license
 - [x] configure pnpm and Node 22
 - [x] add TypeScript ESM build
 - [x] add Vitest, oxfmt, oxlint, and publint
 - [x] add package artifact smoke
-- [ ] configure and prove npm trusted publishing
+- [x] configure and prove npm trusted publishing
 - [x] add security policy and contribution guide
 - [ ] protect `main` with required CI
 - [ ] protect the GitHub `npm` release environment
@@ -3362,12 +3362,12 @@ decision-log entry. They must not be smuggled in as adapter fixes.
 - [x] implement global apply lock
 - [x] implement atomic run journal
 - [x] implement artifact revalidation and isolation
-- [ ] implement command cancellation and interrupted-run reporting
-- [ ] implement redacted export
+- [x] implement command cancellation and interrupted-run reporting
+- [x] implement redacted export
 - [x] keep destructive tests inside synthetic temporary roots
-- [ ] add explicit runtime destructive-test root guard
-- [ ] add stale-lock inspection and owned recovery
-- [ ] add partial-run recovery inspection
+- [x] add explicit runtime destructive-test root guard
+- [x] add stale-lock inspection and owned recovery
+- [x] add partial-run recovery inspection
 
 ### Adapters
 
@@ -3378,7 +3378,7 @@ decision-log entry. They must not be smuggled in as adapter fixes.
 - [x] initial Docker inventory
 - [x] Cursor, Copilot CLI, Zed, OpenCode, and Grok inventory
 - [ ] runtime audit
-- [ ] Mole probe
+- [x] Mole probe
 - [x] exact configured artifact removal
 - [ ] Git dirty, staged, untracked, operation, detached, and push-state proof
 - [ ] Codex and Claude session-to-worktree roots
@@ -3391,10 +3391,10 @@ decision-log entry. They must not be smuggled in as adapter fixes.
 ### Documentation and release
 
 - [x] safety guide
-- [ ] automation guide
-- [ ] recovery guide
+- [x] automation guide
+- [x] recovery guide
 - [x] adapter capability matrix
-- [ ] config reference
+- [x] config reference
 - [ ] website docs
 - [ ] npm provenance proof
 - [ ] Homebrew formula

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -2494,6 +2494,9 @@ Every event includes:
 - command/run ID
 - sequence number
 
+Once `command.started` is emitted, `command.completed` is always the terminal
+record, including a `failed` status when audit or persistence fails.
+
 ### Output compatibility
 
 Breaking changes to:

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -74,6 +74,10 @@ agentrinse lock recover --yes
 
 Remote, active, malformed, or uninspectable locks fail closed.
 
+Recovery is serialized by a kernel-held mutex (`lockf` on macOS, `flock` on
+Linux). A crashed recovery process releases that mutex automatically; the
+marker file itself is not evidence that recovery is active.
+
 ## State Corruption
 
 Run:

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -1,0 +1,87 @@
+# Recovery
+
+AgentRinse records enough local state to distinguish completed, skipped,
+failed, partial, and interrupted runs. It does not retry an old plan
+automatically.
+
+## Inspect Runs
+
+```bash
+agentrinse history
+agentrinse history --since 30d
+agentrinse show run <run-id>
+```
+
+Run journals live under:
+
+```text
+$XDG_STATE_HOME/agentrinse/runs/<run-id>.json
+```
+
+or `$HOME/.local/state/agentrinse/runs` when `XDG_STATE_HOME` is unset.
+
+## Interrupted Runs
+
+The first SIGINT requests cooperative cancellation. AgentRinse finishes any
+active isolation/removal critical section, persists its exact outcome, then
+marks the run `interrupted` at the next safe checkpoint. Repeated SIGINT does
+not bypass journaling.
+
+Inspect the run. Do not reuse its plan. Create a fresh audit and plan after
+confirming every recorded path.
+
+## Partial or Failed Runs
+
+`show run` prints each diagnostic and last known isolation path. A tombstone
+has the form:
+
+```text
+<project>/.agentrinse-<run-and-action-id>.tombstone
+```
+
+If a run is `partial`, some content may already be gone. Do not assume the
+original or tombstone tree is complete. Inspect both paths, preserve needed
+files, repair the project with its normal package/build tool, then create a
+fresh audit.
+
+AgentRinse never labels a removal failure as rolled back after recursive
+deletion has begun.
+
+## Apply Locks
+
+Inspect before recovery:
+
+```bash
+agentrinse lock status
+agentrinse lock status --json
+```
+
+The lock records PID, process start identity where available, hostname,
+command, plan ID, run ID, token, and creation time.
+
+Recovery is allowed only when:
+
+- the lock hostname matches the current host
+- the recorded process is absent, or the PID belongs to a process with a
+  different start identity
+- the lock token and inode still match immediately before removal
+
+Age alone is never proof.
+
+```bash
+agentrinse lock recover --yes
+```
+
+Remote, active, malformed, or uninspectable locks fail closed.
+
+## State Corruption
+
+Run:
+
+```bash
+agentrinse doctor
+```
+
+Doctor validates persisted audit, plan, and run schemas without rewriting
+them. Preserve incompatible files before moving them out of the state
+directory. Never delete a journal that is the only record of a partial action.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -57,8 +57,9 @@ exact tarball is:
 - attached to the GitHub release with its `.sha256` file
 
 The npm job has no repository write permission. The release-asset job has no
-OIDC token or npm environment. Verify the published registry integrity and the
-GitHub checksum against the downloaded tarball after every release.
+OIDC token or npm environment, runs only after npm publication succeeds, and
+never overwrites existing assets. Verify the published registry integrity and
+the GitHub checksum against the downloaded tarball after every release.
 
 If a release-triggered run contains obsolete verification automation, run the
 current workflow manually with `release_tag` set to the existing tag. Manual

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -48,6 +48,17 @@ provenance and avoids a long-lived publish secret.
 
 The workflow refuses tags that do not exactly match `package.json`.
 
+The release workflow builds the package once in an unprivileged job. That
+exact tarball is:
+
+- checksummed with SHA-256
+- passed to the OIDC-only npm publish job
+- attached to the GitHub release with its `.sha256` file
+
+The npm job has no repository write permission. The release-asset job has no
+OIDC token or npm environment. Verify the published registry integrity and the
+GitHub checksum against the downloaded tarball after every release.
+
 If a release-triggered run contains obsolete verification automation, run the
 current workflow manually with `release_tag` set to the existing tag. Manual
 dispatches run in a separate validation job without the `npm` environment or

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -52,6 +52,7 @@ The release workflow builds the package once in an unprivileged job. That
 exact tarball is:
 
 - checksummed with SHA-256
+- installed and exercised through audit, plan, and apply
 - passed to the OIDC-only npm publish job
 - attached to the GitHub release with its `.sha256` file
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-## 0.1: Safe Rebuildable Artifacts
+## 0.1: Operational Safe Artifacts
 
 Shipped:
 
@@ -14,16 +14,19 @@ Shipped:
 - atomic same-parent isolation
 - rebuildable artifact removal
 - generated JSON Schemas
-
-## 0.2: Operational Visibility
-
-- run history and journal inspection commands
-- explicit stale-lock inspection and recovery command
-- explicit partial-run recovery guidance
-- richer provider diagnostics
-- NDJSON event output
+- config initialization and doctor diagnostics
+- history, show, partial-run guidance, and stale-lock recovery
+- JSON envelopes, NDJSON events, and redacted audit export
 - shell completion
-- Homebrew distribution
+- npm distribution with macOS and Linux package proof
+
+## 0.2: Agent-Aware Reachability
+
+- Git dirty, staged, untracked, operation, detached, and push-state proof
+- provider session-to-worktree roots
+- provider-managed worktree and pin roots
+- runtime installation inventory
+- report-only cleanup recommendations for protected provider state
 
 ## 0.3: Recoverable Worktrees
 
@@ -32,6 +35,7 @@ Shipped:
 - recovery refs
 - same-filesystem quarantine
 - tested undo and expiry
+- Homebrew distribution
 
 This phase requires a separate mutation-boundary decision.
 

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -99,10 +99,15 @@ Execution errors are journaled separately from persistence errors. If deletion
 succeeds but persisting `applied` fails, the durable action remains
 `applying`; AgentRinse never rewrites the completed mutation as a failed one.
 
-One global apply lock prevents concurrent runs. Existing lock files fail
-closed, including stale-looking locks. An operator must inspect the recorded
-host and PID before manually removing a stale lock. Release verifies the lock
-token and inode before unlinking its own lock.
+One global apply lock prevents concurrent runs. The record includes PID,
+process start identity where available, hostname, command, plan ID, and run
+ID. AgentRinse can recover a local lock only after proving the recorded process
+is gone or the PID was reused. Age alone is never evidence. Recovery and
+ordinary release both verify the lock token and inode before unlinking.
+
+SIGINT is cooperative. AgentRinse completes any active isolation/removal
+critical section, persists its exact outcome, and marks the run interrupted at
+the next safe checkpoint.
 
 The state directory is rejected if it is inside a planned cleanup target.
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "agentrinse",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": false,
-  "description": "Reservation release for safe agentic-development cleanup.",
+  "description": "Safe, local-first cleanup for agentic development.",
   "keywords": [
     "agents",
     "cleanup",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "schemas:check": "pnpm build && node scripts/generate-schemas.mjs --check",
     "schemas:generate": "pnpm build && node scripts/generate-schemas.mjs",
     "smoke": "pnpm build && node scripts/smoke.mjs",
+    "smoke:package": "pnpm build && node scripts/smoke-package.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc -p tsconfig.json --noEmit"

--- a/schemas/command-envelope.schema.json
+++ b/schemas/command-envelope.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "schemaVersion": {
+      "type": "number",
+      "const": 1
+    },
+    "command": {
+      "type": "string",
+      "minLength": 1
+    },
+    "agentrinseVersion": {
+      "type": "string",
+      "minLength": 1
+    },
+    "startedAt": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+    },
+    "completedAt": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["ok", "degraded", "failed"]
+    },
+    "data": {},
+    "diagnostics": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "severity": {
+            "type": "string",
+            "enum": ["info", "warning", "error"]
+          },
+          "code": {
+            "type": "string",
+            "minLength": 1
+          },
+          "message": {
+            "type": "string",
+            "minLength": 1
+          },
+          "adapter": {
+            "type": "string",
+            "minLength": 1
+          },
+          "resourceId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "remediation": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": ["severity", "code", "message"]
+      }
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "command",
+    "agentrinseVersion",
+    "startedAt",
+    "completedAt",
+    "status",
+    "data",
+    "diagnostics"
+  ],
+  "$id": "https://agentrinse.com/schemas/command-envelope.schema.json",
+  "title": "AgentRinse command-envelope schema"
+}

--- a/schemas/command-event.schema.json
+++ b/schemas/command-event.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "schemaVersion": {
+      "type": "number",
+      "const": 1
+    },
+    "event": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+    },
+    "command": {
+      "type": "string",
+      "minLength": 1
+    },
+    "commandId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "sequence": {
+      "type": "integer",
+      "exclusiveMinimum": 0,
+      "maximum": 9007199254740991
+    },
+    "data": {}
+  },
+  "required": ["schemaVersion", "event", "timestamp", "command", "commandId", "sequence"],
+  "$id": "https://agentrinse.com/schemas/command-event.schema.json",
+  "title": "AgentRinse command-event schema"
+}

--- a/schemas/doctor.schema.json
+++ b/schemas/doctor.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "schemaVersion": {
+      "type": "number",
+      "const": 1
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["ok", "warning", "error"]
+    },
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "status": {
+            "type": "string",
+            "enum": ["pass", "warning", "error"]
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1
+          },
+          "detail": {
+            "type": "string",
+            "minLength": 1
+          },
+          "remediation": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": ["id", "status", "summary"]
+      }
+    }
+  },
+  "required": ["schemaVersion", "generatedAt", "status", "checks"],
+  "$id": "https://agentrinse.com/schemas/doctor.schema.json",
+  "title": "AgentRinse doctor schema"
+}

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -26,7 +26,7 @@
     },
     "status": {
       "type": "string",
-      "enum": ["running", "completed", "partial", "failed"]
+      "enum": ["running", "completed", "partial", "failed", "interrupted"]
     },
     "actions": {
       "type": "array",

--- a/scripts/generate-schemas.mjs
+++ b/scripts/generate-schemas.mjs
@@ -4,12 +4,18 @@ import { join } from "node:path";
 
 import { z } from "zod";
 
-import { auditReportSchema, cleanupPlanSchema, cleanupRunSchema } from "../dist/index.js";
+import {
+  auditReportSchema,
+  cleanupPlanSchema,
+  cleanupRunSchema,
+  doctorReportSchema,
+} from "../dist/index.js";
 
 const outputDirectory = join(process.cwd(), "schemas");
 const check = process.argv.includes("--check");
 const schemas = [
   ["audit.schema.json", "audit", auditReportSchema],
+  ["doctor.schema.json", "doctor", doctorReportSchema],
   ["plan.schema.json", "plan", cleanupPlanSchema],
   ["run.schema.json", "run", cleanupRunSchema],
 ];

--- a/scripts/generate-schemas.mjs
+++ b/scripts/generate-schemas.mjs
@@ -6,6 +6,8 @@ import { z } from "zod";
 
 import {
   auditReportSchema,
+  commandEnvelopeSchema,
+  commandEventSchema,
   cleanupPlanSchema,
   cleanupRunSchema,
   doctorReportSchema,
@@ -15,6 +17,8 @@ const outputDirectory = join(process.cwd(), "schemas");
 const check = process.argv.includes("--check");
 const schemas = [
   ["audit.schema.json", "audit", auditReportSchema],
+  ["command-envelope.schema.json", "command-envelope", commandEnvelopeSchema],
+  ["command-event.schema.json", "command-event", commandEventSchema],
   ["doctor.schema.json", "doctor", doctorReportSchema],
   ["plan.schema.json", "plan", cleanupPlanSchema],
   ["run.schema.json", "run", cleanupRunSchema],

--- a/scripts/smoke-package.mjs
+++ b/scripts/smoke-package.mjs
@@ -1,0 +1,57 @@
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readFile, realpath } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join, resolve } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const root = await realpath(await mkdtemp(join(tmpdir(), "agentrinse-package-smoke-")));
+const packageRoot = join(root, "package");
+const installRoot = join(root, "install");
+const requestedTarball = process.argv.slice(2).find((argument) => argument !== "--");
+
+let tarball;
+if (requestedTarball) {
+  tarball = resolve(requestedTarball);
+} else {
+  await mkdir(packageRoot);
+  const packed = await execFileAsync("npm", ["pack", "--json", "--pack-destination", packageRoot], {
+    cwd: process.cwd(),
+  });
+  const result = JSON.parse(packed.stdout);
+  const filename = result[0]?.filename;
+  if (typeof filename !== "string") {
+    throw new Error("npm pack did not report a package filename");
+  }
+  tarball = join(packageRoot, filename);
+}
+
+await readFile(tarball);
+await execFileAsync(
+  "npm",
+  ["install", "--prefix", installRoot, "--ignore-scripts", "--no-audit", "--no-fund", tarball],
+  { cwd: root },
+);
+
+const executable =
+  process.platform === "win32"
+    ? join(installRoot, "node_modules", ".bin", "agentrinse.cmd")
+    : join(installRoot, "node_modules", ".bin", "agentrinse");
+const version = (await execFileAsync(executable, ["--version"], { cwd: root })).stdout.trim();
+const smoke = await execFileAsync(process.execPath, ["scripts/smoke.mjs"], {
+  cwd: process.cwd(),
+  env: {
+    ...process.env,
+    AGENTRINSE_SMOKE_CLI: executable,
+  },
+});
+const result = JSON.parse(smoke.stdout);
+
+process.stdout.write(
+  `${JSON.stringify({
+    ...result,
+    version,
+    package: basename(tarball),
+    installed: true,
+  })}\n`,
+);

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -76,84 +76,44 @@ if (!Array.isArray(plan.actions) || plan.actions.length !== 1) {
 }
 
 await access(artifact);
-if (packageJson.version === "0.0.0") {
-  try {
-    await execFileAsync(
-      process.execPath,
-      [
-        "dist/cli.js",
-        "apply",
-        "--plan",
-        planPath,
-        "--config",
-        configPath,
-        "--state-dir",
-        statePath,
-        "--yes",
-        "--json",
-      ],
-      { cwd: process.cwd() },
-    );
-    throw new Error("reservation smoke apply unexpectedly succeeded");
-  } catch (error) {
-    if (
-      !(error instanceof Error) ||
-      !("stderr" in error) ||
-      !String(error.stderr).includes("apply is unavailable in the unsupported 0.0.0")
-    ) {
-      throw error;
-    }
-  }
-  await access(artifact);
-  await access(join(project, "source.ts"));
-  process.stdout.write(
-    `${JSON.stringify({
-      syntheticRoot: root,
-      findings: audit.findings.length,
-      protected: 2,
-      planActions: plan.actions.length,
-      apply: "blocked-reservation",
-    })}\n`,
-  );
-} else {
-  const apply = await execFileAsync(
-    process.execPath,
-    [
-      "dist/cli.js",
-      "apply",
-      "--plan",
-      planPath,
-      "--config",
-      configPath,
-      "--state-dir",
-      statePath,
-      "--yes",
-      "--json",
-    ],
-    { cwd: process.cwd() },
-  );
-  const run = JSON.parse(apply.stdout);
+const apply = await execFileAsync(
+  process.execPath,
+  [
+    "dist/cli.js",
+    "apply",
+    "--plan",
+    planPath,
+    "--config",
+    configPath,
+    "--state-dir",
+    statePath,
+    "--yes",
+    "--json",
+  ],
+  { cwd: process.cwd() },
+);
+const run = JSON.parse(apply.stdout);
 
-  if (run.status !== "completed" || run.actions?.[0]?.status !== "applied") {
-    throw new Error("smoke apply did not complete");
-  }
-  await access(join(project, "source.ts"));
-  try {
-    await access(artifact);
-    throw new Error("smoke apply left the planned artifact in place");
-  } catch (error) {
-    if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") {
-      throw error;
-    }
-  }
-  process.stdout.write(
-    `${JSON.stringify({
-      syntheticRoot: root,
-      findings: audit.findings.length,
-      protected: 2,
-      planActions: plan.actions.length,
-      applied: 1,
-      reclaimedBytes: run.reclaimedBytes,
-    })}\n`,
-  );
+if (run.status !== "completed" || run.actions?.[0]?.status !== "applied") {
+  throw new Error("smoke apply did not complete");
 }
+await access(join(project, "source.ts"));
+try {
+  await access(artifact);
+  throw new Error("smoke apply left the planned artifact in place");
+} catch (error) {
+  if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") {
+    throw error;
+  }
+}
+process.stdout.write(
+  `${JSON.stringify({
+    version: packageJson.version,
+    syntheticRoot: root,
+    findings: audit.findings.length,
+    protected: 2,
+    planActions: plan.actions.length,
+    applied: 1,
+    reclaimedBytes: run.reclaimedBytes,
+  })}\n`,
+);

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -6,7 +6,9 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 const packageJson = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"));
+const { assertDestructiveFixtureRoot } = await import("../dist/core/safety.js");
 const root = await realpath(await mkdtemp(join(tmpdir(), "agentrinse-smoke-")));
+await assertDestructiveFixtureRoot(root);
 const home = join(root, "home");
 const auditPath = join(root, "audit.json");
 const planPath = join(root, "plan.json");

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -7,6 +7,11 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 const packageJson = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"));
 const { assertDestructiveFixtureRoot } = await import("../dist/core/safety.js");
+const installedCli = process.env.AGENTRINSE_SMOKE_CLI;
+const runCli = (args) =>
+  installedCli
+    ? execFileAsync(installedCli, args, { cwd: process.cwd() })
+    : execFileAsync(process.execPath, ["dist/cli.js", ...args], { cwd: process.cwd() });
 const root = await realpath(await mkdtemp(join(tmpdir(), "agentrinse-smoke-")));
 await assertDestructiveFixtureRoot(root);
 const home = join(root, "home");
@@ -46,16 +51,8 @@ await writeFile(
   )}\n`,
 );
 
-await execFileAsync(
-  process.execPath,
-  ["dist/cli.js", "audit", "--home", home, "--config", configPath, "--json", "--output", auditPath],
-  { cwd: process.cwd() },
-);
-await execFileAsync(
-  process.execPath,
-  ["dist/cli.js", "plan", "--audit", auditPath, "--config", configPath, "--output", planPath],
-  { cwd: process.cwd() },
-);
+await runCli(["audit", "--home", home, "--config", configPath, "--json", "--output", auditPath]);
+await runCli(["plan", "--audit", auditPath, "--config", configPath, "--output", planPath]);
 
 const audit = JSON.parse(await readFile(auditPath, "utf8"));
 const plan = JSON.parse(await readFile(planPath, "utf8"));
@@ -76,22 +73,17 @@ if (!Array.isArray(plan.actions) || plan.actions.length !== 1) {
 }
 
 await access(artifact);
-const apply = await execFileAsync(
-  process.execPath,
-  [
-    "dist/cli.js",
-    "apply",
-    "--plan",
-    planPath,
-    "--config",
-    configPath,
-    "--state-dir",
-    statePath,
-    "--yes",
-    "--json",
-  ],
-  { cwd: process.cwd() },
-);
+const apply = await runCli([
+  "apply",
+  "--plan",
+  planPath,
+  "--config",
+  configPath,
+  "--state-dir",
+  statePath,
+  "--yes",
+  "--json",
+]);
 const run = JSON.parse(apply.stdout);
 
 if (run.status !== "completed" || run.actions?.[0]?.status !== "applied") {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
 import { main } from "./main.js";
+import { CommandInterruptedError } from "./core/interruption.js";
 
 main().catch((error: unknown) => {
   const message = error instanceof Error ? error.message : String(error);
   process.stderr.write(`agentrinse: ${message}\n`);
-  process.exitCode = 1;
+  process.exitCode = error instanceof CommandInterruptedError ? error.exitCode : 1;
 });

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -15,6 +15,7 @@ export type ApplyCommandOptions = {
   stateDir?: string;
   yes: boolean;
   json: boolean;
+  signal?: AbortSignal;
 };
 
 export type ApplyCommandResult = {
@@ -75,6 +76,7 @@ export async function executeApplyCommand(
     input,
     config,
     stateRoot: resolveStateRoot(plan.home, options.stateDir),
+    ...(options.signal === undefined ? {} : { signal: options.signal }),
   });
   return {
     run: result.run,

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -1,7 +1,7 @@
 import { createInterface } from "node:readline/promises";
 import { resolve } from "node:path";
 
-import { loadConfig } from "../config/load.js";
+import { loadConfigForHome } from "../config/load.js";
 import { cleanupPlanSchema } from "../contracts/plan.js";
 import type { CleanupRun } from "../contracts/run.js";
 import { applyCleanupPlan } from "../core/apply.js";
@@ -65,7 +65,7 @@ export async function executeApplyCommand(
 
   const input = await readJsonFile(resolve(options.plan));
   const plan = cleanupPlanSchema.parse(input);
-  const config = await loadConfig(options.config);
+  const { config } = await loadConfigForHome(plan.home, options.config);
 
   if (!options.yes && !(await confirmApply(plan.actions.length))) {
     throw new Error("apply cancelled");

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -5,6 +5,7 @@ import { loadConfigForHome } from "../config/load.js";
 import { cleanupPlanSchema } from "../contracts/plan.js";
 import type { CleanupRun } from "../contracts/run.js";
 import { applyCleanupPlan } from "../core/apply.js";
+import { CommandInterruptedError } from "../core/interruption.js";
 import { readJsonFile } from "../state/json-file.js";
 import { resolveStateRoot } from "../state/layout.js";
 
@@ -23,20 +24,59 @@ export type ApplyCommandResult = {
   output: string;
 };
 
-async function confirmApply(actionCount: number): Promise<boolean> {
-  if (!process.stdin.isTTY || !process.stdout.isTTY) {
-    throw new Error("apply requires --yes when stdin or stdout is not an interactive terminal");
-  }
+export type ConfirmApplyDependencies = {
+  isInteractive?: () => boolean;
+  question?: (prompt: string, signal?: AbortSignal) => Promise<string>;
+};
 
+async function defaultQuestion(promptText: string, signal?: AbortSignal): Promise<string> {
   const prompt = createInterface({
     input: process.stdin,
     output: process.stdout,
   });
   try {
-    const answer = await prompt.question(`Apply ${actionCount} safe cleanup action(s)? [y/N] `);
-    return ["y", "yes"].includes(answer.trim().toLowerCase());
+    return signal === undefined
+      ? await prompt.question(promptText)
+      : await prompt.question(promptText, { signal });
   } finally {
     prompt.close();
+  }
+}
+
+function interruptionFrom(signal?: AbortSignal): CommandInterruptedError | undefined {
+  if (signal?.aborted !== true) {
+    return undefined;
+  }
+  return signal.reason instanceof CommandInterruptedError
+    ? signal.reason
+    : new CommandInterruptedError("apply interrupted");
+}
+
+export async function confirmApply(
+  actionCount: number,
+  signal?: AbortSignal,
+  dependencies: ConfirmApplyDependencies = {},
+): Promise<boolean> {
+  const initialInterruption = interruptionFrom(signal);
+  if (initialInterruption !== undefined) {
+    throw initialInterruption;
+  }
+  if (!(dependencies.isInteractive ?? (() => process.stdin.isTTY && process.stdout.isTTY))()) {
+    throw new Error("apply requires --yes when stdin or stdout is not an interactive terminal");
+  }
+
+  try {
+    const answer = await (dependencies.question ?? defaultQuestion)(
+      `Apply ${actionCount} safe cleanup action(s)? [y/N] `,
+      signal,
+    );
+    return ["y", "yes"].includes(answer.trim().toLowerCase());
+  } catch (error) {
+    const interruption = interruptionFrom(signal);
+    if (interruption !== undefined) {
+      throw interruption;
+    }
+    throw error;
   }
 }
 
@@ -63,7 +103,7 @@ export async function executeApplyCommand(
   const plan = cleanupPlanSchema.parse(input);
   const { config } = await loadConfigForHome(plan.home, options.config);
 
-  if (!options.yes && !(await confirmApply(plan.actions.length))) {
+  if (!options.yes && !(await confirmApply(plan.actions.length, options.signal))) {
     throw new Error("apply cancelled");
   }
 

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -7,7 +7,6 @@ import type { CleanupRun } from "../contracts/run.js";
 import { applyCleanupPlan } from "../core/apply.js";
 import { readJsonFile } from "../state/json-file.js";
 import { resolveStateRoot } from "../state/layout.js";
-import { VERSION } from "../version.js";
 
 export type ApplyCommandOptions = {
   plan: string;
@@ -60,10 +59,6 @@ export async function executeApplyCommand(
   if (options.json && !options.yes) {
     throw new Error("apply --json requires --yes");
   }
-  if (VERSION === "0.0.0") {
-    throw new Error("apply is unavailable in the unsupported 0.0.0 reservation release");
-  }
-
   const input = await readJsonFile(resolve(options.plan));
   const plan = cleanupPlanSchema.parse(input);
   const { config } = await loadConfigForHome(plan.home, options.config);

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -1,7 +1,7 @@
 import { resolve } from "node:path";
 
 import { createAuditAdapters } from "../adapters/registry.js";
-import { loadConfig } from "../config/load.js";
+import { loadConfigForHome } from "../config/load.js";
 import type { AuditReport } from "../contracts/report.js";
 import { runAudit } from "../core/audit.js";
 import { renderAudit } from "../output.js";
@@ -22,9 +22,10 @@ export type AuditCommandResult = {
 export async function executeAuditCommand(
   options: AuditCommandOptions,
 ): Promise<AuditCommandResult> {
-  const config = await loadConfig(options.config);
+  const home = resolve(options.home);
+  const { config } = await loadConfigForHome(home, options.config);
   const report = await runAudit({
-    home: resolve(options.home),
+    home,
     config,
     adapters: createAuditAdapters(config),
   });

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -6,16 +6,19 @@ import type { AuditReport } from "../contracts/report.js";
 import { runAudit } from "../core/audit.js";
 import { renderAudit } from "../output.js";
 import { writeJsonAtomic } from "../state/json-file.js";
+import { resolveStateRoot, stateLayout } from "../state/layout.js";
 
 export type AuditCommandOptions = {
   home: string;
   config?: string;
   json: boolean;
   output?: string;
+  stateDir?: string;
 };
 
 export type AuditCommandResult = {
   report: AuditReport;
+  statePath: string;
   output: string;
 };
 
@@ -29,6 +32,11 @@ export async function executeAuditCommand(
     config,
     adapters: createAuditAdapters(config),
   });
+  const statePath = resolve(
+    stateLayout(resolveStateRoot(home, options.stateDir)).audits,
+    `${report.auditId}.json`,
+  );
+  await writeJsonAtomic(statePath, report);
 
   if (options.output !== undefined) {
     await writeJsonAtomic(resolve(options.output), report);
@@ -36,6 +44,7 @@ export async function executeAuditCommand(
 
   return {
     report,
+    statePath,
     output: options.json ? `${JSON.stringify(report, null, 2)}\n` : renderAudit(report),
   };
 }

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -1,9 +1,17 @@
+import { randomUUID } from "node:crypto";
 import { resolve } from "node:path";
 
 import { createAuditAdapters } from "../adapters/registry.js";
 import { loadConfigForHome } from "../config/load.js";
 import type { AuditReport } from "../contracts/report.js";
-import { runAudit } from "../core/audit.js";
+import { runAudit, type AuditProgressEvent } from "../core/audit.js";
+import { redactAuditReport, redactAuditValue } from "../core/redaction.js";
+import {
+  createCommandEnvelope,
+  createCommandEvent,
+  jsonDocument,
+  ndjsonRecord,
+} from "../machine-output.js";
 import { renderAudit } from "../output.js";
 import { writeJsonAtomic } from "../state/json-file.js";
 import { resolveStateRoot, stateLayout } from "../state/layout.js";
@@ -11,9 +19,13 @@ import { resolveStateRoot, stateLayout } from "../state/layout.js";
 export type AuditCommandOptions = {
   home: string;
   config?: string;
-  json: boolean;
+  json?: boolean;
+  ndjson?: boolean;
+  redact?: boolean;
   output?: string;
   stateDir?: string;
+  now?: () => Date;
+  emit?: (output: string) => void;
 };
 
 export type AuditCommandResult = {
@@ -25,12 +37,57 @@ export type AuditCommandResult = {
 export async function executeAuditCommand(
   options: AuditCommandOptions,
 ): Promise<AuditCommandResult> {
+  if (options.json === true && options.ndjson === true) {
+    throw new Error("audit accepts only one of --json or --ndjson");
+  }
+  if (options.redact === true && options.json !== true && options.ndjson !== true) {
+    throw new Error("audit --redact requires --json or --ndjson");
+  }
+
+  const clock = options.now ?? (() => new Date());
+  const commandId = randomUUID();
+  const salt = randomUUID();
+  const ndjson: string[] = [];
+  let sequence = 0;
+  const emitEvent = (event: string, timestamp: string, data?: unknown): void => {
+    const value = createCommandEvent({
+      event,
+      timestamp,
+      command: "audit",
+      commandId,
+      sequence: (sequence += 1),
+      ...(data === undefined ? {} : { data }),
+    });
+    const output = ndjsonRecord(value);
+    if (options.emit === undefined) {
+      ndjson.push(output);
+    } else {
+      options.emit(output);
+    }
+  };
+
   const home = resolve(options.home);
   const { config } = await loadConfigForHome(home, options.config);
+  const startedAt = clock().toISOString();
+  if (options.ndjson === true) {
+    emitEvent("command.started", startedAt, options.redact === true ? { home: "$HOME" } : { home });
+  }
   const report = await runAudit({
     home,
     config,
     adapters: createAuditAdapters(config),
+    now: clock,
+    ...(options.ndjson === true
+      ? {
+          onEvent: (event: AuditProgressEvent) => {
+            emitEvent(
+              event.type,
+              event.timestamp,
+              options.redact === true ? redactAuditValue(event.data, home, salt) : event.data,
+            );
+          },
+        }
+      : {}),
   });
   const statePath = resolve(
     stateLayout(resolveStateRoot(home, options.stateDir)).audits,
@@ -42,9 +99,42 @@ export async function executeAuditCommand(
     await writeJsonAtomic(resolve(options.output), report);
   }
 
+  const selectedReport = options.redact === true ? redactAuditReport(report, salt) : report;
+  if (options.ndjson === true) {
+    emitEvent("command.completed", report.completedAt, {
+      auditId:
+        options.redact === true
+          ? redactAuditValue({ auditId: report.auditId }, home, salt).auditId
+          : report.auditId,
+      status:
+        report.probes.some((probe) => probe.status === "degraded") || report.diagnostics.length > 0
+          ? "degraded"
+          : "ok",
+      probes: report.probes.length,
+      findings: report.findings.length,
+    });
+  }
+  const status =
+    report.probes.some((probe) => probe.status === "degraded") || report.diagnostics.length > 0
+      ? "degraded"
+      : "ok";
   return {
     report,
     statePath,
-    output: options.json ? `${JSON.stringify(report, null, 2)}\n` : renderAudit(report),
+    output:
+      options.ndjson === true
+        ? ndjson.join("")
+        : options.json === true
+          ? jsonDocument(
+              createCommandEnvelope({
+                command: "audit",
+                startedAt: report.startedAt,
+                completedAt: report.completedAt,
+                status,
+                data: selectedReport,
+                diagnostics: selectedReport.diagnostics,
+              }),
+            )
+          : renderAudit(report),
   };
 }

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -72,69 +72,85 @@ export async function executeAuditCommand(
   if (options.ndjson === true) {
     emitEvent("command.started", startedAt, options.redact === true ? { home: "$HOME" } : { home });
   }
-  const report = await runAudit({
-    home,
-    config,
-    adapters: createAuditAdapters(config),
-    now: clock,
-    ...(options.ndjson === true
-      ? {
-          onEvent: (event: AuditProgressEvent) => {
-            emitEvent(
-              event.type,
-              event.timestamp,
-              options.redact === true ? redactAuditValue(event.data, home, salt) : event.data,
-            );
-          },
-        }
-      : {}),
-  });
-  const statePath = resolve(
-    stateLayout(resolveStateRoot(home, options.stateDir)).audits,
-    `${report.auditId}.json`,
-  );
-  await writeJsonAtomic(statePath, report);
-
-  if (options.output !== undefined) {
-    await writeJsonAtomic(resolve(options.output), report);
-  }
-
-  const selectedReport = options.redact === true ? redactAuditReport(report, salt) : report;
-  if (options.ndjson === true) {
-    emitEvent("command.completed", report.completedAt, {
-      auditId:
-        options.redact === true
-          ? redactAuditValue({ auditId: report.auditId }, home, salt).auditId
-          : report.auditId,
-      status:
-        report.probes.some((probe) => probe.status === "degraded") || report.diagnostics.length > 0
-          ? "degraded"
-          : "ok",
-      probes: report.probes.length,
-      findings: report.findings.length,
+  try {
+    const report = await runAudit({
+      home,
+      config,
+      adapters: createAuditAdapters(config),
+      now: clock,
+      ...(options.ndjson === true
+        ? {
+            onEvent: (event: AuditProgressEvent) => {
+              emitEvent(
+                event.type,
+                event.timestamp,
+                options.redact === true ? redactAuditValue(event.data, home, salt) : event.data,
+              );
+            },
+          }
+        : {}),
     });
+    const statePath = resolve(
+      stateLayout(resolveStateRoot(home, options.stateDir)).audits,
+      `${report.auditId}.json`,
+    );
+    await writeJsonAtomic(statePath, report);
+
+    if (options.output !== undefined) {
+      await writeJsonAtomic(resolve(options.output), report);
+    }
+
+    const selectedReport = options.redact === true ? redactAuditReport(report, salt) : report;
+    if (options.ndjson === true) {
+      emitEvent("command.completed", report.completedAt, {
+        auditId:
+          options.redact === true
+            ? redactAuditValue({ auditId: report.auditId }, home, salt).auditId
+            : report.auditId,
+        status:
+          report.probes.some((probe) => probe.status === "degraded") ||
+          report.diagnostics.length > 0
+            ? "degraded"
+            : "ok",
+        probes: report.probes.length,
+        findings: report.findings.length,
+      });
+    }
+    const status =
+      report.probes.some((probe) => probe.status === "degraded") || report.diagnostics.length > 0
+        ? "degraded"
+        : "ok";
+    return {
+      report,
+      statePath,
+      output:
+        options.ndjson === true
+          ? ndjson.join("")
+          : options.json === true
+            ? jsonDocument(
+                createCommandEnvelope({
+                  command: "audit",
+                  startedAt: report.startedAt,
+                  completedAt: report.completedAt,
+                  status,
+                  data: selectedReport,
+                  diagnostics: selectedReport.diagnostics,
+                }),
+              )
+            : renderAudit(report),
+    };
+  } catch (error) {
+    if (options.ndjson === true) {
+      const data = {
+        status: "failed",
+        error: error instanceof Error ? error.message : String(error),
+      };
+      emitEvent(
+        "command.completed",
+        clock().toISOString(),
+        options.redact === true ? redactAuditValue(data, home, salt) : data,
+      );
+    }
+    throw error;
   }
-  const status =
-    report.probes.some((probe) => probe.status === "degraded") || report.diagnostics.length > 0
-      ? "degraded"
-      : "ok";
-  return {
-    report,
-    statePath,
-    output:
-      options.ndjson === true
-        ? ndjson.join("")
-        : options.json === true
-          ? jsonDocument(
-              createCommandEnvelope({
-                command: "audit",
-                startedAt: report.startedAt,
-                completedAt: report.completedAt,
-                status,
-                data: selectedReport,
-                diagnostics: selectedReport.diagnostics,
-              }),
-            )
-          : renderAudit(report),
-  };
 }

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -90,11 +90,11 @@ export async function executeAuditCommand(
           }
         : {}),
     });
-    const statePath = resolve(
-      stateLayout(resolveStateRoot(home, options.stateDir)).audits,
-      `${report.auditId}.json`,
-    );
-    await writeJsonAtomic(statePath, report);
+    const layout = stateLayout(resolveStateRoot(home, options.stateDir));
+    const statePath = resolve(layout.audits, `${report.auditId}.json`);
+    await writeJsonAtomic(statePath, report, {
+      privateDirectories: [layout.root, layout.audits],
+    });
 
     if (options.output !== undefined) {
       await writeJsonAtomic(resolve(options.output), report);

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -1,0 +1,105 @@
+export const completionShells = ["bash", "zsh", "fish"] as const;
+export type CompletionShell = (typeof completionShells)[number];
+
+const COMMANDS = [
+  "adapters",
+  "apply",
+  "audit",
+  "completion",
+  "config",
+  "doctor",
+  "history",
+  "lock",
+  "plan",
+  "show",
+] as const;
+
+const SUBCOMMANDS = {
+  completion: [...completionShells],
+  config: ["init", "path", "show", "validate"],
+  lock: ["recover", "status"],
+  show: ["plan", "resource", "run"],
+} as const;
+
+function bashCompletion(): string {
+  return `# bash completion for AgentRinse
+_agentrinse_completion() {
+  local current command
+  current="\${COMP_WORDS[COMP_CWORD]}"
+  command="\${COMP_WORDS[1]}"
+
+  if [[ "\${COMP_CWORD}" -eq 1 ]]; then
+    COMPREPLY=( $(compgen -W "${COMMANDS.join(" ")}" -- "\${current}") )
+    return
+  fi
+
+  case "\${command}" in
+    completion) COMPREPLY=( $(compgen -W "${SUBCOMMANDS.completion.join(" ")}" -- "\${current}") ) ;;
+    config) COMPREPLY=( $(compgen -W "${SUBCOMMANDS.config.join(" ")}" -- "\${current}") ) ;;
+    lock) COMPREPLY=( $(compgen -W "${SUBCOMMANDS.lock.join(" ")}" -- "\${current}") ) ;;
+    show) COMPREPLY=( $(compgen -W "${SUBCOMMANDS.show.join(" ")}" -- "\${current}") ) ;;
+    *) COMPREPLY=( $(compgen -W "--help --version --home --config --state-dir --json --ndjson --redact --yes --output --audit --plan --since" -- "\${current}") ) ;;
+  esac
+}
+complete -F _agentrinse_completion agentrinse
+`;
+}
+
+function zshCompletion(): string {
+  return `#compdef agentrinse
+
+_agentrinse() {
+  local -a commands
+  commands=(
+${COMMANDS.map((command) => `    '${command}:${command}'`).join("\n")}
+  )
+
+  if (( CURRENT == 2 )); then
+    _describe 'command' commands
+    return
+  fi
+
+  case "\${words[2]}" in
+    completion) _values 'shell' ${SUBCOMMANDS.completion.join(" ")} ;;
+    config) _values 'config command' ${SUBCOMMANDS.config.join(" ")} ;;
+    lock) _values 'lock command' ${SUBCOMMANDS.lock.join(" ")} ;;
+    show) _values 'show command' ${SUBCOMMANDS.show.join(" ")} ;;
+    *) _arguments '*:argument:_files' ;;
+  esac
+}
+
+compdef _agentrinse agentrinse
+`;
+}
+
+function fishCompletion(): string {
+  const lines = [
+    "# fish completion for AgentRinse",
+    "complete -c agentrinse -f",
+    ...COMMANDS.map(
+      (command) =>
+        `complete -c agentrinse -n '__fish_use_subcommand' -a '${command}' -d '${command}'`,
+    ),
+  ];
+  for (const [command, subcommands] of Object.entries(SUBCOMMANDS)) {
+    for (const subcommand of subcommands) {
+      lines.push(
+        `complete -c agentrinse -n '__fish_seen_subcommand_from ${command}' -a '${subcommand}'`,
+      );
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+export function renderCompletion(shell: string): string {
+  if (shell === "bash") {
+    return bashCompletion();
+  }
+  if (shell === "zsh") {
+    return zshCompletion();
+  }
+  if (shell === "fish") {
+    return fishCompletion();
+  }
+  throw new Error(`unsupported completion shell ${shell}; expected bash, zsh, or fish`);
+}

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,0 +1,73 @@
+import { access } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { DEFAULT_CONFIG } from "../config/defaults.js";
+import { loadConfig, loadConfigForHome } from "../config/load.js";
+import { resolveConfigPath, type ConfigEnvironment } from "../config/path.js";
+import type { AgentRinseConfig } from "../config/schema.js";
+import { writeJsonExclusive } from "../state/json-file.js";
+
+export type ConfigCommandOptions = {
+  home: string;
+  config?: string | undefined;
+  environment?: ConfigEnvironment | undefined;
+};
+
+export type ConfigCommandResult = {
+  path: string;
+  output: string;
+  config?: AgentRinseConfig;
+};
+
+function targetPath(options: ConfigCommandOptions): string {
+  return resolveConfigPath(
+    resolve(options.home),
+    options.config,
+    options.environment ?? process.env,
+  );
+}
+
+export function executeConfigPathCommand(options: ConfigCommandOptions): ConfigCommandResult {
+  const path = targetPath(options);
+  return { path, output: `${path}\n` };
+}
+
+export async function executeConfigInitCommand(
+  options: ConfigCommandOptions,
+): Promise<ConfigCommandResult> {
+  const path = targetPath(options);
+  await writeJsonExclusive(path, DEFAULT_CONFIG);
+  return {
+    path,
+    config: structuredClone(DEFAULT_CONFIG),
+    output: `created ${path}\n`,
+  };
+}
+
+export async function executeConfigShowCommand(
+  options: ConfigCommandOptions,
+): Promise<ConfigCommandResult> {
+  const loaded = await loadConfigForHome(
+    options.home,
+    options.config,
+    options.environment ?? process.env,
+  );
+  return {
+    path: loaded.path,
+    config: loaded.config,
+    output: `${JSON.stringify(loaded.config, null, 2)}\n`,
+  };
+}
+
+export async function executeConfigValidateCommand(
+  options: ConfigCommandOptions,
+): Promise<ConfigCommandResult> {
+  const path = targetPath(options);
+  await access(path);
+  const config = await loadConfig(path);
+  return {
+    path,
+    config,
+    output: `valid ${path}\n`,
+  };
+}

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -29,6 +29,7 @@ export type DoctorCommandDependencies = {
   platform?: NodeJS.Platform;
   environment?: NodeJS.ProcessEnv;
   runCommand?: (command: string, args: string[]) => Promise<CommandResult>;
+  readProcessStat?: () => Promise<string>;
   lock?: LockInspectionDependencies;
 };
 
@@ -187,7 +188,7 @@ async function stateCheck(root: string): Promise<DoctorCheck> {
         detail: existing,
       };
     }
-    await access(existing, constants.R_OK | constants.W_OK);
+    await access(existing, constants.R_OK | constants.W_OK | constants.X_OK);
     return {
       id: "state",
       status: "pass",
@@ -211,6 +212,7 @@ async function stateCheck(root: string): Promise<DoctorCheck> {
 async function processOwnershipCheck(
   platform: NodeJS.Platform,
   runCommand: (command: string, args: string[]) => Promise<CommandResult>,
+  readProcessStat: () => Promise<string>,
 ): Promise<DoctorCheck> {
   if (platform === "win32") {
     return {
@@ -219,16 +221,12 @@ async function processOwnershipCheck(
       summary: "native Windows process ownership proof is unavailable",
     };
   }
+  let procfsError: unknown;
   if (platform === "linux") {
     try {
-      await readFile("/proc/self/stat", "utf8");
+      await readProcessStat();
     } catch (error) {
-      return {
-        id: "process-ownership",
-        status: "error",
-        summary: "Linux procfs process ownership proof is unavailable",
-        detail: errorMessage(error),
-      };
+      procfsError = error;
     }
   }
   try {
@@ -237,19 +235,29 @@ async function processOwnershipCheck(
       id: "process-ownership",
       status: "pass",
       summary:
-        platform === "linux"
+        platform === "linux" && procfsError === undefined
           ? "procfs ownership proof and lsof fallback are available"
-          : "lsof process ownership proof is available",
+          : platform === "linux"
+            ? "lsof fallback ownership proof is available"
+            : "lsof process ownership proof is available",
+      ...(procfsError === undefined
+        ? {}
+        : { detail: `procfs ownership proof is unavailable: ${errorMessage(procfsError)}` }),
     };
   } catch (error) {
     return {
       id: "process-ownership",
       status: "error",
       summary:
-        platform === "linux"
-          ? "lsof fallback is unavailable"
-          : "lsof process ownership proof is unavailable",
-      detail: errorMessage(error),
+        platform === "linux" && procfsError !== undefined
+          ? "Linux process ownership proof is unavailable"
+          : platform === "linux"
+            ? "lsof fallback is unavailable"
+            : "lsof process ownership proof is unavailable",
+      detail:
+        procfsError === undefined
+          ? errorMessage(error)
+          : `procfs: ${errorMessage(procfsError)}; lsof: ${errorMessage(error)}`,
       remediation: "Install lsof before applying cleanup plans.",
     };
   }
@@ -454,7 +462,7 @@ async function providerChecks(
         });
         continue;
       }
-      await access(root, constants.R_OK);
+      await access(root, constants.R_OK | constants.X_OK);
       checks.push({
         id: `provider:${spec.id}`,
         status: "pass",
@@ -488,7 +496,7 @@ async function artifactChecks(config: AgentRinseConfig): Promise<DoctorCheck[]> 
       if (!stats.isDirectory() || stats.isSymbolicLink()) {
         throw new Error("configured artifact root must be a real directory");
       }
-      await access(root, constants.R_OK | constants.W_OK);
+      await access(root, constants.R_OK | constants.W_OK | constants.X_OK);
       checks.push({
         id: `artifact-root:${index}`,
         status: "pass",
@@ -612,7 +620,11 @@ export async function executeDoctorCommand(
     platformCheck(platform),
     ...loaded.checks,
     await stateCheck(root),
-    await processOwnershipCheck(platform, runCommand),
+    await processOwnershipCheck(
+      platform,
+      runCommand,
+      dependencies.readProcessStat ?? (() => readFile("/proc/self/stat", "utf8")),
+    ),
     await recoveryMutexCheck(platform, runCommand),
     ...(await gitChecks(loaded.config, runCommand)),
     await dockerCheck(loaded.config.adapters.docker?.enabled === true, runCommand),

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -30,6 +30,7 @@ export type DoctorCommandDependencies = {
   environment?: NodeJS.ProcessEnv;
   runCommand?: (command: string, args: string[]) => Promise<CommandResult>;
   readProcessStat?: () => Promise<string>;
+  currentUid?: () => number | undefined;
   lock?: LockInspectionDependencies;
 };
 
@@ -176,7 +177,7 @@ async function configChecks(
   }
 }
 
-async function stateCheck(root: string): Promise<DoctorCheck> {
+async function stateCheck(root: string, currentUid?: number): Promise<DoctorCheck> {
   try {
     const existing = await nearestExistingPath(root);
     const stats = await lstat(existing);
@@ -186,6 +187,15 @@ async function stateCheck(root: string): Promise<DoctorCheck> {
         status: "error",
         summary: "state path resolves through a non-directory or symlink",
         detail: existing,
+      };
+    }
+    if (existing === resolve(root) && currentUid !== undefined && stats.uid !== currentUid) {
+      return {
+        id: "state",
+        status: "error",
+        summary: "state directory is not owned by the current user",
+        detail: root,
+        remediation: "Choose or create a state directory owned by the current user.",
       };
     }
     await access(existing, constants.R_OK | constants.W_OK | constants.X_OK);
@@ -623,7 +633,7 @@ export async function executeDoctorCommand(
   const checks: DoctorCheck[] = [
     platformCheck(platform),
     ...loaded.checks,
-    await stateCheck(root),
+    await stateCheck(root, dependencies.currentUid?.() ?? process.getuid?.()),
     await processOwnershipCheck(
       platform,
       runCommand,

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -394,12 +394,16 @@ async function dockerCheck(
   } catch (error) {
     return {
       id: "docker",
-      status: "warning",
-      summary: "Docker CLI is installed but its daemon or context is unavailable",
-      detail: errorMessage(error),
-      remediation: enabled
-        ? "Start Docker or disable the Docker adapter."
-        : "No action is required while the Docker adapter is disabled.",
+      status: enabled ? "warning" : "pass",
+      summary: enabled
+        ? "Docker CLI is installed but its daemon or context is unavailable"
+        : "Docker daemon is unavailable (optional)",
+      ...(enabled
+        ? {
+            detail: errorMessage(error),
+            remediation: "Start Docker or disable the Docker adapter.",
+          }
+        : {}),
     };
   }
 }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -255,6 +255,39 @@ async function processOwnershipCheck(
   }
 }
 
+async function recoveryMutexCheck(
+  platform: NodeJS.Platform,
+  runCommand: (command: string, args: string[]) => Promise<CommandResult>,
+): Promise<DoctorCheck> {
+  if (platform !== "darwin" && platform !== "linux") {
+    return {
+      id: "recovery-mutex",
+      status: "pass",
+      summary: "stale-lock recovery is not available on this platform",
+    };
+  }
+  const command = platform === "darwin" ? "lockf" : "flock";
+  try {
+    const result = await runCommand("sh", ["-c", `command -v ${command}`]);
+    return {
+      id: "recovery-mutex",
+      status: "pass",
+      summary: `${result.stdout.trim() || command} provides crash-safe stale-lock recovery`,
+    };
+  } catch (error) {
+    return {
+      id: "recovery-mutex",
+      status: "error",
+      summary: `${command} is unavailable`,
+      detail: errorMessage(error),
+      remediation:
+        platform === "darwin"
+          ? "Restore the macOS lockf utility before recovering stale locks."
+          : "Install util-linux to provide flock before recovering stale locks.",
+    };
+  }
+}
+
 async function gitChecks(
   config: AgentRinseConfig,
   runCommand: (command: string, args: string[]) => Promise<CommandResult>,
@@ -569,6 +602,7 @@ export async function executeDoctorCommand(
     ...loaded.checks,
     await stateCheck(root),
     await processOwnershipCheck(platform, runCommand),
+    await recoveryMutexCheck(platform, runCommand),
     ...(await gitChecks(loaded.config, runCommand)),
     await dockerCheck(loaded.config.adapters.docker?.enabled === true, runCommand),
     await moleCheck(platform, runCommand),

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -557,7 +557,18 @@ async function lockCheck(
   locksDirectory: string,
   dependencies?: LockInspectionDependencies,
 ): Promise<DoctorCheck> {
-  const status = await inspectApplyLock(locksDirectory, dependencies);
+  let status: Awaited<ReturnType<typeof inspectApplyLock>>;
+  try {
+    status = await inspectApplyLock(locksDirectory, dependencies);
+  } catch (error) {
+    return {
+      id: "apply-lock",
+      status: "error",
+      summary: "apply lock could not be inspected",
+      detail: errorMessage(error),
+      remediation: "Do not apply or recover until the lock owner can be inspected.",
+    };
+  }
   if (status.status === "absent") {
     return { id: "apply-lock", status: "pass", summary: "no apply lock is present" };
   }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,0 +1,592 @@
+import { execFile } from "node:child_process";
+import { constants } from "node:fs";
+import { access, lstat, readFile, readdir } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { promisify } from "node:util";
+import type { ZodType } from "zod";
+
+import { PROVIDER_SPECS } from "../adapters/provider-specs.js";
+import { DEFAULT_CONFIG } from "../config/defaults.js";
+import { loadConfigForHome } from "../config/load.js";
+import type { AgentRinseConfig } from "../config/schema.js";
+import { cleanupPlanSchema } from "../contracts/plan.js";
+import { auditReportSchema } from "../contracts/report.js";
+import { cleanupRunSchema } from "../contracts/run.js";
+import { doctorReportSchema, type DoctorCheck, type DoctorReport } from "../contracts/doctor.js";
+import { readJsonFile } from "../state/json-file.js";
+import { resolveStateRoot, stateLayout } from "../state/layout.js";
+import { inspectApplyLock, type LockInspectionDependencies } from "../state/lock.js";
+
+const execFileAsync = promisify(execFile);
+
+export type CommandResult = {
+  stdout: string;
+  stderr: string;
+};
+
+export type DoctorCommandDependencies = {
+  now?: () => Date;
+  platform?: NodeJS.Platform;
+  environment?: NodeJS.ProcessEnv;
+  runCommand?: (command: string, args: string[]) => Promise<CommandResult>;
+  lock?: LockInspectionDependencies;
+};
+
+export type DoctorCommandOptions = {
+  home: string;
+  config?: string | undefined;
+  stateDir?: string | undefined;
+  json: boolean;
+  dependencies?: DoctorCommandDependencies | undefined;
+};
+
+export type DoctorCommandResult = {
+  report: DoctorReport;
+  output: string;
+};
+
+async function defaultRunCommand(command: string, args: string[]): Promise<CommandResult> {
+  const result = await execFileAsync(command, args, {
+    encoding: "utf8",
+    maxBuffer: 2 * 1024 * 1024,
+    timeout: 5_000,
+  });
+  return { stdout: result.stdout, stderr: result.stderr };
+}
+
+function errorCode(error: unknown): string | undefined {
+  return error instanceof Error && "code" in error
+    ? String((error as NodeJS.ErrnoException).code)
+    : undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function nearestExistingPath(path: string): Promise<string> {
+  let candidate = resolve(path);
+  for (;;) {
+    try {
+      await lstat(candidate);
+      return candidate;
+    } catch (error) {
+      if (errorCode(error) !== "ENOENT") {
+        throw error;
+      }
+      const parent = dirname(candidate);
+      if (parent === candidate) {
+        throw error;
+      }
+      candidate = parent;
+    }
+  }
+}
+
+function reportStatus(checks: DoctorCheck[]): DoctorReport["status"] {
+  if (checks.some((check) => check.status === "error")) {
+    return "error";
+  }
+  return checks.some((check) => check.status === "warning") ? "warning" : "ok";
+}
+
+function renderDoctor(report: DoctorReport): string {
+  const lines = [`AgentRinse doctor: ${report.status}`, ""];
+  for (const check of report.checks) {
+    lines.push(`${check.status.padEnd(7)} ${check.id.padEnd(24)} ${check.summary}`);
+    if (check.detail !== undefined) {
+      lines.push(`        ${check.detail}`);
+    }
+    if (check.remediation !== undefined) {
+      lines.push(`        remediation: ${check.remediation}`);
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function platformCheck(platform: NodeJS.Platform): DoctorCheck {
+  if (platform === "darwin") {
+    return {
+      id: "platform",
+      status: "pass",
+      summary: "macOS supports audit and safe artifact cleanup",
+    };
+  }
+  if (platform === "linux") {
+    return {
+      id: "platform",
+      status: "pass",
+      summary: "Linux supports audit and safe artifact cleanup",
+    };
+  }
+  if (platform === "win32") {
+    return {
+      id: "platform",
+      status: "warning",
+      summary: "native Windows is audit-only",
+      remediation: "Use WSL for supported safe artifact cleanup.",
+    };
+  }
+  return {
+    id: "platform",
+    status: "error",
+    summary: `platform ${platform} is unsupported`,
+  };
+}
+
+async function configChecks(
+  options: DoctorCommandOptions,
+  environment: NodeJS.ProcessEnv,
+): Promise<{ checks: DoctorCheck[]; config: AgentRinseConfig }> {
+  try {
+    const loaded = await loadConfigForHome(options.home, options.config, environment);
+    return {
+      config: loaded.config,
+      checks: [
+        loaded.exists
+          ? {
+              id: "config",
+              status: "pass",
+              summary: "configuration is valid",
+              detail: loaded.path,
+            }
+          : {
+              id: "config",
+              status: "warning",
+              summary: "default configuration is in use",
+              detail: `No configuration file exists at ${loaded.path}.`,
+              remediation: "Run agentrinse config init before configuring cleanup roots.",
+            },
+      ],
+    };
+  } catch (error) {
+    return {
+      config: structuredClone(DEFAULT_CONFIG),
+      checks: [
+        {
+          id: "config",
+          status: "error",
+          summary: "configuration could not be loaded",
+          detail: errorMessage(error),
+          remediation: "Fix the JSON or run agentrinse config init at a new path.",
+        },
+      ],
+    };
+  }
+}
+
+async function stateCheck(root: string): Promise<DoctorCheck> {
+  try {
+    const existing = await nearestExistingPath(root);
+    const stats = await lstat(existing);
+    if (!stats.isDirectory() || stats.isSymbolicLink()) {
+      return {
+        id: "state",
+        status: "error",
+        summary: "state path resolves through a non-directory or symlink",
+        detail: existing,
+      };
+    }
+    await access(existing, constants.R_OK | constants.W_OK);
+    return {
+      id: "state",
+      status: "pass",
+      summary:
+        existing === resolve(root)
+          ? "state directory is readable and writable"
+          : "state directory can be created",
+      detail: existing === resolve(root) ? root : `Nearest writable parent: ${existing}`,
+    };
+  } catch (error) {
+    return {
+      id: "state",
+      status: "error",
+      summary: "state directory is not usable",
+      detail: errorMessage(error),
+      remediation: "Choose a readable, writable local state directory.",
+    };
+  }
+}
+
+async function processOwnershipCheck(
+  platform: NodeJS.Platform,
+  runCommand: (command: string, args: string[]) => Promise<CommandResult>,
+): Promise<DoctorCheck> {
+  if (platform === "win32") {
+    return {
+      id: "process-ownership",
+      status: "warning",
+      summary: "native Windows process ownership proof is unavailable",
+    };
+  }
+  if (platform === "linux") {
+    try {
+      await readFile("/proc/self/stat", "utf8");
+    } catch (error) {
+      return {
+        id: "process-ownership",
+        status: "error",
+        summary: "Linux procfs process ownership proof is unavailable",
+        detail: errorMessage(error),
+      };
+    }
+  }
+  try {
+    await runCommand("lsof", ["-v"]);
+    return {
+      id: "process-ownership",
+      status: "pass",
+      summary:
+        platform === "linux"
+          ? "procfs ownership proof and lsof fallback are available"
+          : "lsof process ownership proof is available",
+    };
+  } catch (error) {
+    return {
+      id: "process-ownership",
+      status: "error",
+      summary:
+        platform === "linux"
+          ? "lsof fallback is unavailable"
+          : "lsof process ownership proof is unavailable",
+      detail: errorMessage(error),
+      remediation: "Install lsof before applying cleanup plans.",
+    };
+  }
+}
+
+async function gitChecks(
+  config: AgentRinseConfig,
+  runCommand: (command: string, args: string[]) => Promise<CommandResult>,
+): Promise<DoctorCheck[]> {
+  const checks: DoctorCheck[] = [];
+  try {
+    const result = await runCommand("git", ["--version"]);
+    const version = result.stdout.trim();
+    checks.push({
+      id: "git",
+      status: "pass",
+      summary: version === "" ? "Git is available" : version,
+    });
+  } catch (error) {
+    return [
+      {
+        id: "git",
+        status: "error",
+        summary: "Git is unavailable",
+        detail: errorMessage(error),
+        remediation: "Install Git before enabling worktree inventory.",
+      },
+    ];
+  }
+
+  const git = config.adapters.git;
+  if (git?.enabled !== true) {
+    checks.push({
+      id: "git:porcelain",
+      status: "pass",
+      summary: "Git worktree adapter is disabled",
+    });
+    return checks;
+  }
+  if (git.root === undefined) {
+    checks.push({
+      id: "git:porcelain",
+      status: "warning",
+      summary: "Git worktree adapter has no explicit repository root",
+      remediation: "Set adapters.git.root or disable the Git adapter.",
+    });
+    return checks;
+  }
+
+  try {
+    await runCommand("git", ["-C", resolve(git.root), "worktree", "list", "--porcelain", "-z"]);
+    checks.push({
+      id: "git:porcelain",
+      status: "pass",
+      summary: "Git worktree porcelain is available",
+      detail: resolve(git.root),
+    });
+  } catch (error) {
+    checks.push({
+      id: "git:porcelain",
+      status: "error",
+      summary: "Git worktree porcelain failed",
+      detail: errorMessage(error),
+      remediation: "Fix the configured Git root before enabling worktree inventory.",
+    });
+  }
+  return checks;
+}
+
+async function dockerCheck(
+  enabled: boolean,
+  runCommand: (command: string, args: string[]) => Promise<CommandResult>,
+): Promise<DoctorCheck> {
+  try {
+    await runCommand("docker", ["--version"]);
+  } catch (error) {
+    return {
+      id: "docker",
+      status: enabled ? "warning" : "pass",
+      summary: enabled ? "Docker CLI is unavailable" : "Docker is not installed (optional)",
+      ...(enabled
+        ? {
+            detail: errorMessage(error),
+            remediation: "Install Docker or disable the Docker adapter.",
+          }
+        : {}),
+    };
+  }
+
+  try {
+    const [context, version] = await Promise.all([
+      runCommand("docker", ["context", "show"]),
+      runCommand("docker", ["version", "--format", "{{.Server.Version}}"]),
+    ]);
+    return {
+      id: "docker",
+      status: "pass",
+      summary: `Docker daemon ${version.stdout.trim() || "available"}`,
+      detail: `Context: ${context.stdout.trim() || "unknown"}`,
+    };
+  } catch (error) {
+    return {
+      id: "docker",
+      status: "warning",
+      summary: "Docker CLI is installed but its daemon or context is unavailable",
+      detail: errorMessage(error),
+      remediation: enabled
+        ? "Start Docker or disable the Docker adapter."
+        : "No action is required while the Docker adapter is disabled.",
+    };
+  }
+}
+
+async function moleCheck(
+  platform: NodeJS.Platform,
+  runCommand: (command: string, args: string[]) => Promise<CommandResult>,
+): Promise<DoctorCheck> {
+  if (platform !== "darwin") {
+    return {
+      id: "mole",
+      status: "pass",
+      summary: "Mole handoff is not applicable on this platform",
+    };
+  }
+  try {
+    const result = await runCommand("mo", ["--version"]);
+    return {
+      id: "mole",
+      status: "pass",
+      summary: result.stdout.trim() || result.stderr.trim() || "Mole is available",
+      detail: "Mole is optional and remains an external handoff.",
+    };
+  } catch {
+    return {
+      id: "mole",
+      status: "pass",
+      summary: "Mole is not installed (optional)",
+    };
+  }
+}
+
+async function providerChecks(
+  home: string,
+  config: AgentRinseConfig,
+  platform: NodeJS.Platform,
+): Promise<DoctorCheck[]> {
+  const checks: DoctorCheck[] = [];
+  for (const spec of Object.values(PROVIDER_SPECS).sort((left, right) =>
+    left.id.localeCompare(right.id),
+  )) {
+    const configured = config.adapters[spec.id];
+    if (configured?.enabled === false) {
+      checks.push({
+        id: `provider:${spec.id}`,
+        status: "pass",
+        summary: `${spec.displayName} adapter is disabled`,
+      });
+      continue;
+    }
+    const root = resolve(configured?.root ?? spec.defaultRoot(home, platform));
+    try {
+      const stats = await lstat(root);
+      if (!stats.isDirectory() || stats.isSymbolicLink()) {
+        checks.push({
+          id: `provider:${spec.id}`,
+          status: "warning",
+          summary: `${spec.displayName} root is not a real directory`,
+          detail: root,
+        });
+        continue;
+      }
+      await access(root, constants.R_OK);
+      checks.push({
+        id: `provider:${spec.id}`,
+        status: "pass",
+        summary: `${spec.displayName} root is readable`,
+        detail: root,
+      });
+    } catch (error) {
+      const missing = errorCode(error) === "ENOENT";
+      checks.push({
+        id: `provider:${spec.id}`,
+        status: configured?.root !== undefined && missing ? "warning" : missing ? "pass" : "error",
+        summary: missing
+          ? `${spec.displayName} root is absent`
+          : `${spec.displayName} root is unreadable`,
+        detail: root,
+        ...(configured?.root !== undefined && missing
+          ? { remediation: "Fix or remove the explicit provider root." }
+          : {}),
+      });
+    }
+  }
+  return checks;
+}
+
+async function artifactChecks(config: AgentRinseConfig): Promise<DoctorCheck[]> {
+  const checks: DoctorCheck[] = [];
+  for (const [index, project] of config.artifacts.projects.entries()) {
+    const root = resolve(project.root);
+    try {
+      const stats = await lstat(root);
+      if (!stats.isDirectory() || stats.isSymbolicLink()) {
+        throw new Error("configured artifact root must be a real directory");
+      }
+      await access(root, constants.R_OK | constants.W_OK);
+      checks.push({
+        id: `artifact-root:${index}`,
+        status: "pass",
+        summary: "artifact root supports same-parent isolation",
+        detail: root,
+      });
+    } catch (error) {
+      checks.push({
+        id: `artifact-root:${index}`,
+        status: "error",
+        summary: "artifact root is not safe for cleanup",
+        detail: `${root}: ${errorMessage(error)}`,
+      });
+    }
+  }
+  if (checks.length === 0) {
+    checks.push({
+      id: "artifact-roots",
+      status: "pass",
+      summary: "no artifact cleanup roots are configured",
+    });
+  }
+  return checks;
+}
+
+async function schemaDirectoryCheck<T>(
+  id: string,
+  directory: string,
+  schema: ZodType<T>,
+): Promise<DoctorCheck> {
+  let names: string[];
+  try {
+    names = (await readdir(directory)).filter((name) => name.endsWith(".json")).sort();
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") {
+      return { id, status: "pass", summary: "no persisted records found" };
+    }
+    return {
+      id,
+      status: "error",
+      summary: "persisted records could not be listed",
+      detail: errorMessage(error),
+    };
+  }
+
+  const failures: string[] = [];
+  for (const name of names) {
+    try {
+      schema.parse(await readJsonFile(join(directory, name)));
+    } catch {
+      failures.push(name);
+    }
+  }
+  return failures.length === 0
+    ? { id, status: "pass", summary: `${names.length} persisted record(s) are compatible` }
+    : {
+        id,
+        status: "error",
+        summary: `${failures.length} persisted record(s) are incompatible`,
+        detail: failures.join(", "),
+        remediation: "Inspect the records before moving or removing any AgentRinse state.",
+      };
+}
+
+async function lockCheck(
+  locksDirectory: string,
+  dependencies?: LockInspectionDependencies,
+): Promise<DoctorCheck> {
+  const status = await inspectApplyLock(locksDirectory, dependencies);
+  if (status.status === "absent") {
+    return { id: "apply-lock", status: "pass", summary: "no apply lock is present" };
+  }
+  if (status.status === "active") {
+    return {
+      id: "apply-lock",
+      status: "warning",
+      summary: `an apply run is active (PID ${status.owner.pid})`,
+      detail: `run ${status.owner.runId}`,
+    };
+  }
+  if (status.status === "stale") {
+    return {
+      id: "apply-lock",
+      status: "warning",
+      summary: "a proven stale apply lock is present",
+      detail: status.reason,
+      remediation: "Review agentrinse lock status, then run agentrinse lock recover --yes.",
+    };
+  }
+  return {
+    id: "apply-lock",
+    status: "error",
+    summary: `apply lock status is ${status.status}`,
+    detail: status.reason,
+    remediation: "Do not remove the lock until its owner can be proven stale.",
+  };
+}
+
+export async function executeDoctorCommand(
+  options: DoctorCommandOptions,
+): Promise<DoctorCommandResult> {
+  const dependencies = options.dependencies ?? {};
+  const platform = dependencies.platform ?? process.platform;
+  const environment = dependencies.environment ?? process.env;
+  const runCommand = dependencies.runCommand ?? defaultRunCommand;
+  const root = resolveStateRoot(options.home, options.stateDir, environment);
+  const layout = stateLayout(root);
+  const loaded = await configChecks(options, environment);
+  const checks: DoctorCheck[] = [
+    platformCheck(platform),
+    ...loaded.checks,
+    await stateCheck(root),
+    await processOwnershipCheck(platform, runCommand),
+    ...(await gitChecks(loaded.config, runCommand)),
+    await dockerCheck(loaded.config.adapters.docker?.enabled === true, runCommand),
+    await moleCheck(platform, runCommand),
+    ...(await providerChecks(options.home, loaded.config, platform)),
+    ...(await artifactChecks(loaded.config)),
+    await lockCheck(layout.locks, dependencies.lock),
+    await schemaDirectoryCheck("schema:audits", layout.audits, auditReportSchema),
+    await schemaDirectoryCheck("schema:plans", layout.plans, cleanupPlanSchema),
+    await schemaDirectoryCheck("schema:runs", layout.runs, cleanupRunSchema),
+  ];
+  const report = doctorReportSchema.parse({
+    schemaVersion: 1,
+    generatedAt: (dependencies.now ?? (() => new Date()))().toISOString(),
+    status: reportStatus(checks),
+    checks,
+  });
+  return {
+    report,
+    output: options.json ? `${JSON.stringify(report, null, 2)}\n` : renderDoctor(report),
+  };
+}

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -1,0 +1,51 @@
+import { cleanupRunSchema, type CleanupRun } from "../contracts/run.js";
+import { parseDurationMs } from "../core/duration.js";
+import { resolveStateRoot, stateLayout } from "../state/layout.js";
+import { listJsonRecords } from "../state/records.js";
+
+export type HistoryCommandOptions = {
+  home: string;
+  stateDir?: string | undefined;
+  since?: string | undefined;
+  json: boolean;
+  now?: Date | undefined;
+};
+
+export type HistoryCommandResult = {
+  runs: CleanupRun[];
+  output: string;
+};
+
+export function renderHistory(runs: CleanupRun[]): string {
+  if (runs.length === 0) {
+    return "No AgentRinse runs found.\n";
+  }
+
+  const lines = ["AgentRinse history", ""];
+  for (const run of runs) {
+    const applied = run.actions.filter((action) => action.status === "applied").length;
+    const failed = run.actions.filter((action) =>
+      ["failed", "rolled-back", "partially-applied"].includes(action.status),
+    ).length;
+    lines.push(
+      `${run.startedAt}  ${run.status.padEnd(9)}  ${run.runId}  applied=${applied} failed=${failed}`,
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+export async function executeHistoryCommand(
+  options: HistoryCommandOptions,
+): Promise<HistoryCommandResult> {
+  const layout = stateLayout(resolveStateRoot(options.home, options.stateDir));
+  let runs = await listJsonRecords(layout.runs, cleanupRunSchema);
+  if (options.since !== undefined) {
+    const cutoff = (options.now ?? new Date()).getTime() - parseDurationMs(options.since);
+    runs = runs.filter((run) => Date.parse(run.startedAt) >= cutoff);
+  }
+  runs.sort((left, right) => right.startedAt.localeCompare(left.startedAt));
+  return {
+    runs,
+    output: options.json ? `${JSON.stringify(runs, null, 2)}\n` : renderHistory(runs),
+  };
+}

--- a/src/commands/lock.ts
+++ b/src/commands/lock.ts
@@ -1,0 +1,76 @@
+import { resolveStateRoot, stateLayout } from "../state/layout.js";
+import {
+  inspectApplyLock,
+  recoverStaleApplyLock,
+  type ApplyLockOwner,
+  type ApplyLockStatus,
+  type LockInspectionDependencies,
+} from "../state/lock.js";
+
+export type LockCommandOptions = {
+  home: string;
+  stateDir?: string | undefined;
+  json: boolean;
+  dependencies?: LockInspectionDependencies | undefined;
+};
+
+export type LockRecoverCommandOptions = LockCommandOptions & {
+  yes: boolean;
+};
+
+export type LockStatusCommandResult = {
+  status: ApplyLockStatus;
+  output: string;
+};
+
+export type LockRecoverCommandResult = {
+  owner: ApplyLockOwner;
+  output: string;
+};
+
+function renderLockStatus(status: ApplyLockStatus): string {
+  if (status.status === "absent") {
+    return `apply lock: absent\npath: ${status.path}\n`;
+  }
+  if (status.status === "malformed") {
+    return `apply lock: malformed\npath: ${status.path}\nreason: ${status.reason}\n`;
+  }
+  return [
+    `apply lock: ${status.status}`,
+    `path: ${status.path}`,
+    `owner: ${status.owner.hostname} pid=${status.owner.pid}`,
+    `command: ${status.owner.command}`,
+    `plan: ${status.owner.planId}`,
+    `run: ${status.owner.runId}`,
+    `created: ${status.owner.createdAt}`,
+    ...("reason" in status ? [`reason: ${status.reason}`] : []),
+    "",
+  ].join("\n");
+}
+
+export async function executeLockStatusCommand(
+  options: LockCommandOptions,
+): Promise<LockStatusCommandResult> {
+  const layout = stateLayout(resolveStateRoot(options.home, options.stateDir));
+  const status = await inspectApplyLock(layout.locks, options.dependencies);
+  return {
+    status,
+    output: options.json ? `${JSON.stringify(status, null, 2)}\n` : renderLockStatus(status),
+  };
+}
+
+export async function executeLockRecoverCommand(
+  options: LockRecoverCommandOptions,
+): Promise<LockRecoverCommandResult> {
+  if (!options.yes) {
+    throw new Error('lock recovery requires --yes after reviewing "agentrinse lock status"');
+  }
+  const layout = stateLayout(resolveStateRoot(options.home, options.stateDir));
+  const owner = await recoverStaleApplyLock(layout.locks, options.dependencies);
+  return {
+    owner,
+    output: options.json
+      ? `${JSON.stringify({ status: "recovered", owner }, null, 2)}\n`
+      : `recovered stale apply lock for run ${owner.runId}\n`,
+  };
+}

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path";
 
-import { loadConfig } from "../config/load.js";
+import { loadConfigForHome } from "../config/load.js";
 import { cleanupPlanSchema, type CleanupPlan } from "../contracts/plan.js";
 import { auditReportSchema } from "../contracts/report.js";
 import { createCleanupPlan } from "../core/plan.js";
@@ -19,7 +19,7 @@ export type PlanCommandResult = {
 
 export async function executePlanCommand(options: PlanCommandOptions): Promise<PlanCommandResult> {
   const audit = auditReportSchema.parse(await readJsonFile(resolve(options.audit)));
-  const config = await loadConfig(options.config);
+  const { config } = await loadConfigForHome(audit.home, options.config);
   const plan = cleanupPlanSchema.parse(createCleanupPlan(audit, config));
 
   if (options.output !== undefined) {

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -24,11 +24,11 @@ export async function executePlanCommand(options: PlanCommandOptions): Promise<P
   const audit = auditReportSchema.parse(await readJsonFile(resolve(options.audit)));
   const { config } = await loadConfigForHome(audit.home, options.config);
   const plan = cleanupPlanSchema.parse(createCleanupPlan(audit, config));
-  const statePath = resolve(
-    stateLayout(resolveStateRoot(audit.home, options.stateDir)).plans,
-    `${plan.planId}.json`,
-  );
-  await writeJsonAtomic(statePath, plan);
+  const layout = stateLayout(resolveStateRoot(audit.home, options.stateDir));
+  const statePath = resolve(layout.plans, `${plan.planId}.json`);
+  await writeJsonAtomic(statePath, plan, {
+    privateDirectories: [layout.root, layout.plans],
+  });
 
   if (options.output !== undefined) {
     await writeJsonAtomic(resolve(options.output), plan);

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -5,15 +5,18 @@ import { cleanupPlanSchema, type CleanupPlan } from "../contracts/plan.js";
 import { auditReportSchema } from "../contracts/report.js";
 import { createCleanupPlan } from "../core/plan.js";
 import { readJsonFile, writeJsonAtomic } from "../state/json-file.js";
+import { resolveStateRoot, stateLayout } from "../state/layout.js";
 
 export type PlanCommandOptions = {
   audit: string;
   config?: string;
   output?: string;
+  stateDir?: string;
 };
 
 export type PlanCommandResult = {
   plan: CleanupPlan;
+  statePath: string;
   output: string;
 };
 
@@ -21,6 +24,11 @@ export async function executePlanCommand(options: PlanCommandOptions): Promise<P
   const audit = auditReportSchema.parse(await readJsonFile(resolve(options.audit)));
   const { config } = await loadConfigForHome(audit.home, options.config);
   const plan = cleanupPlanSchema.parse(createCleanupPlan(audit, config));
+  const statePath = resolve(
+    stateLayout(resolveStateRoot(audit.home, options.stateDir)).plans,
+    `${plan.planId}.json`,
+  );
+  await writeJsonAtomic(statePath, plan);
 
   if (options.output !== undefined) {
     await writeJsonAtomic(resolve(options.output), plan);
@@ -28,6 +36,7 @@ export async function executePlanCommand(options: PlanCommandOptions): Promise<P
 
   return {
     plan,
+    statePath,
     output: `${JSON.stringify(plan, null, 2)}\n`,
   };
 }

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -27,7 +27,7 @@ export function renderRunDetails(run: CleanupRun): string {
     }
   }
 
-  if (run.status === "partial" || run.status === "failed") {
+  if (run.status === "partial" || run.status === "failed" || run.status === "interrupted") {
     lines.push(
       "",
       "Recovery: inspect every isolation path and diagnostic above.",

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -1,0 +1,83 @@
+import { cleanupPlanSchema, type CleanupPlan } from "../contracts/plan.js";
+import { auditReportSchema, type AuditReport } from "../contracts/report.js";
+import { cleanupRunSchema, type CleanupRun } from "../contracts/run.js";
+import { resolveStateRoot, stateLayout } from "../state/layout.js";
+import { listJsonRecords, readJsonRecord } from "../state/records.js";
+
+export type ShowCommandOptions = {
+  home: string;
+  stateDir?: string | undefined;
+  json: boolean;
+};
+
+export type ShowCommandResult<T> = {
+  value: T;
+  output: string;
+};
+
+export function renderRunDetails(run: CleanupRun): string {
+  const lines = [`run ${run.runId}: ${run.status}`, `plan ${run.planId}`, ""];
+  for (const action of run.actions) {
+    lines.push(`${action.status.padEnd(18)} ${action.actionId} ${action.type}`);
+    if (action.diagnostic !== undefined) {
+      lines.push(`  ${action.diagnostic.code}: ${action.diagnostic.message}`);
+    }
+    if (action.isolationPath !== undefined) {
+      lines.push(`  isolation: ${action.isolationPath}`);
+    }
+  }
+
+  if (run.status === "partial" || run.status === "failed") {
+    lines.push(
+      "",
+      "Recovery: inspect every isolation path and diagnostic above.",
+      "Do not retry the old plan; resolve partial state, then create a fresh audit and plan.",
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+export async function executeShowRunCommand(
+  idOrPath: string,
+  options: ShowCommandOptions,
+): Promise<ShowCommandResult<CleanupRun>> {
+  const layout = stateLayout(resolveStateRoot(options.home, options.stateDir));
+  const run = await readJsonRecord(layout.runs, idOrPath, cleanupRunSchema);
+  return {
+    value: run,
+    output: options.json ? `${JSON.stringify(run, null, 2)}\n` : renderRunDetails(run),
+  };
+}
+
+export async function executeShowPlanCommand(
+  idOrPath: string,
+  options: ShowCommandOptions,
+): Promise<ShowCommandResult<CleanupPlan>> {
+  const layout = stateLayout(resolveStateRoot(options.home, options.stateDir));
+  const plan = await readJsonRecord(layout.plans, idOrPath, cleanupPlanSchema);
+  return {
+    value: plan,
+    output: `${JSON.stringify(plan, null, 2)}\n`,
+  };
+}
+
+export async function executeShowResourceCommand(
+  resourceId: string,
+  options: ShowCommandOptions,
+): Promise<ShowCommandResult<{ audit: AuditReport; finding: AuditReport["findings"][number] }>> {
+  const layout = stateLayout(resolveStateRoot(options.home, options.stateDir));
+  const audits = await listJsonRecords(layout.audits, auditReportSchema);
+  audits.sort((left, right) => right.completedAt.localeCompare(left.completedAt));
+
+  for (const audit of audits) {
+    const finding = audit.findings.find((candidate) => candidate.resource.id === resourceId);
+    if (finding !== undefined) {
+      const value = { audit, finding };
+      return {
+        value,
+        output: `${JSON.stringify(value, null, 2)}\n`,
+      };
+    }
+  }
+  throw new Error(`resource ${resourceId} was not found in persisted audits`);
+}

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -1,6 +1,8 @@
 import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
 
 import { DEFAULT_CONFIG } from "./defaults.js";
+import { resolveConfigPath, type ConfigEnvironment } from "./path.js";
 import { agentRinseConfigSchema, type AgentRinseConfig } from "./schema.js";
 
 export async function loadConfig(path?: string): Promise<AgentRinseConfig> {
@@ -31,4 +33,34 @@ export async function loadConfig(path?: string): Promise<AgentRinseConfig> {
       ...parsed.plan,
     },
   };
+}
+
+function isMissing(error: unknown): boolean {
+  return (
+    error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}
+
+export async function loadConfigForHome(
+  home: string,
+  explicitPath?: string,
+  environment: ConfigEnvironment = process.env,
+): Promise<{ config: AgentRinseConfig; path: string; exists: boolean }> {
+  const path = resolveConfigPath(resolve(home), explicitPath, environment);
+  try {
+    return {
+      config: await loadConfig(path),
+      path,
+      exists: true,
+    };
+  } catch (error) {
+    if (explicitPath === undefined && isMissing(error)) {
+      return {
+        config: await loadConfig(),
+        path,
+        exists: false,
+      };
+    }
+    throw error;
+  }
 }

--- a/src/config/path.ts
+++ b/src/config/path.ts
@@ -1,4 +1,4 @@
-import { resolve } from "node:path";
+import { isAbsolute, resolve } from "node:path";
 
 export type ConfigEnvironment = {
   XDG_CONFIG_HOME?: string;
@@ -12,7 +12,11 @@ export function resolveConfigPath(
   if (explicit !== undefined) {
     return resolve(explicit);
   }
-  if (environment.XDG_CONFIG_HOME !== undefined) {
+  if (
+    environment.XDG_CONFIG_HOME !== undefined &&
+    environment.XDG_CONFIG_HOME !== "" &&
+    isAbsolute(environment.XDG_CONFIG_HOME)
+  ) {
     return resolve(environment.XDG_CONFIG_HOME, "agentrinse", "config.json");
   }
   return resolve(home, ".config", "agentrinse", "config.json");

--- a/src/config/path.ts
+++ b/src/config/path.ts
@@ -1,0 +1,19 @@
+import { resolve } from "node:path";
+
+export type ConfigEnvironment = {
+  XDG_CONFIG_HOME?: string;
+};
+
+export function resolveConfigPath(
+  home: string,
+  explicit?: string,
+  environment: ConfigEnvironment = process.env,
+): string {
+  if (explicit !== undefined) {
+    return resolve(explicit);
+  }
+  if (environment.XDG_CONFIG_HOME !== undefined) {
+    return resolve(environment.XDG_CONFIG_HOME, "agentrinse", "config.json");
+  }
+  return resolve(home, ".config", "agentrinse", "config.json");
+}

--- a/src/contracts/doctor.ts
+++ b/src/contracts/doctor.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const doctorCheckSchema = z.object({
+  id: z.string().min(1),
+  status: z.enum(["pass", "warning", "error"]),
+  summary: z.string().min(1),
+  detail: z.string().min(1).optional(),
+  remediation: z.string().min(1).optional(),
+});
+
+export const doctorReportSchema = z.object({
+  schemaVersion: z.literal(1),
+  generatedAt: z.string().datetime({ offset: true }),
+  status: z.enum(["ok", "warning", "error"]),
+  checks: z.array(doctorCheckSchema),
+});
+
+export type DoctorCheck = z.infer<typeof doctorCheckSchema>;
+export type DoctorReport = z.infer<typeof doctorReportSchema>;

--- a/src/contracts/output.ts
+++ b/src/contracts/output.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+import { diagnosticSchema, type Diagnostic } from "./diagnostic.js";
+
+export const commandEnvelopeStatusSchema = z.enum(["ok", "degraded", "failed"]);
+
+export const commandEnvelopeSchema = z.object({
+  schemaVersion: z.literal(1),
+  command: z.string().min(1),
+  agentrinseVersion: z.string().min(1),
+  startedAt: z.string().datetime({ offset: true }),
+  completedAt: z.string().datetime({ offset: true }),
+  status: commandEnvelopeStatusSchema,
+  data: z.unknown(),
+  diagnostics: z.array(diagnosticSchema),
+});
+
+export const commandEventSchema = z.object({
+  schemaVersion: z.literal(1),
+  event: z.string().min(1),
+  timestamp: z.string().datetime({ offset: true }),
+  command: z.string().min(1),
+  commandId: z.string().min(1),
+  sequence: z.number().int().positive(),
+  data: z.unknown().optional(),
+});
+
+export type CommandEnvelopeStatus = z.infer<typeof commandEnvelopeStatusSchema>;
+export type CommandEnvelope<T> = Omit<z.infer<typeof commandEnvelopeSchema>, "data"> & {
+  data: T;
+  diagnostics: Diagnostic[];
+};
+export type CommandEvent<T = unknown> = Omit<z.infer<typeof commandEventSchema>, "data"> & {
+  data?: T;
+};

--- a/src/contracts/run.ts
+++ b/src/contracts/run.ts
@@ -24,7 +24,7 @@ export const actionExecutionSchema = z.object({
   diagnostic: diagnosticSchema.optional(),
 });
 
-export const runStatusSchema = z.enum(["running", "completed", "partial", "failed"]);
+export const runStatusSchema = z.enum(["running", "completed", "partial", "failed", "interrupted"]);
 
 export const cleanupRunSchema = z.object({
   schemaVersion: z.literal(1),

--- a/src/core/apply.ts
+++ b/src/core/apply.ts
@@ -18,6 +18,7 @@ import {
   type ArtifactRevalidationResult,
 } from "./artifact-revalidation.js";
 import { sha256 } from "./digest.js";
+import { CommandInterruptedError } from "./interruption.js";
 import { verifyCleanupPlan } from "./plan-verification.js";
 import { isPathInside, resolvePhysicalPath } from "./safety.js";
 
@@ -46,10 +47,21 @@ export type ApplyCleanupPlanOptions = {
   input: unknown;
   config: AgentRinseConfig;
   stateRoot: string;
+  signal?: AbortSignal;
   dependencies?: ApplyDependencies;
 };
 
+function throwIfInterrupted(signal?: AbortSignal): void {
+  if (signal?.aborted !== true) {
+    return;
+  }
+  throw signal.reason instanceof CommandInterruptedError
+    ? signal.reason
+    : new CommandInterruptedError("apply interrupted");
+}
+
 export async function applyCleanupPlan(options: ApplyCleanupPlanOptions): Promise<ApplyResult> {
+  throwIfInterrupted(options.signal);
   const clock = options.dependencies?.clock ?? (() => new Date());
   const config = agentRinseConfigSchema.parse(options.config);
   const plan = verifyCleanupPlan(options.input, config, clock());
@@ -73,20 +85,24 @@ export async function applyCleanupPlan(options: ApplyCleanupPlanOptions): Promis
     command: "agentrinse apply",
   });
 
+  let journal: Awaited<ReturnType<typeof createRunJournal>> | undefined;
   try {
-    const journal = await (options.dependencies?.createJournal ?? createRunJournal)(
+    journal = await (options.dependencies?.createJournal ?? createRunJournal)(
       layout.runs,
       plan,
       clock(),
       runId,
     );
+    throwIfInterrupted(options.signal);
 
     for (const action of plan.actions) {
+      throwIfInterrupted(options.signal);
       const startedAt = clock().toISOString();
       await journal.updateAction(action.actionId, {
         status: "revalidating",
         startedAt,
       });
+      throwIfInterrupted(options.signal);
 
       const revalidation =
         options.dependencies?.revalidate === undefined
@@ -100,6 +116,7 @@ export async function applyCleanupPlan(options: ApplyCleanupPlanOptions): Promis
         });
         continue;
       }
+      throwIfInterrupted(options.signal);
 
       const authorizationCheckedAt = clock();
       if (authorizationCheckedAt.getTime() >= Date.parse(plan.expiresAt)) {
@@ -123,6 +140,7 @@ export async function applyCleanupPlan(options: ApplyCleanupPlanOptions): Promis
         status: "applying",
         isolationPath,
       });
+      throwIfInterrupted(options.signal);
 
       let result: ArtifactExecutionResult;
       try {
@@ -172,10 +190,25 @@ export async function applyCleanupPlan(options: ApplyCleanupPlanOptions): Promis
         reclaimedBytes: result.reclaimedBytes,
         isolationPath: result.isolationPath,
       });
+      throwIfInterrupted(options.signal);
     }
 
     const run = await journal.complete(clock());
     return { plan, run, journalPath: journal.path };
+  } catch (error) {
+    if (error instanceof CommandInterruptedError && journal !== undefined) {
+      const run = await journal.interrupt(
+        {
+          severity: "warning",
+          code: "COMMAND_INTERRUPTED",
+          message:
+            "Apply was interrupted at a safe checkpoint. Inspect the journal before creating a fresh audit and plan.",
+        },
+        clock(),
+      );
+      return { plan, run, journalPath: journal.path };
+    }
+    throw error;
   } finally {
     await lock.release();
   }

--- a/src/core/apply.ts
+++ b/src/core/apply.ts
@@ -6,6 +6,7 @@ import type { CleanupPlan } from "../contracts/plan.js";
 import type { CleanupRun } from "../contracts/run.js";
 import { acquireApplyLock } from "../state/lock.js";
 import { stateLayout } from "../state/layout.js";
+import { ensurePrivateDirectory } from "../state/json-file.js";
 import { createRunJournal } from "../state/run-journal.js";
 import {
   ArtifactExecutionError,
@@ -79,6 +80,9 @@ export async function applyCleanupPlan(options: ApplyCleanupPlanOptions): Promis
     }
   }
   const runId = randomUUID();
+  await ensurePrivateDirectory(layout.root);
+  await ensurePrivateDirectory(layout.locks);
+  await ensurePrivateDirectory(layout.runs);
   const lock = await acquireApplyLock(layout.locks, {
     planId: plan.planId,
     runId,

--- a/src/core/apply.ts
+++ b/src/core/apply.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import { agentRinseConfigSchema, type AgentRinseConfig } from "../config/schema.js";
 import type { ArtifactRemoveAction } from "../contracts/action.js";
 import type { CleanupPlan } from "../contracts/plan.js";
@@ -64,15 +66,20 @@ export async function applyCleanupPlan(options: ApplyCleanupPlanOptions): Promis
       );
     }
   }
-  const lock = await acquireApplyLock(layout.locks, plan.planId);
+  const runId = randomUUID();
+  const lock = await acquireApplyLock(layout.locks, {
+    planId: plan.planId,
+    runId,
+    command: "agentrinse apply",
+  });
 
   try {
     const journal = await (options.dependencies?.createJournal ?? createRunJournal)(
       layout.runs,
       plan,
       clock(),
+      runId,
     );
-    const runId = journal.snapshot().runId;
 
     for (const action of plan.actions) {
       const startedAt = clock().toISOString();

--- a/src/core/apply.ts
+++ b/src/core/apply.ts
@@ -114,6 +114,7 @@ export async function applyCleanupPlan(options: ApplyCleanupPlanOptions): Promis
           completedAt: clock().toISOString(),
           diagnostic: revalidation.diagnostic,
         });
+        throwIfInterrupted(options.signal);
         continue;
       }
       throwIfInterrupted(options.signal);
@@ -131,6 +132,7 @@ export async function applyCleanupPlan(options: ApplyCleanupPlanOptions): Promis
             resourceId: action.resourceId,
           },
         });
+        throwIfInterrupted(options.signal);
         continue;
       }
 
@@ -179,6 +181,7 @@ export async function applyCleanupPlan(options: ApplyCleanupPlanOptions): Promis
           },
         });
         if (executionError?.outcome === "skipped-stale") {
+          throwIfInterrupted(options.signal);
           continue;
         }
         break;

--- a/src/core/apply.ts
+++ b/src/core/apply.ts
@@ -197,6 +197,9 @@ export async function applyCleanupPlan(options: ApplyCleanupPlanOptions): Promis
     }
 
     const run = await journal.complete(clock());
+    if (run.status === "completed") {
+      throwIfInterrupted(options.signal);
+    }
     return { plan, run, journalPath: journal.path };
   } catch (error) {
     if (error instanceof CommandInterruptedError && journal !== undefined) {

--- a/src/core/audit.ts
+++ b/src/core/audit.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import type { AgentRinseConfig } from "../config/schema.js";
 import type { AuditAdapter, AuditContext } from "../contracts/adapter.js";
+import type { Diagnostic } from "../contracts/diagnostic.js";
 import type { Finding } from "../contracts/finding.js";
 import { auditReportSchema, type AuditReport } from "../contracts/report.js";
 import type { ResourceSnapshot } from "../contracts/resource.js";
@@ -21,6 +22,11 @@ export type AuditProgressEvent =
       type: "adapter.probed";
       timestamp: string;
       data: AuditReport["probes"][number];
+    }
+  | {
+      type: "diagnostic.reported";
+      timestamp: string;
+      data: Diagnostic;
     }
   | {
       type: "resource.discovered";
@@ -57,9 +63,23 @@ export async function runAudit(options: RunAuditOptions): Promise<AuditReport> {
       timestamp: clock().toISOString(),
       data: probe,
     });
+    for (const diagnostic of probe.diagnostics) {
+      options.onEvent?.({
+        type: "diagnostic.reported",
+        timestamp: clock().toISOString(),
+        data: diagnostic,
+      });
+    }
 
     const collection = await adapter.collect(context, probe);
     diagnostics.push(...collection.diagnostics);
+    for (const diagnostic of collection.diagnostics) {
+      options.onEvent?.({
+        type: "diagnostic.reported",
+        timestamp: clock().toISOString(),
+        data: diagnostic,
+      });
+    }
     for (const resource of collection.resources) {
       options.onEvent?.({
         type: "resource.discovered",

--- a/src/core/audit.ts
+++ b/src/core/audit.ts
@@ -2,7 +2,9 @@ import { randomUUID } from "node:crypto";
 
 import type { AgentRinseConfig } from "../config/schema.js";
 import type { AuditAdapter, AuditContext } from "../contracts/adapter.js";
+import type { Finding } from "../contracts/finding.js";
 import { auditReportSchema, type AuditReport } from "../contracts/report.js";
+import type { ResourceSnapshot } from "../contracts/resource.js";
 import { assertAuditRoot } from "./safety.js";
 
 export type RunAuditOptions = {
@@ -11,7 +13,25 @@ export type RunAuditOptions = {
   adapters: AuditAdapter[];
   now?: () => Date;
   signal?: AbortSignal;
+  onEvent?: (event: AuditProgressEvent) => void;
 };
+
+export type AuditProgressEvent =
+  | {
+      type: "adapter.probed";
+      timestamp: string;
+      data: AuditReport["probes"][number];
+    }
+  | {
+      type: "resource.discovered";
+      timestamp: string;
+      data: ResourceSnapshot;
+    }
+  | {
+      type: "finding.completed";
+      timestamp: string;
+      data: Finding;
+    };
 
 export async function runAudit(options: RunAuditOptions): Promise<AuditReport> {
   const clock = options.now ?? (() => new Date());
@@ -32,11 +52,27 @@ export async function runAudit(options: RunAuditOptions): Promise<AuditReport> {
     const probe = await adapter.probe(context);
     probes.push(probe);
     diagnostics.push(...probe.diagnostics);
+    options.onEvent?.({
+      type: "adapter.probed",
+      timestamp: clock().toISOString(),
+      data: probe,
+    });
 
     const collection = await adapter.collect(context, probe);
     diagnostics.push(...collection.diagnostics);
     for (const resource of collection.resources) {
-      findings.push(await adapter.classify(context, resource));
+      options.onEvent?.({
+        type: "resource.discovered",
+        timestamp: clock().toISOString(),
+        data: resource,
+      });
+      const finding = await adapter.classify(context, resource);
+      findings.push(finding);
+      options.onEvent?.({
+        type: "finding.completed",
+        timestamp: clock().toISOString(),
+        data: finding,
+      });
     }
   }
 

--- a/src/core/duration.ts
+++ b/src/core/duration.ts
@@ -1,0 +1,23 @@
+const DURATION_PATTERN = /^([1-9]\d*)(ms|s|m|h|d)$/;
+
+const UNIT_MS: Record<string, number> = {
+  ms: 1,
+  s: 1000,
+  m: 60_000,
+  h: 60 * 60_000,
+  d: 24 * 60 * 60_000,
+};
+
+export function parseDurationMs(input: string): number {
+  const match = DURATION_PATTERN.exec(input.trim());
+  if (match === null) {
+    throw new Error(`invalid duration ${JSON.stringify(input)}; use a positive value like 30d`);
+  }
+
+  const amount = Number.parseInt(match[1]!, 10);
+  const result = amount * UNIT_MS[match[2]!]!;
+  if (!Number.isSafeInteger(result)) {
+    throw new Error(`duration ${JSON.stringify(input)} is too large`);
+  }
+  return result;
+}

--- a/src/core/interruption.ts
+++ b/src/core/interruption.ts
@@ -1,0 +1,4 @@
+export class CommandInterruptedError extends Error {
+  override readonly name = "CommandInterruptedError";
+  readonly exitCode = 130;
+}

--- a/src/core/process-identity.ts
+++ b/src/core/process-identity.ts
@@ -1,0 +1,104 @@
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export type ProcessIdentityInspection =
+  | { status: "alive"; identity: string }
+  | { status: "dead" }
+  | { status: "unknown"; reason: string };
+
+function errorCode(error: unknown): string | undefined {
+  return error instanceof Error && "code" in error
+    ? String((error as NodeJS.ErrnoException).code)
+    : undefined;
+}
+
+function probePid(pid: number): "alive" | "dead" | "unknown" {
+  try {
+    process.kill(pid, 0);
+    return "alive";
+  } catch (error) {
+    const code = errorCode(error);
+    return code === "ESRCH" ? "dead" : code === "EPERM" ? "alive" : "unknown";
+  }
+}
+
+function parseLinuxStartTime(stat: string): string | undefined {
+  const commandEnd = stat.lastIndexOf(")");
+  if (commandEnd === -1) {
+    return undefined;
+  }
+  const fieldsAfterCommand = stat
+    .slice(commandEnd + 1)
+    .trim()
+    .split(/\s+/u);
+  return fieldsAfterCommand[19];
+}
+
+async function inspectLinuxProcess(pid: number): Promise<ProcessIdentityInspection> {
+  try {
+    const stat = await readFile(`/proc/${pid}/stat`, "utf8");
+    const startTime = parseLinuxStartTime(stat);
+    return startTime === undefined
+      ? { status: "unknown", reason: `could not parse /proc/${pid}/stat` }
+      : { status: "alive", identity: `linux-proc-start:${startTime}` };
+  } catch (error) {
+    const code = errorCode(error);
+    if (code === "ENOENT" || code === "ESRCH") {
+      return { status: "dead" };
+    }
+    return {
+      status: "unknown",
+      reason: `could not inspect /proc/${pid}/stat${code === undefined ? "" : ` (${code})`}`,
+    };
+  }
+}
+
+async function inspectMacProcess(pid: number): Promise<ProcessIdentityInspection> {
+  try {
+    const { stdout } = await execFileAsync("ps", ["-p", String(pid), "-o", "lstart="], {
+      encoding: "utf8",
+    });
+    const startTime = stdout.trim().replace(/\s+/gu, " ");
+    if (startTime.length === 0) {
+      return probePid(pid) === "dead"
+        ? { status: "dead" }
+        : { status: "unknown", reason: `ps returned no start identity for PID ${pid}` };
+    }
+    return { status: "alive", identity: `darwin-ps-start:${startTime}` };
+  } catch {
+    const pidStatus = probePid(pid);
+    if (pidStatus === "dead") {
+      return { status: "dead" };
+    }
+    return {
+      status: "unknown",
+      reason: `could not inspect process start identity for PID ${pid}`,
+    };
+  }
+}
+
+export async function inspectProcessIdentity(
+  pid: number,
+  platform: NodeJS.Platform = process.platform,
+): Promise<ProcessIdentityInspection> {
+  if (!Number.isSafeInteger(pid) || pid <= 0) {
+    return { status: "unknown", reason: `invalid process ID ${pid}` };
+  }
+  if (platform === "linux") {
+    return inspectLinuxProcess(pid);
+  }
+  if (platform === "darwin") {
+    return inspectMacProcess(pid);
+  }
+
+  const status = probePid(pid);
+  return status === "dead"
+    ? { status: "dead" }
+    : {
+        status: "unknown",
+        reason: `process start identity is unsupported on ${platform}`,
+      };
+}

--- a/src/core/process-identity.ts
+++ b/src/core/process-identity.ts
@@ -4,6 +4,16 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
+type RunProcessCommand = (
+  file: string,
+  args: string[],
+  options: { encoding: "utf8"; env: NodeJS.ProcessEnv },
+) => Promise<{ stdout: string; stderr: string }>;
+
+export type ProcessIdentityDependencies = {
+  runProcessCommand?: RunProcessCommand;
+};
+
 export type ProcessIdentityInspection =
   | { status: "alive"; identity: string }
   | { status: "dead" }
@@ -56,10 +66,21 @@ async function inspectLinuxProcess(pid: number): Promise<ProcessIdentityInspecti
   }
 }
 
-async function inspectMacProcess(pid: number): Promise<ProcessIdentityInspection> {
+async function inspectMacProcess(
+  pid: number,
+  dependencies: ProcessIdentityDependencies,
+): Promise<ProcessIdentityInspection> {
   try {
-    const { stdout } = await execFileAsync("ps", ["-p", String(pid), "-o", "lstart="], {
+    const runProcessCommand =
+      dependencies.runProcessCommand ?? (execFileAsync as RunProcessCommand);
+    const { stdout } = await runProcessCommand("ps", ["-p", String(pid), "-o", "lstart="], {
       encoding: "utf8",
+      env: {
+        ...process.env,
+        LANG: "C",
+        LC_ALL: "C",
+        TZ: "UTC",
+      },
     });
     const startTime = stdout.trim().replace(/\s+/gu, " ");
     if (startTime.length === 0) {
@@ -83,6 +104,7 @@ async function inspectMacProcess(pid: number): Promise<ProcessIdentityInspection
 export async function inspectProcessIdentity(
   pid: number,
   platform: NodeJS.Platform = process.platform,
+  dependencies: ProcessIdentityDependencies = {},
 ): Promise<ProcessIdentityInspection> {
   if (!Number.isSafeInteger(pid) || pid <= 0) {
     return { status: "unknown", reason: `invalid process ID ${pid}` };
@@ -91,7 +113,7 @@ export async function inspectProcessIdentity(
     return inspectLinuxProcess(pid);
   }
   if (platform === "darwin") {
-    return inspectMacProcess(pid);
+    return inspectMacProcess(pid, dependencies);
   }
 
   const status = probePid(pid);

--- a/src/core/process-identity.ts
+++ b/src/core/process-identity.ts
@@ -12,6 +12,8 @@ type RunProcessCommand = (
 
 export type ProcessIdentityDependencies = {
   runProcessCommand?: RunProcessCommand;
+  readProcessStat?: (pid: number) => Promise<string>;
+  probeProcess?: (pid: number) => "alive" | "dead" | "unknown";
 };
 
 export type ProcessIdentityInspection =
@@ -47,9 +49,15 @@ function parseLinuxStartTime(stat: string): string | undefined {
   return fieldsAfterCommand[19];
 }
 
-async function inspectLinuxProcess(pid: number): Promise<ProcessIdentityInspection> {
+async function inspectLinuxProcess(
+  pid: number,
+  dependencies: ProcessIdentityDependencies,
+): Promise<ProcessIdentityInspection> {
   try {
-    const stat = await readFile(`/proc/${pid}/stat`, "utf8");
+    const stat =
+      dependencies.readProcessStat === undefined
+        ? await readFile(`/proc/${pid}/stat`, "utf8")
+        : await dependencies.readProcessStat(pid);
     const startTime = parseLinuxStartTime(stat);
     return startTime === undefined
       ? { status: "unknown", reason: `could not parse /proc/${pid}/stat` }
@@ -57,7 +65,10 @@ async function inspectLinuxProcess(pid: number): Promise<ProcessIdentityInspecti
   } catch (error) {
     const code = errorCode(error);
     if (code === "ENOENT" || code === "ESRCH") {
-      return { status: "dead" };
+      const status = (dependencies.probeProcess ?? probePid)(pid);
+      if (status === "dead") {
+        return { status: "dead" };
+      }
     }
     return {
       status: "unknown",
@@ -110,7 +121,7 @@ export async function inspectProcessIdentity(
     return { status: "unknown", reason: `invalid process ID ${pid}` };
   }
   if (platform === "linux") {
-    return inspectLinuxProcess(pid);
+    return inspectLinuxProcess(pid, dependencies);
   }
   if (platform === "darwin") {
     return inspectMacProcess(pid, dependencies);

--- a/src/core/redaction.ts
+++ b/src/core/redaction.ts
@@ -33,7 +33,12 @@ const HOST_KEYS = new Set(["host", "hostname"]);
 type RedactionContext = {
   home: string;
   salt: string;
-  paths: string[];
+  pathTrie: PathTrieNode;
+};
+
+type PathTrieNode = {
+  children: Map<string, PathTrieNode>;
+  path?: string;
 };
 
 function token(kind: string, value: string, salt: string): string {
@@ -50,8 +55,54 @@ function redactPath(value: string, home: string, salt: string): string {
   return isAbsolute(value) ? `$PATH/<${token("path", value, salt)}>` : value;
 }
 
-function escapeRegularExpression(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+function buildPathTrie(paths: Iterable<string>, home: string): PathTrieNode {
+  const root: PathTrieNode = { children: new Map() };
+  for (const path of paths) {
+    if (path === home) {
+      continue;
+    }
+    let node = root;
+    for (let index = 0; index < path.length; index += 1) {
+      const character = path[index] ?? "";
+      let child = node.children.get(character);
+      if (child === undefined) {
+        child = { children: new Map() };
+        node.children.set(character, child);
+      }
+      node = child;
+    }
+    node.path = path;
+  }
+  return root;
+}
+
+function replaceKnownPaths(value: string, context: RedactionContext): string {
+  let output = "";
+  let cursor = 0;
+  while (cursor < value.length) {
+    let node = context.pathTrie;
+    let scan = cursor;
+    let match: string | undefined;
+    while (scan < value.length) {
+      const child = node.children.get(value[scan] ?? "");
+      if (child === undefined) {
+        break;
+      }
+      node = child;
+      scan += 1;
+      if (node.path !== undefined) {
+        match = node.path;
+      }
+    }
+    if (match === undefined) {
+      output += value[cursor];
+      cursor += 1;
+      continue;
+    }
+    output += redactPath(match, context.home, context.salt);
+    cursor += match.length;
+  }
+  return output;
 }
 
 function replacePathMatch(matched: string, context: RedactionContext): string {
@@ -61,19 +112,11 @@ function replacePathMatch(matched: string, context: RedactionContext): string {
 }
 
 function redactText(value: string, context: RedactionContext): string {
-  let output = value;
-  for (const path of context.paths) {
-    output = output.split(path).join(redactPath(path, context.home, context.salt));
-  }
-
-  const homePath = new RegExp(`${escapeRegularExpression(context.home)}[^\\s"'<>]*`, "gu");
-  output = output.replace(homePath, (matched) => replacePathMatch(matched, context));
-  output = output.replace(/(?<![$\w:>])\/[^\s"'<>]+/gu, (matched) =>
+  let output = replaceKnownPaths(value, context);
+  output = output.replace(/(?<![$\w:>])\/[^"'<>]*/gu, (matched) =>
     replacePathMatch(matched, context),
   );
-  return output.replace(/\b[A-Za-z]:\\[^\s"'<>]+/gu, (matched) =>
-    replacePathMatch(matched, context),
-  );
+  return output.replace(/\b[A-Za-z]:\\[^"'<>]*/gu, (matched) => replacePathMatch(matched, context));
 }
 
 function collectPaths(value: unknown, key: string | undefined, paths: Set<string>): void {
@@ -131,7 +174,7 @@ export function redactAuditValue<T>(value: T, home: string, salt: string): T {
   const context: RedactionContext = {
     home,
     salt,
-    paths: [...paths].sort((left, right) => right.length - left.length),
+    pathTrie: buildPathTrie(paths, home),
   };
   return redactValue(value, context) as T;
 }

--- a/src/core/redaction.ts
+++ b/src/core/redaction.ts
@@ -1,0 +1,94 @@
+import { isAbsolute, sep } from "node:path";
+
+import type { AuditReport } from "../contracts/report.js";
+import { sha256 } from "./digest.js";
+
+const IDENTIFIER_KEYS = new Set([
+  "Command",
+  "Image",
+  "Names",
+  "Repository",
+  "actionId",
+  "auditId",
+  "branch",
+  "canonicalKey",
+  "displayName",
+  "evidenceRef",
+  "externalId",
+  "findingId",
+  "head",
+  "id",
+  "resourceId",
+]);
+const PATH_KEYS = new Set([
+  "home",
+  "isolationPath",
+  "mountBoundaryPaths",
+  "path",
+  "projectRoot",
+  "root",
+]);
+const HOST_KEYS = new Set(["host", "hostname"]);
+
+function token(kind: string, value: string, salt: string): string {
+  return `${kind}:${sha256(`${salt}\0${value}`).slice(0, 16)}`;
+}
+
+function redactPath(value: string, home: string, salt: string): string {
+  if (value === home) {
+    return "$HOME";
+  }
+  if (value.startsWith(`${home}${sep}`)) {
+    return `$HOME/<${token("path", value, salt)}>`;
+  }
+  return isAbsolute(value) ? `$PATH/<${token("path", value, salt)}>` : value;
+}
+
+function escapeRegularExpression(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function redactText(value: string, home: string, salt: string): string {
+  const homePath = new RegExp(`${escapeRegularExpression(home)}[^\\s"'<>]*`, "gu");
+  return value.replace(homePath, (matched) => {
+    const suffix = matched.match(/[),.;:]+$/u)?.[0] ?? "";
+    const path = suffix === "" ? matched : matched.slice(0, -suffix.length);
+    return `${redactPath(path, home, salt)}${suffix}`;
+  });
+}
+
+function redactValue(value: unknown, home: string, salt: string, key?: string): unknown {
+  if (typeof value === "string") {
+    if (key !== undefined && IDENTIFIER_KEYS.has(key)) {
+      return token("id", value, salt);
+    }
+    if (key !== undefined && PATH_KEYS.has(key)) {
+      return redactPath(value, home, salt);
+    }
+    return redactText(value, home, salt);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactValue(item, home, salt, key));
+  }
+  if (typeof value !== "object" || value === null) {
+    return value;
+  }
+
+  const output: Record<string, unknown> = {};
+  for (const [childKey, childValue] of Object.entries(value)) {
+    if (HOST_KEYS.has(childKey)) {
+      continue;
+    }
+    output[childKey] =
+      childKey === "candidateActions" ? [] : redactValue(childValue, home, salt, childKey);
+  }
+  return output;
+}
+
+export function redactAuditValue<T>(value: T, home: string, salt: string): T {
+  return redactValue(value, home, salt) as T;
+}
+
+export function redactAuditReport(report: AuditReport, salt: string): AuditReport {
+  return redactAuditValue(report, report.home, salt);
+}

--- a/src/core/redaction.ts
+++ b/src/core/redaction.ts
@@ -57,7 +57,7 @@ function replacePathMatch(matched: string, context: RedactionContext): string {
 
 function redactText(value: string, context: RedactionContext): string {
   let output = value;
-  output = output.replace(/(?<![$\w:>])\/[^"'<>]*/gu, (matched) =>
+  output = output.replace(/(?<![$\w>])\/[^"'<>]*/gu, (matched) =>
     replacePathMatch(matched, context),
   );
   return output.replace(/\b[A-Za-z]:\\[^"'<>]*/gu, (matched) => replacePathMatch(matched, context));

--- a/src/core/redaction.ts
+++ b/src/core/redaction.ts
@@ -33,12 +33,6 @@ const HOST_KEYS = new Set(["host", "hostname"]);
 type RedactionContext = {
   home: string;
   salt: string;
-  pathTrie: PathTrieNode;
-};
-
-type PathTrieNode = {
-  children: Map<string, PathTrieNode>;
-  path?: string;
 };
 
 function token(kind: string, value: string, salt: string): string {
@@ -55,56 +49,6 @@ function redactPath(value: string, home: string, salt: string): string {
   return isAbsolute(value) ? `$PATH/<${token("path", value, salt)}>` : value;
 }
 
-function buildPathTrie(paths: Iterable<string>, home: string): PathTrieNode {
-  const root: PathTrieNode = { children: new Map() };
-  for (const path of paths) {
-    if (path === home) {
-      continue;
-    }
-    let node = root;
-    for (let index = 0; index < path.length; index += 1) {
-      const character = path[index] ?? "";
-      let child = node.children.get(character);
-      if (child === undefined) {
-        child = { children: new Map() };
-        node.children.set(character, child);
-      }
-      node = child;
-    }
-    node.path = path;
-  }
-  return root;
-}
-
-function replaceKnownPaths(value: string, context: RedactionContext): string {
-  let output = "";
-  let cursor = 0;
-  while (cursor < value.length) {
-    let node = context.pathTrie;
-    let scan = cursor;
-    let match: string | undefined;
-    while (scan < value.length) {
-      const child = node.children.get(value[scan] ?? "");
-      if (child === undefined) {
-        break;
-      }
-      node = child;
-      scan += 1;
-      if (node.path !== undefined) {
-        match = node.path;
-      }
-    }
-    if (match === undefined) {
-      output += value[cursor];
-      cursor += 1;
-      continue;
-    }
-    output += redactPath(match, context.home, context.salt);
-    cursor += match.length;
-  }
-  return output;
-}
-
 function replacePathMatch(matched: string, context: RedactionContext): string {
   const suffix = matched.match(/[),.;:]+$/u)?.[0] ?? "";
   const path = suffix === "" ? matched : matched.slice(0, -suffix.length);
@@ -112,32 +56,11 @@ function replacePathMatch(matched: string, context: RedactionContext): string {
 }
 
 function redactText(value: string, context: RedactionContext): string {
-  let output = replaceKnownPaths(value, context);
+  let output = value;
   output = output.replace(/(?<![$\w:>])\/[^"'<>]*/gu, (matched) =>
     replacePathMatch(matched, context),
   );
   return output.replace(/\b[A-Za-z]:\\[^"'<>]*/gu, (matched) => replacePathMatch(matched, context));
-}
-
-function collectPaths(value: unknown, key: string | undefined, paths: Set<string>): void {
-  if (typeof value === "string") {
-    if (key !== undefined && PATH_KEYS.has(key) && isAbsolute(value)) {
-      paths.add(value);
-    }
-    return;
-  }
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      collectPaths(item, key, paths);
-    }
-    return;
-  }
-  if (typeof value !== "object" || value === null) {
-    return;
-  }
-  for (const [childKey, childValue] of Object.entries(value)) {
-    collectPaths(childValue, childKey, paths);
-  }
 }
 
 function redactValue(value: unknown, context: RedactionContext, key?: string): unknown {
@@ -169,12 +92,9 @@ function redactValue(value: unknown, context: RedactionContext, key?: string): u
 }
 
 export function redactAuditValue<T>(value: T, home: string, salt: string): T {
-  const paths = new Set<string>([home]);
-  collectPaths(value, undefined, paths);
   const context: RedactionContext = {
     home,
     salt,
-    pathTrie: buildPathTrie(paths, home),
   };
   return redactValue(value, context) as T;
 }

--- a/src/core/redaction.ts
+++ b/src/core/redaction.ts
@@ -60,6 +60,7 @@ function replacePathMatch(matched: string, context: RedactionContext): string {
 function redactText(value: string, context: RedactionContext): string {
   let output = value;
   output = output.replace(/\\\\.*/gu, (matched) => replacePathMatch(matched, context));
+  output = output.replace(/(?<!\\)\\(?!\\).*/gu, (matched) => replacePathMatch(matched, context));
   output = output.replace(/(?<![$\w>])\/.*/gu, (matched) => replacePathMatch(matched, context));
   return output.replace(/\b[A-Za-z]:\\.*/gu, (matched) => replacePathMatch(matched, context));
 }

--- a/src/core/redaction.ts
+++ b/src/core/redaction.ts
@@ -30,6 +30,12 @@ const PATH_KEYS = new Set([
 ]);
 const HOST_KEYS = new Set(["host", "hostname"]);
 
+type RedactionContext = {
+  home: string;
+  salt: string;
+  paths: string[];
+};
+
 function token(kind: string, value: string, salt: string): string {
   return `${kind}:${sha256(`${salt}\0${value}`).slice(0, 16)}`;
 }
@@ -48,27 +54,61 @@ function escapeRegularExpression(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
 
-function redactText(value: string, home: string, salt: string): string {
-  const homePath = new RegExp(`${escapeRegularExpression(home)}[^\\s"'<>]*`, "gu");
-  return value.replace(homePath, (matched) => {
-    const suffix = matched.match(/[),.;:]+$/u)?.[0] ?? "";
-    const path = suffix === "" ? matched : matched.slice(0, -suffix.length);
-    return `${redactPath(path, home, salt)}${suffix}`;
-  });
+function replacePathMatch(matched: string, context: RedactionContext): string {
+  const suffix = matched.match(/[),.;:]+$/u)?.[0] ?? "";
+  const path = suffix === "" ? matched : matched.slice(0, -suffix.length);
+  return `${redactPath(path, context.home, context.salt)}${suffix}`;
 }
 
-function redactValue(value: unknown, home: string, salt: string, key?: string): unknown {
+function redactText(value: string, context: RedactionContext): string {
+  let output = value;
+  for (const path of context.paths) {
+    output = output.split(path).join(redactPath(path, context.home, context.salt));
+  }
+
+  const homePath = new RegExp(`${escapeRegularExpression(context.home)}[^\\s"'<>]*`, "gu");
+  output = output.replace(homePath, (matched) => replacePathMatch(matched, context));
+  output = output.replace(/(?<![$\w:>])\/[^\s"'<>]+/gu, (matched) =>
+    replacePathMatch(matched, context),
+  );
+  return output.replace(/\b[A-Za-z]:\\[^\s"'<>]+/gu, (matched) =>
+    replacePathMatch(matched, context),
+  );
+}
+
+function collectPaths(value: unknown, key: string | undefined, paths: Set<string>): void {
   if (typeof value === "string") {
-    if (key !== undefined && IDENTIFIER_KEYS.has(key)) {
-      return token("id", value, salt);
+    if (key !== undefined && PATH_KEYS.has(key) && isAbsolute(value)) {
+      paths.add(value);
     }
-    if (key !== undefined && PATH_KEYS.has(key)) {
-      return redactPath(value, home, salt);
-    }
-    return redactText(value, home, salt);
+    return;
   }
   if (Array.isArray(value)) {
-    return value.map((item) => redactValue(item, home, salt, key));
+    for (const item of value) {
+      collectPaths(item, key, paths);
+    }
+    return;
+  }
+  if (typeof value !== "object" || value === null) {
+    return;
+  }
+  for (const [childKey, childValue] of Object.entries(value)) {
+    collectPaths(childValue, childKey, paths);
+  }
+}
+
+function redactValue(value: unknown, context: RedactionContext, key?: string): unknown {
+  if (typeof value === "string") {
+    if (key !== undefined && IDENTIFIER_KEYS.has(key)) {
+      return token("id", value, context.salt);
+    }
+    if (key !== undefined && PATH_KEYS.has(key)) {
+      return redactPath(value, context.home, context.salt);
+    }
+    return redactText(value, context);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactValue(item, context, key));
   }
   if (typeof value !== "object" || value === null) {
     return value;
@@ -80,13 +120,20 @@ function redactValue(value: unknown, home: string, salt: string, key?: string): 
       continue;
     }
     output[childKey] =
-      childKey === "candidateActions" ? [] : redactValue(childValue, home, salt, childKey);
+      childKey === "candidateActions" ? [] : redactValue(childValue, context, childKey);
   }
   return output;
 }
 
 export function redactAuditValue<T>(value: T, home: string, salt: string): T {
-  return redactValue(value, home, salt) as T;
+  const paths = new Set<string>([home]);
+  collectPaths(value, undefined, paths);
+  const context: RedactionContext = {
+    home,
+    salt,
+    paths: [...paths].sort((left, right) => right.length - left.length),
+  };
+  return redactValue(value, context) as T;
 }
 
 export function redactAuditReport(report: AuditReport, salt: string): AuditReport {

--- a/src/core/redaction.ts
+++ b/src/core/redaction.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, sep } from "node:path";
+import { posix, win32 } from "node:path";
 
 import type { AuditReport } from "../contracts/report.js";
 import { sha256 } from "./digest.js";
@@ -43,10 +43,12 @@ function redactPath(value: string, home: string, salt: string): string {
   if (value === home) {
     return "$HOME";
   }
-  if (value.startsWith(`${home}${sep}`)) {
+  if (value.startsWith(`${home}${posix.sep}`) || value.startsWith(`${home}${win32.sep}`)) {
     return `$HOME/<${token("path", value, salt)}>`;
   }
-  return isAbsolute(value) ? `$PATH/<${token("path", value, salt)}>` : value;
+  return posix.isAbsolute(value) || win32.isAbsolute(value)
+    ? `$PATH/<${token("path", value, salt)}>`
+    : value;
 }
 
 function replacePathMatch(matched: string, context: RedactionContext): string {
@@ -57,6 +59,7 @@ function replacePathMatch(matched: string, context: RedactionContext): string {
 
 function redactText(value: string, context: RedactionContext): string {
   let output = value;
+  output = output.replace(/\\\\.*/gu, (matched) => replacePathMatch(matched, context));
   output = output.replace(/(?<![$\w>])\/.*/gu, (matched) => replacePathMatch(matched, context));
   return output.replace(/\b[A-Za-z]:\\.*/gu, (matched) => replacePathMatch(matched, context));
 }

--- a/src/core/redaction.ts
+++ b/src/core/redaction.ts
@@ -57,10 +57,8 @@ function replacePathMatch(matched: string, context: RedactionContext): string {
 
 function redactText(value: string, context: RedactionContext): string {
   let output = value;
-  output = output.replace(/(?<![$\w>])\/[^"'<>]*/gu, (matched) =>
-    replacePathMatch(matched, context),
-  );
-  return output.replace(/\b[A-Za-z]:\\[^"'<>]*/gu, (matched) => replacePathMatch(matched, context));
+  output = output.replace(/(?<![$\w>])\/.*/gu, (matched) => replacePathMatch(matched, context));
+  return output.replace(/\b[A-Za-z]:\\.*/gu, (matched) => replacePathMatch(matched, context));
 }
 
 function redactValue(value: unknown, context: RedactionContext, key?: string): unknown {

--- a/src/core/redaction.ts
+++ b/src/core/redaction.ts
@@ -59,10 +59,14 @@ function replacePathMatch(matched: string, context: RedactionContext): string {
 
 function redactText(value: string, context: RedactionContext): string {
   let output = value;
-  output = output.replace(/\\\\.*/gu, (matched) => replacePathMatch(matched, context));
-  output = output.replace(/(?<!\\)\\(?!\\).*/gu, (matched) => replacePathMatch(matched, context));
-  output = output.replace(/(?<![$\w>])\/.*/gu, (matched) => replacePathMatch(matched, context));
-  return output.replace(/\b[A-Za-z]:\\.*/gu, (matched) => replacePathMatch(matched, context));
+  output = output.replace(/\\\\[\s\S]*/gu, (matched) => replacePathMatch(matched, context));
+  output = output.replace(/(?<!\\)\\(?!\\)[\s\S]*/gu, (matched) =>
+    replacePathMatch(matched, context),
+  );
+  output = output.replace(/(?<![$\w>])\/[\s\S]*/gu, (matched) =>
+    replacePathMatch(matched, context),
+  );
+  return output.replace(/\b[A-Za-z]:\\[\s\S]*/gu, (matched) => replacePathMatch(matched, context));
 }
 
 function redactValue(value: unknown, context: RedactionContext, key?: string): unknown {

--- a/src/core/safety.ts
+++ b/src/core/safety.ts
@@ -94,9 +94,12 @@ export async function assertDestructiveFixtureRoot(
   if (resolvedCandidate === resolvedHome) {
     throw new UnsafeDestructiveFixtureError("destructive fixture cannot use the real home");
   }
-  if (isPathInside(resolvedCandidate, resolvedRepository)) {
+  if (
+    isPathInside(resolvedCandidate, resolvedRepository) ||
+    isPathInside(resolvedRepository, resolvedCandidate)
+  ) {
     throw new UnsafeDestructiveFixtureError(
-      "destructive fixture cannot contain the repository checkout",
+      "destructive fixture cannot overlap the repository checkout",
     );
   }
 

--- a/src/core/safety.ts
+++ b/src/core/safety.ts
@@ -1,9 +1,13 @@
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { realpath } from "node:fs/promises";
 import { basename, dirname, isAbsolute, parse, relative, resolve } from "node:path";
 
 export class UnsafeAuditRootError extends Error {
   override readonly name = "UnsafeAuditRootError";
+}
+
+export class UnsafeDestructiveFixtureError extends Error {
+  override readonly name = "UnsafeDestructiveFixtureError";
 }
 
 export function isPathInside(root: string, candidate: string): boolean {
@@ -55,6 +59,45 @@ export async function assertAuditRoot(candidate: string, realHome = homedir()): 
 
   if (resolvedCandidate !== resolvedHome && isPathInside(resolvedCandidate, resolvedHome)) {
     throw new UnsafeAuditRootError("refusing to use an ancestor of the real home directory");
+  }
+
+  return resolvedCandidate;
+}
+
+export async function assertDestructiveFixtureRoot(
+  candidate: string,
+  options: {
+    temporaryRoot?: string;
+    realHome?: string;
+    repositoryRoot?: string;
+  } = {},
+): Promise<string> {
+  const [resolvedCandidate, resolvedTemporaryRoot, resolvedHome, resolvedRepository] =
+    await Promise.all([
+      realpath(resolve(candidate)),
+      realpath(resolve(options.temporaryRoot ?? tmpdir())),
+      realpath(resolve(options.realHome ?? homedir())),
+      realpath(resolve(options.repositoryRoot ?? process.cwd())),
+    ]);
+
+  if (resolvedCandidate === parse(resolvedCandidate).root) {
+    throw new UnsafeDestructiveFixtureError("destructive fixture cannot use the filesystem root");
+  }
+  if (resolvedCandidate === resolvedTemporaryRoot) {
+    throw new UnsafeDestructiveFixtureError("destructive fixture cannot use the temporary root");
+  }
+  if (!isPathInside(resolvedTemporaryRoot, resolvedCandidate)) {
+    throw new UnsafeDestructiveFixtureError(
+      "destructive fixture must be inside the selected temporary root",
+    );
+  }
+  if (resolvedCandidate === resolvedHome) {
+    throw new UnsafeDestructiveFixtureError("destructive fixture cannot use the real home");
+  }
+  if (isPathInside(resolvedCandidate, resolvedRepository)) {
+    throw new UnsafeDestructiveFixtureError(
+      "destructive fixture cannot contain the repository checkout",
+    );
   }
 
   return resolvedCandidate;

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,14 @@ export {
   type DoctorCheck,
   type DoctorReport,
 } from "./contracts/doctor.js";
+export {
+  commandEnvelopeSchema,
+  commandEnvelopeStatusSchema,
+  commandEventSchema,
+  type CommandEnvelope,
+  type CommandEnvelopeStatus,
+  type CommandEvent,
+} from "./contracts/output.js";
 export { cleanupPlanSchema, type CleanupPlan } from "./contracts/plan.js";
 export { auditReportSchema, type AdapterProbe, type AuditReport } from "./contracts/report.js";
 export {
@@ -28,6 +36,6 @@ export {
   type ActionExecution,
   type CleanupRun,
 } from "./contracts/run.js";
-export { runAudit, type RunAuditOptions } from "./core/audit.js";
+export { runAudit, type AuditProgressEvent, type RunAuditOptions } from "./core/audit.js";
 export { applyCleanupPlan, type ApplyCleanupPlanOptions, type ApplyResult } from "./core/apply.js";
 export { createCleanupPlan } from "./core/plan.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,12 @@ export {
   type PathIdentity,
   type PlannedAction,
 } from "./contracts/action.js";
+export {
+  doctorCheckSchema,
+  doctorReportSchema,
+  type DoctorCheck,
+  type DoctorReport,
+} from "./contracts/doctor.js";
 export { cleanupPlanSchema, type CleanupPlan } from "./contracts/plan.js";
 export { auditReportSchema, type AdapterProbe, type AuditReport } from "./contracts/report.js";
 export {

--- a/src/machine-output.ts
+++ b/src/machine-output.ts
@@ -1,0 +1,56 @@
+import {
+  commandEnvelopeSchema,
+  commandEventSchema,
+  type CommandEnvelope,
+  type CommandEnvelopeStatus,
+  type CommandEvent,
+} from "./contracts/output.js";
+import type { Diagnostic } from "./contracts/diagnostic.js";
+import { VERSION } from "./version.js";
+
+export function createCommandEnvelope<T>(options: {
+  command: string;
+  startedAt: string;
+  completedAt: string;
+  status: CommandEnvelopeStatus;
+  data: T;
+  diagnostics?: Diagnostic[];
+}): CommandEnvelope<T> {
+  return commandEnvelopeSchema.parse({
+    schemaVersion: 1,
+    command: options.command,
+    agentrinseVersion: VERSION,
+    startedAt: options.startedAt,
+    completedAt: options.completedAt,
+    status: options.status,
+    data: options.data,
+    diagnostics: options.diagnostics ?? [],
+  }) as CommandEnvelope<T>;
+}
+
+export function createCommandEvent<T>(options: {
+  event: string;
+  timestamp: string;
+  command: string;
+  commandId: string;
+  sequence: number;
+  data?: T;
+}): CommandEvent<T> {
+  return commandEventSchema.parse({
+    schemaVersion: 1,
+    event: options.event,
+    timestamp: options.timestamp,
+    command: options.command,
+    commandId: options.commandId,
+    sequence: options.sequence,
+    ...(options.data === undefined ? {} : { data: options.data }),
+  }) as CommandEvent<T>;
+}
+
+export function jsonDocument(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+export function ndjsonRecord(value: unknown): string {
+  return `${JSON.stringify(value)}\n`;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,8 @@ export function buildProgram(): Command {
     .option("--home <path>", "home directory to audit")
     .option("--config <path>", "explicit JSON config")
     .option("--json", "emit the versioned JSON report", false)
+    .option("--ndjson", "stream versioned NDJSON events", false)
+    .option("--redact", "redact paths and identifiers in machine output", false)
     .option("--output <path>", "write the JSON report atomically")
     .option("--state-dir <path>", "override the AgentRinse state directory")
     .action(
@@ -40,14 +42,19 @@ export function buildProgram(): Command {
         home?: string;
         config?: string;
         json: boolean;
+        ndjson: boolean;
+        redact: boolean;
         output?: string;
         stateDir?: string;
       }) => {
         const result = await executeAuditCommand({
           ...options,
           home: options.home ?? homedir(),
+          ...(options.ndjson ? { emit: (output) => process.stdout.write(output) } : {}),
         });
-        process.stdout.write(result.output);
+        if (result.output !== "") {
+          process.stdout.write(result.output);
+        }
       },
     );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,13 @@ import {
   executeConfigShowCommand,
   executeConfigValidateCommand,
 } from "./commands/config.js";
+import { executeHistoryCommand } from "./commands/history.js";
 import { executePlanCommand } from "./commands/plan.js";
+import {
+  executeShowPlanCommand,
+  executeShowResourceCommand,
+  executeShowRunCommand,
+} from "./commands/show.js";
 import { VERSION } from "./version.js";
 
 export function buildProgram(): Command {
@@ -26,13 +32,22 @@ export function buildProgram(): Command {
     .option("--config <path>", "explicit JSON config")
     .option("--json", "emit the versioned JSON report", false)
     .option("--output <path>", "write the JSON report atomically")
-    .action(async (options: { home?: string; config?: string; json: boolean; output?: string }) => {
-      const result = await executeAuditCommand({
-        ...options,
-        home: options.home ?? homedir(),
-      });
-      process.stdout.write(result.output);
-    });
+    .option("--state-dir <path>", "override the AgentRinse state directory")
+    .action(
+      async (options: {
+        home?: string;
+        config?: string;
+        json: boolean;
+        output?: string;
+        stateDir?: string;
+      }) => {
+        const result = await executeAuditCommand({
+          ...options,
+          home: options.home ?? homedir(),
+        });
+        process.stdout.write(result.output);
+      },
+    );
 
   program
     .command("plan")
@@ -40,10 +55,13 @@ export function buildProgram(): Command {
     .requiredOption("--audit <path>", "saved audit JSON")
     .option("--config <path>", "explicit JSON config")
     .option("--output <path>", "write the plan atomically")
-    .action(async (options: { audit: string; config?: string; output?: string }) => {
-      const result = await executePlanCommand(options);
-      process.stdout.write(result.output);
-    });
+    .option("--state-dir <path>", "override the AgentRinse state directory")
+    .action(
+      async (options: { audit: string; config?: string; output?: string; stateDir?: string }) => {
+        const result = await executePlanCommand(options);
+        process.stdout.write(result.output);
+      },
+    );
 
   program
     .command("apply")
@@ -130,6 +148,73 @@ export function buildProgram(): Command {
       });
       process.stdout.write(result.output);
     });
+
+  program
+    .command("history")
+    .description("List persisted cleanup runs.")
+    .option("--home <path>", "home directory used for state resolution")
+    .option("--state-dir <path>", "override the AgentRinse state directory")
+    .option("--since <duration>", "include runs newer than a duration such as 30d")
+    .option("--json", "emit JSON", false)
+    .action(
+      async (options: { home?: string; stateDir?: string; since?: string; json: boolean }) => {
+        const result = await executeHistoryCommand({
+          ...options,
+          home: options.home ?? homedir(),
+        });
+        process.stdout.write(result.output);
+      },
+    );
+
+  const show = program.command("show").description("Inspect persisted AgentRinse records.");
+
+  show
+    .command("run <run-id-or-path>")
+    .description("Show one cleanup run.")
+    .option("--home <path>", "home directory used for state resolution")
+    .option("--state-dir <path>", "override the AgentRinse state directory")
+    .option("--json", "emit JSON", false)
+    .action(
+      async (idOrPath: string, options: { home?: string; stateDir?: string; json: boolean }) => {
+        const result = await executeShowRunCommand(idOrPath, {
+          ...options,
+          home: options.home ?? homedir(),
+        });
+        process.stdout.write(result.output);
+      },
+    );
+
+  show
+    .command("plan <plan-id-or-path>")
+    .description("Show one cleanup plan.")
+    .option("--home <path>", "home directory used for state resolution")
+    .option("--state-dir <path>", "override the AgentRinse state directory")
+    .option("--json", "emit JSON", false)
+    .action(
+      async (idOrPath: string, options: { home?: string; stateDir?: string; json: boolean }) => {
+        const result = await executeShowPlanCommand(idOrPath, {
+          ...options,
+          home: options.home ?? homedir(),
+        });
+        process.stdout.write(result.output);
+      },
+    );
+
+  show
+    .command("resource <resource-id>")
+    .description("Show the latest persisted resource finding.")
+    .option("--home <path>", "home directory used for state resolution")
+    .option("--state-dir <path>", "override the AgentRinse state directory")
+    .option("--json", "emit JSON", false)
+    .action(
+      async (resourceId: string, options: { home?: string; stateDir?: string; json: boolean }) => {
+        const result = await executeShowResourceCommand(resourceId, {
+          ...options,
+          home: options.home ?? homedir(),
+        });
+        process.stdout.write(result.output);
+      },
+    );
 
   return program;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import {
   executeConfigValidateCommand,
 } from "./commands/config.js";
 import { executeHistoryCommand } from "./commands/history.js";
+import { executeLockRecoverCommand, executeLockStatusCommand } from "./commands/lock.js";
 import { executePlanCommand } from "./commands/plan.js";
 import {
   executeShowPlanCommand,
@@ -215,6 +216,37 @@ export function buildProgram(): Command {
         process.stdout.write(result.output);
       },
     );
+
+  const lock = program.command("lock").description("Inspect and recover the apply lock.");
+
+  lock
+    .command("status")
+    .description("Inspect the apply lock and its recorded process identity.")
+    .option("--home <path>", "home directory used for state resolution")
+    .option("--state-dir <path>", "override the AgentRinse state directory")
+    .option("--json", "emit JSON", false)
+    .action(async (options: { home?: string; stateDir?: string; json: boolean }) => {
+      const result = await executeLockStatusCommand({
+        ...options,
+        home: options.home ?? homedir(),
+      });
+      process.stdout.write(result.output);
+    });
+
+  lock
+    .command("recover")
+    .description("Remove a local lock only after proving its process identity is gone.")
+    .option("--home <path>", "home directory used for state resolution")
+    .option("--state-dir <path>", "override the AgentRinse state directory")
+    .option("--yes", "authorize recovery after inspecting the lock", false)
+    .option("--json", "emit JSON", false)
+    .action(async (options: { home?: string; stateDir?: string; yes: boolean; json: boolean }) => {
+      const result = await executeLockRecoverCommand({
+        ...options,
+        home: options.home ?? homedir(),
+      });
+      process.stdout.write(result.output);
+    });
 
   return program;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import {
   executeConfigShowCommand,
   executeConfigValidateCommand,
 } from "./commands/config.js";
+import { executeDoctorCommand } from "./commands/doctor.js";
 import { executeHistoryCommand } from "./commands/history.js";
 import { executeLockRecoverCommand, executeLockStatusCommand } from "./commands/lock.js";
 import { executePlanCommand } from "./commands/plan.js";
@@ -94,6 +95,26 @@ export function buildProgram(): Command {
     .action(() => {
       process.stdout.write(renderAdapters());
     });
+
+  program
+    .command("doctor")
+    .description("Diagnose platform, configuration, state, and optional integrations.")
+    .option("--home <path>", "home directory used for diagnostics")
+    .option("--config <path>", "explicit JSON config")
+    .option("--state-dir <path>", "override the AgentRinse state directory")
+    .option("--json", "emit the versioned JSON report", false)
+    .action(
+      async (options: { home?: string; config?: string; stateDir?: string; json: boolean }) => {
+        const result = await executeDoctorCommand({
+          ...options,
+          home: options.home ?? homedir(),
+        });
+        process.stdout.write(result.output);
+        if (result.report.status === "error") {
+          process.exitCode = 1;
+        }
+      },
+    );
 
   const config = program.command("config").description("Inspect and initialize configuration.");
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import {
   executeShowResourceCommand,
   executeShowRunCommand,
 } from "./commands/show.js";
+import { CommandInterruptedError } from "./core/interruption.js";
 import { VERSION } from "./version.js";
 
 export function buildProgram(): Command {
@@ -89,10 +90,24 @@ export function buildProgram(): Command {
         yes: boolean;
         json: boolean;
       }) => {
-        const result = await executeApplyCommand(options);
-        process.stdout.write(result.output);
-        if (["failed", "partial"].includes(result.run.status)) {
-          process.exitCode = 2;
+        const controller = new AbortController();
+        const interrupt = () => {
+          controller.abort(new CommandInterruptedError("interrupted by SIGINT"));
+        };
+        process.on("SIGINT", interrupt);
+        try {
+          const result = await executeApplyCommand({
+            ...options,
+            signal: controller.signal,
+          });
+          process.stdout.write(result.output);
+          if (result.run.status === "interrupted") {
+            process.exitCode = 130;
+          } else if (["failed", "partial"].includes(result.run.status)) {
+            process.exitCode = 2;
+          }
+        } finally {
+          process.removeListener("SIGINT", interrupt);
         }
       },
     );

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,15 @@
 import { Command } from "commander";
+import { homedir } from "node:os";
 
 import { executeAuditCommand } from "./commands/audit.js";
 import { renderAdapters } from "./commands/adapters.js";
 import { executeApplyCommand } from "./commands/apply.js";
+import {
+  executeConfigInitCommand,
+  executeConfigPathCommand,
+  executeConfigShowCommand,
+  executeConfigValidateCommand,
+} from "./commands/config.js";
 import { executePlanCommand } from "./commands/plan.js";
 import { VERSION } from "./version.js";
 
@@ -15,12 +22,15 @@ export function buildProgram(): Command {
   program
     .command("audit")
     .description("Inventory a home without mutating it.")
-    .requiredOption("--home <path>", "home directory to audit")
+    .option("--home <path>", "home directory to audit")
     .option("--config <path>", "explicit JSON config")
     .option("--json", "emit the versioned JSON report", false)
     .option("--output <path>", "write the JSON report atomically")
-    .action(async (options: { home: string; config?: string; json: boolean; output?: string }) => {
-      const result = await executeAuditCommand(options);
+    .action(async (options: { home?: string; config?: string; json: boolean; output?: string }) => {
+      const result = await executeAuditCommand({
+        ...options,
+        home: options.home ?? homedir(),
+      });
       process.stdout.write(result.output);
     });
 
@@ -64,6 +74,61 @@ export function buildProgram(): Command {
     .description("List adapter maturity and ownership.")
     .action(() => {
       process.stdout.write(renderAdapters());
+    });
+
+  const config = program.command("config").description("Inspect and initialize configuration.");
+
+  config
+    .command("path")
+    .description("Print the resolved configuration path.")
+    .option("--home <path>", "home directory used for default resolution")
+    .option("--config <path>", "explicit JSON config")
+    .action((options: { home?: string; config?: string }) => {
+      process.stdout.write(
+        executeConfigPathCommand({
+          home: options.home ?? homedir(),
+          config: options.config,
+        }).output,
+      );
+    });
+
+  config
+    .command("init")
+    .description("Create a default configuration without overwriting.")
+    .option("--home <path>", "home directory used for default resolution")
+    .option("--config <path>", "explicit JSON config")
+    .action(async (options: { home?: string; config?: string }) => {
+      const result = await executeConfigInitCommand({
+        home: options.home ?? homedir(),
+        config: options.config,
+      });
+      process.stdout.write(result.output);
+    });
+
+  config
+    .command("show")
+    .description("Print the effective configuration.")
+    .option("--home <path>", "home directory used for default resolution")
+    .option("--config <path>", "explicit JSON config")
+    .action(async (options: { home?: string; config?: string }) => {
+      const result = await executeConfigShowCommand({
+        home: options.home ?? homedir(),
+        config: options.config,
+      });
+      process.stdout.write(result.output);
+    });
+
+  config
+    .command("validate")
+    .description("Validate an existing configuration file.")
+    .option("--home <path>", "home directory used for default resolution")
+    .option("--config <path>", "explicit JSON config")
+    .action(async (options: { home?: string; config?: string }) => {
+      const result = await executeConfigValidateCommand({
+        home: options.home ?? homedir(),
+        config: options.config,
+      });
+      process.stdout.write(result.output);
     });
 
   return program;

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import {
   executeConfigShowCommand,
   executeConfigValidateCommand,
 } from "./commands/config.js";
+import { renderCompletion } from "./commands/completion.js";
 import { executeDoctorCommand } from "./commands/doctor.js";
 import { executeHistoryCommand } from "./commands/history.js";
 import { executeLockRecoverCommand, executeLockStatusCommand } from "./commands/lock.js";
@@ -122,6 +123,13 @@ export function buildProgram(): Command {
         }
       },
     );
+
+  program
+    .command("completion <shell>")
+    .description("Generate shell completion for bash, zsh, or fish.")
+    .action((shell: string) => {
+      process.stdout.write(renderCompletion(shell));
+    });
 
   const config = program.command("config").description("Inspect and initialize configuration.");
 

--- a/src/state/json-file.ts
+++ b/src/state/json-file.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, open, readFile, rename, rm } from "node:fs/promises";
+import { chmod, lstat, mkdir, open, readFile, rename, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { randomUUID } from "node:crypto";
 
@@ -15,8 +15,32 @@ export async function syncDirectory(path: string): Promise<void> {
   }
 }
 
-export async function writeJsonAtomic(path: string, value: unknown): Promise<void> {
+export type JsonWriteOptions = {
+  privateDirectories?: string[];
+};
+
+async function ensurePrivateDirectory(directory: string): Promise<void> {
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  const stats = await lstat(directory);
+  if (!stats.isDirectory() || stats.isSymbolicLink()) {
+    throw new Error(`private state path is not a real directory: ${directory}`);
+  }
+  const uid = process.getuid?.();
+  if (uid !== undefined && stats.uid !== uid) {
+    throw new Error(`private state directory is not owned by the current user: ${directory}`);
+  }
+  await chmod(directory, 0o700);
+}
+
+export async function writeJsonAtomic(
+  path: string,
+  value: unknown,
+  options: JsonWriteOptions = {},
+): Promise<void> {
   const directory = dirname(path);
+  for (const privateDirectory of new Set(options.privateDirectories ?? [])) {
+    await ensurePrivateDirectory(privateDirectory);
+  }
   await mkdir(directory, { recursive: true, mode: 0o700 });
 
   const temporary = join(directory, `.${randomUUID()}.tmp`);

--- a/src/state/json-file.ts
+++ b/src/state/json-file.ts
@@ -19,7 +19,7 @@ export type JsonWriteOptions = {
   privateDirectories?: string[];
 };
 
-async function ensurePrivateDirectory(directory: string): Promise<void> {
+export async function ensurePrivateDirectory(directory: string): Promise<void> {
   await mkdir(directory, { recursive: true, mode: 0o700 });
   const stats = await lstat(directory);
   if (!stats.isDirectory() || stats.isSymbolicLink()) {

--- a/src/state/json-file.ts
+++ b/src/state/json-file.ts
@@ -18,7 +18,6 @@ export async function syncDirectory(path: string): Promise<void> {
 export async function writeJsonAtomic(path: string, value: unknown): Promise<void> {
   const directory = dirname(path);
   await mkdir(directory, { recursive: true, mode: 0o700 });
-  await chmod(directory, 0o700);
 
   const temporary = join(directory, `.${randomUUID()}.tmp`);
   const handle = await open(temporary, "wx", 0o600);
@@ -40,7 +39,6 @@ export async function writeJsonAtomic(path: string, value: unknown): Promise<voi
 export async function writeJsonExclusive(path: string, value: unknown): Promise<void> {
   const directory = dirname(path);
   await mkdir(directory, { recursive: true, mode: 0o700 });
-  await chmod(directory, 0o700);
 
   const handle = await open(path, "wx", 0o600);
   try {

--- a/src/state/json-file.ts
+++ b/src/state/json-file.ts
@@ -36,3 +36,22 @@ export async function writeJsonAtomic(path: string, value: unknown): Promise<voi
     throw error;
   }
 }
+
+export async function writeJsonExclusive(path: string, value: unknown): Promise<void> {
+  const directory = dirname(path);
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  await chmod(directory, 0o700);
+
+  const handle = await open(path, "wx", 0o600);
+  try {
+    await handle.writeFile(`${JSON.stringify(value, null, 2)}\n`, "utf8");
+    await handle.sync();
+    await handle.close();
+    await chmod(path, 0o600);
+    await syncDirectory(directory);
+  } catch (error) {
+    await handle.close().catch(() => undefined);
+    await rm(path, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}

--- a/src/state/layout.ts
+++ b/src/state/layout.ts
@@ -6,6 +6,8 @@ export type StateEnvironment = {
 
 export type StateLayout = {
   root: string;
+  audits: string;
+  plans: string;
   locks: string;
   runs: string;
   tombstones: string;
@@ -29,6 +31,8 @@ export function stateLayout(root: string): StateLayout {
   const resolved = resolve(root);
   return {
     root: resolved,
+    audits: join(resolved, "audits"),
+    plans: join(resolved, "plans"),
     locks: join(resolved, "locks"),
     runs: join(resolved, "runs"),
     tombstones: join(resolved, "tombstones"),

--- a/src/state/lock.ts
+++ b/src/state/lock.ts
@@ -102,6 +102,60 @@ async function readOwner(path: string): Promise<ApplyLockOwner | undefined> {
   }
 }
 
+async function acquireRecoveryMutex(locksDirectory: string): Promise<StateLock> {
+  await mkdir(locksDirectory, { recursive: true, mode: 0o700 });
+  const path = join(locksDirectory, "apply.recovery.lock");
+  const token = randomUUID();
+  let handle: FileHandle;
+  try {
+    handle = await open(path, "wx", 0o600);
+  } catch (error) {
+    if (isErrno(error, "EEXIST")) {
+      throw new LockRecoveryError("apply lock recovery is already in progress");
+    }
+    throw error;
+  }
+
+  try {
+    await handle.writeFile(`${JSON.stringify({ token, pid: process.pid })}\n`, "utf8");
+    await handle.sync();
+    await syncDirectory(locksDirectory);
+    const identity = await handle.stat();
+    let released = false;
+
+    return {
+      path,
+      async release() {
+        if (released) {
+          return;
+        }
+        released = true;
+        await handle.close();
+        try {
+          const [raw, current] = await Promise.all([readFile(path, "utf8"), lstat(path)]);
+          const record = JSON.parse(raw) as { token?: unknown };
+          if (
+            record.token === token &&
+            current.dev === identity.dev &&
+            current.ino === identity.ino
+          ) {
+            await rm(path);
+            await syncDirectory(locksDirectory);
+          }
+        } catch (error) {
+          if (!isErrno(error, "ENOENT")) {
+            throw error;
+          }
+        }
+      },
+    };
+  } catch (error) {
+    await handle.close().catch(() => undefined);
+    await rm(path, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
 async function inspectLockSnapshot(
   locksDirectory: string,
   dependencies: LockInspectionDependencies = {},
@@ -203,34 +257,39 @@ export async function recoverStaleApplyLock(
   locksDirectory: string,
   dependencies: LockInspectionDependencies = {},
 ): Promise<ApplyLockOwner> {
-  const snapshot = await inspectLockSnapshot(locksDirectory, dependencies);
-  if (snapshot.status.status !== "stale" || snapshot.identity === undefined) {
-    throw new LockRecoveryError(
-      `apply lock is ${snapshot.status.status}; recovery requires a proven stale local owner`,
-    );
-  }
+  const recoveryMutex = await acquireRecoveryMutex(locksDirectory);
+  try {
+    const snapshot = await inspectLockSnapshot(locksDirectory, dependencies);
+    if (snapshot.status.status !== "stale" || snapshot.identity === undefined) {
+      throw new LockRecoveryError(
+        `apply lock is ${snapshot.status.status}; recovery requires a proven stale local owner`,
+      );
+    }
 
-  await dependencies.beforeRecoveryRemove?.();
-  const [owner, current] = await Promise.all([
-    readOwner(snapshot.status.path),
-    lstat(snapshot.status.path),
-  ]).catch((error: unknown) => {
-    if (isErrno(error, "ENOENT")) {
+    await dependencies.beforeRecoveryRemove?.();
+    const [owner, current] = await Promise.all([
+      readOwner(snapshot.status.path),
+      lstat(snapshot.status.path),
+    ]).catch((error: unknown) => {
+      if (isErrno(error, "ENOENT")) {
+        throw new LockRecoveryError("apply lock changed before recovery");
+      }
+      throw error;
+    });
+    if (
+      owner?.token !== snapshot.status.owner.token ||
+      current.dev !== snapshot.identity.dev ||
+      current.ino !== snapshot.identity.ino
+    ) {
       throw new LockRecoveryError("apply lock changed before recovery");
     }
-    throw error;
-  });
-  if (
-    owner?.token !== snapshot.status.owner.token ||
-    current.dev !== snapshot.identity.dev ||
-    current.ino !== snapshot.identity.ino
-  ) {
-    throw new LockRecoveryError("apply lock changed before recovery");
-  }
 
-  await rm(snapshot.status.path);
-  await syncDirectory(locksDirectory);
-  return snapshot.status.owner;
+    await rm(snapshot.status.path);
+    await syncDirectory(locksDirectory);
+    return snapshot.status.owner;
+  } finally {
+    await recoveryMutex.release();
+  }
 }
 
 export async function acquireApplyLock(

--- a/src/state/lock.ts
+++ b/src/state/lock.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
 import type { Stats } from "node:fs";
 import { lstat, mkdir, open, readFile, rm, type FileHandle } from "node:fs/promises";
 import { hostname } from "node:os";
@@ -102,58 +103,98 @@ async function readOwner(path: string): Promise<ApplyLockOwner | undefined> {
   }
 }
 
-async function acquireRecoveryMutex(locksDirectory: string): Promise<StateLock> {
+type RecoveryMutex = {
+  assertHeld(): void;
+  release(): Promise<void>;
+};
+
+async function acquireRecoveryMutex(locksDirectory: string): Promise<RecoveryMutex> {
   await mkdir(locksDirectory, { recursive: true, mode: 0o700 });
   const path = join(locksDirectory, "apply.recovery.lock");
-  const token = randomUUID();
-  let handle: FileHandle;
-  try {
-    handle = await open(path, "wx", 0o600);
-  } catch (error) {
-    if (isErrno(error, "EEXIST")) {
-      throw new LockRecoveryError("apply lock recovery is already in progress");
-    }
-    throw error;
+  const holdCommand = 'printf "agentrinse-recovery-lock\\n"; cat >/dev/null';
+  const command =
+    process.platform === "darwin" ? "lockf" : process.platform === "linux" ? "flock" : undefined;
+  if (command === undefined) {
+    throw new LockRecoveryError(`apply lock recovery is unsupported on ${process.platform}`);
   }
+  const args =
+    command === "lockf"
+      ? ["-k", "-s", "-t", "0", path, "sh", "-c", holdCommand]
+      : ["-n", path, "sh", "-c", holdCommand];
+  const child = spawn(command, args, { stdio: ["pipe", "pipe", "pipe"] });
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  let stderr = "";
+  let ready = false;
+  let released = false;
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  let stdout = "";
 
-  try {
-    await handle.writeFile(`${JSON.stringify({ token, pid: process.pid })}\n`, "utf8");
-    await handle.sync();
-    await syncDirectory(locksDirectory);
-    const identity = await handle.stat();
-    let released = false;
-
-    return {
-      path,
-      async release() {
-        if (released) {
-          return;
-        }
-        released = true;
-        await handle.close();
-        try {
-          const [raw, current] = await Promise.all([readFile(path, "utf8"), lstat(path)]);
-          const record = JSON.parse(raw) as { token?: unknown };
-          if (
-            record.token === token &&
-            current.dev === identity.dev &&
-            current.ino === identity.ino
-          ) {
-            await rm(path);
-            await syncDirectory(locksDirectory);
-          }
-        } catch (error) {
-          if (!isErrno(error, "ENOENT")) {
-            throw error;
-          }
+  const exit = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+    (resolve, reject) => {
+      child.once("error", reject);
+      child.once("exit", (code, signal) => resolve({ code, signal }));
+    },
+  );
+  await new Promise<void>((resolve, reject) => {
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+      if (!ready && stdout.includes("agentrinse-recovery-lock\n")) {
+        ready = true;
+        resolve();
+      }
+    });
+    void exit.then(
+      ({ code, signal }) => {
+        if (!ready) {
+          const detail = stderr.trim();
+          reject(
+            new LockRecoveryError(
+              code === 1 || code === 75
+                ? "apply lock recovery is already in progress"
+                : `could not acquire recovery mutex${detail === "" ? "" : `: ${detail}`}${
+                    signal === null ? "" : ` (${signal})`
+                  }`,
+            ),
+          );
         }
       },
-    };
-  } catch (error) {
-    await handle.close().catch(() => undefined);
-    await rm(path, { force: true }).catch(() => undefined);
-    throw error;
-  }
+      (error: unknown) => {
+        reject(
+          new LockRecoveryError(
+            `could not start ${command} for recovery mutex: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          ),
+        );
+      },
+    );
+  });
+
+  return {
+    assertHeld() {
+      if (released || child.exitCode !== null || child.signalCode !== null) {
+        throw new LockRecoveryError("apply lock recovery mutex was lost");
+      }
+    },
+    async release() {
+      if (released) {
+        return;
+      }
+      released = true;
+      child.stdin.end();
+      const result = await exit;
+      if (result.code !== 0) {
+        throw new LockRecoveryError(
+          `recovery mutex exited unexpectedly${
+            result.signal === null ? ` with code ${String(result.code)}` : ` (${result.signal})`
+          }`,
+        );
+      }
+    },
+  };
 }
 
 async function inspectLockSnapshot(
@@ -284,6 +325,7 @@ export async function recoverStaleApplyLock(
       throw new LockRecoveryError("apply lock changed before recovery");
     }
 
+    recoveryMutex.assertHeld();
     await rm(snapshot.status.path);
     await syncDirectory(locksDirectory);
     return snapshot.status.owner;

--- a/src/state/lock.ts
+++ b/src/state/lock.ts
@@ -1,12 +1,21 @@
 import { randomUUID } from "node:crypto";
+import type { Stats } from "node:fs";
 import { lstat, mkdir, open, readFile, rm, type FileHandle } from "node:fs/promises";
 import { hostname } from "node:os";
 import { join } from "node:path";
 
+import {
+  inspectProcessIdentity,
+  type ProcessIdentityInspection,
+} from "../core/process-identity.js";
 import { syncDirectory } from "./json-file.js";
 
 export class LockHeldError extends Error {
   override readonly name = "LockHeldError";
+}
+
+export class LockRecoveryError extends Error {
+  override readonly name = "LockRecoveryError";
 }
 
 export type StateLock = {
@@ -14,71 +23,251 @@ export type StateLock = {
   release(): Promise<void>;
 };
 
-type LockOwner = {
+export type ApplyLockOwner = {
   token: string;
   pid: number;
+  processStartIdentity?: string;
   hostname: string;
+  command: string;
   planId: string;
+  runId: string;
   createdAt: string;
 };
 
-async function readOwner(path: string): Promise<LockOwner | undefined> {
+export type ApplyLockStatus =
+  | { status: "absent"; path: string }
+  | { status: "malformed"; path: string; reason: string }
+  | { status: "active"; path: string; owner: ApplyLockOwner }
+  | { status: "stale"; path: string; owner: ApplyLockOwner; reason: string }
+  | { status: "remote"; path: string; owner: ApplyLockOwner; reason: string }
+  | { status: "unknown"; path: string; owner: ApplyLockOwner; reason: string };
+
+export type AcquireApplyLockOptions = {
+  planId: string;
+  runId: string;
+  command: string;
+};
+
+export type LockInspectionDependencies = {
+  currentHostname?: () => string;
+  inspectProcess?: (pid: number) => Promise<ProcessIdentityInspection>;
+  beforeRecoveryRemove?: () => Promise<void>;
+};
+
+type LockSnapshot = {
+  status: ApplyLockStatus;
+  identity?: Pick<Stats, "dev" | "ino">;
+};
+
+function isErrno(error: unknown, code: string): boolean {
+  return (
+    error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === code
+  );
+}
+
+function parseOwner(value: unknown): ApplyLockOwner | undefined {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("token" in value) ||
+    typeof value.token !== "string" ||
+    !("pid" in value) ||
+    typeof value.pid !== "number" ||
+    !Number.isSafeInteger(value.pid) ||
+    value.pid <= 0 ||
+    !("hostname" in value) ||
+    typeof value.hostname !== "string" ||
+    !("command" in value) ||
+    typeof value.command !== "string" ||
+    !("planId" in value) ||
+    typeof value.planId !== "string" ||
+    !("runId" in value) ||
+    typeof value.runId !== "string" ||
+    !("createdAt" in value) ||
+    typeof value.createdAt !== "string" ||
+    ("processStartIdentity" in value &&
+      value.processStartIdentity !== undefined &&
+      typeof value.processStartIdentity !== "string")
+  ) {
+    return undefined;
+  }
+  return value as ApplyLockOwner;
+}
+
+async function readOwner(path: string): Promise<ApplyLockOwner | undefined> {
   try {
-    const value: unknown = JSON.parse(await readFile(path, "utf8"));
-    if (
-      typeof value === "object" &&
-      value !== null &&
-      "token" in value &&
-      typeof value.token === "string" &&
-      "pid" in value &&
-      typeof value.pid === "number" &&
-      "hostname" in value &&
-      typeof value.hostname === "string" &&
-      "planId" in value &&
-      typeof value.planId === "string" &&
-      "createdAt" in value &&
-      typeof value.createdAt === "string"
-    ) {
-      return value as LockOwner;
-    }
+    return parseOwner(JSON.parse(await readFile(path, "utf8")) as unknown);
   } catch {
     return undefined;
   }
-  return undefined;
 }
 
-export async function acquireApplyLock(locksDirectory: string, planId: string): Promise<StateLock> {
+async function inspectLockSnapshot(
+  locksDirectory: string,
+  dependencies: LockInspectionDependencies = {},
+): Promise<LockSnapshot> {
+  const path = join(locksDirectory, "apply.lock");
+  let raw: string;
+  let identity: Stats;
+  try {
+    [raw, identity] = await Promise.all([readFile(path, "utf8"), lstat(path)]);
+  } catch (error) {
+    if (isErrno(error, "ENOENT")) {
+      return { status: { status: "absent", path } };
+    }
+    throw error;
+  }
+
+  let owner: ApplyLockOwner | undefined;
+  try {
+    owner = parseOwner(JSON.parse(raw) as unknown);
+  } catch {
+    owner = undefined;
+  }
+  if (owner === undefined) {
+    return {
+      status: { status: "malformed", path, reason: "lock record is not valid AgentRinse JSON" },
+      identity,
+    };
+  }
+
+  const localHostname = (dependencies.currentHostname ?? hostname)();
+  if (owner.hostname !== localHostname) {
+    return {
+      status: {
+        status: "remote",
+        path,
+        owner,
+        reason: `lock belongs to host ${owner.hostname}; local host is ${localHostname}`,
+      },
+      identity,
+    };
+  }
+
+  const processIdentity = await (dependencies.inspectProcess ?? inspectProcessIdentity)(owner.pid);
+  if (processIdentity.status === "dead") {
+    return {
+      status: {
+        status: "stale",
+        path,
+        owner,
+        reason: `recorded process ${owner.pid} no longer exists`,
+      },
+      identity,
+    };
+  }
+  if (processIdentity.status === "unknown") {
+    return {
+      status: {
+        status: "unknown",
+        path,
+        owner,
+        reason: processIdentity.reason,
+      },
+      identity,
+    };
+  }
+  if (owner.processStartIdentity === undefined) {
+    return {
+      status: {
+        status: "unknown",
+        path,
+        owner,
+        reason: `lock has no process start identity for live PID ${owner.pid}`,
+      },
+      identity,
+    };
+  }
+  if (owner.processStartIdentity !== processIdentity.identity) {
+    return {
+      status: {
+        status: "stale",
+        path,
+        owner,
+        reason: `PID ${owner.pid} was reused by a different process`,
+      },
+      identity,
+    };
+  }
+  return { status: { status: "active", path, owner }, identity };
+}
+
+export async function inspectApplyLock(
+  locksDirectory: string,
+  dependencies: LockInspectionDependencies = {},
+): Promise<ApplyLockStatus> {
+  return (await inspectLockSnapshot(locksDirectory, dependencies)).status;
+}
+
+export async function recoverStaleApplyLock(
+  locksDirectory: string,
+  dependencies: LockInspectionDependencies = {},
+): Promise<ApplyLockOwner> {
+  const snapshot = await inspectLockSnapshot(locksDirectory, dependencies);
+  if (snapshot.status.status !== "stale" || snapshot.identity === undefined) {
+    throw new LockRecoveryError(
+      `apply lock is ${snapshot.status.status}; recovery requires a proven stale local owner`,
+    );
+  }
+
+  await dependencies.beforeRecoveryRemove?.();
+  const [owner, current] = await Promise.all([
+    readOwner(snapshot.status.path),
+    lstat(snapshot.status.path),
+  ]).catch((error: unknown) => {
+    if (isErrno(error, "ENOENT")) {
+      throw new LockRecoveryError("apply lock changed before recovery");
+    }
+    throw error;
+  });
+  if (
+    owner?.token !== snapshot.status.owner.token ||
+    current.dev !== snapshot.identity.dev ||
+    current.ino !== snapshot.identity.ino
+  ) {
+    throw new LockRecoveryError("apply lock changed before recovery");
+  }
+
+  await rm(snapshot.status.path);
+  await syncDirectory(locksDirectory);
+  return snapshot.status.owner;
+}
+
+export async function acquireApplyLock(
+  locksDirectory: string,
+  options: AcquireApplyLockOptions,
+): Promise<StateLock> {
   await mkdir(locksDirectory, { recursive: true, mode: 0o700 });
   const path = join(locksDirectory, "apply.lock");
   const token = randomUUID();
+  const processIdentity = await inspectProcessIdentity(process.pid);
+  const owner: ApplyLockOwner = {
+    token,
+    pid: process.pid,
+    ...(processIdentity.status === "alive"
+      ? { processStartIdentity: processIdentity.identity }
+      : {}),
+    hostname: hostname(),
+    command: options.command,
+    planId: options.planId,
+    runId: options.runId,
+    createdAt: new Date().toISOString(),
+  };
 
   let handle: FileHandle;
   try {
     handle = await open(path, "wx", 0o600);
   } catch (error) {
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      (error as NodeJS.ErrnoException).code === "EEXIST"
-    ) {
+    if (isErrno(error, "EEXIST")) {
       throw new LockHeldError(
-        `apply lock exists at ${path}; verify its recorded process before removing a stale lock`,
+        `apply lock exists at ${path}; inspect it with "agentrinse lock status"`,
       );
     }
     throw error;
   }
 
   try {
-    await handle.writeFile(
-      `${JSON.stringify({
-        token,
-        pid: process.pid,
-        hostname: hostname(),
-        planId,
-        createdAt: new Date().toISOString(),
-      })}\n`,
-      "utf8",
-    );
+    await handle.writeFile(`${JSON.stringify(owner)}\n`, "utf8");
     await handle.sync();
     await syncDirectory(locksDirectory);
     const identity = await handle.stat();
@@ -94,9 +283,9 @@ export async function acquireApplyLock(locksDirectory: string, planId: string): 
         await handle.close();
 
         try {
-          const [owner, current] = await Promise.all([readOwner(path), lstat(path)]);
+          const [currentOwner, current] = await Promise.all([readOwner(path), lstat(path)]);
           if (
-            owner?.token === token &&
+            currentOwner?.token === token &&
             current.dev === identity.dev &&
             current.ino === identity.ino
           ) {
@@ -104,13 +293,7 @@ export async function acquireApplyLock(locksDirectory: string, planId: string): 
             await syncDirectory(locksDirectory);
           }
         } catch (error) {
-          if (
-            !(
-              error instanceof Error &&
-              "code" in error &&
-              (error as NodeJS.ErrnoException).code === "ENOENT"
-            )
-          ) {
+          if (!isErrno(error, "ENOENT")) {
             throw error;
           }
         }

--- a/src/state/records.ts
+++ b/src/state/records.ts
@@ -1,5 +1,5 @@
 import { readdir } from "node:fs/promises";
-import { isAbsolute, resolve, sep } from "node:path";
+import { isAbsolute, resolve } from "node:path";
 
 import type { ZodType } from "zod";
 
@@ -34,7 +34,15 @@ export async function readJsonRecord<T>(
   idOrPath: string,
   schema: ZodType<T>,
 ): Promise<T> {
-  const explicitPath = isAbsolute(idOrPath) || idOrPath.includes(sep);
-  const path = explicitPath ? resolve(idOrPath) : resolve(directory, `${idOrPath}.json`);
+  const path = resolveJsonRecordPath(directory, idOrPath);
   return schema.parse(await readJsonFile(path));
+}
+
+export function resolveJsonRecordPath(directory: string, idOrPath: string): string {
+  const explicitPath =
+    isAbsolute(idOrPath) ||
+    idOrPath.endsWith(".json") ||
+    idOrPath.includes("/") ||
+    idOrPath.includes("\\");
+  return explicitPath ? resolve(idOrPath) : resolve(directory, `${idOrPath}.json`);
 }

--- a/src/state/records.ts
+++ b/src/state/records.ts
@@ -1,0 +1,40 @@
+import { readdir } from "node:fs/promises";
+import { isAbsolute, resolve, sep } from "node:path";
+
+import type { ZodType } from "zod";
+
+import { readJsonFile } from "./json-file.js";
+
+function isMissing(error: unknown): boolean {
+  return (
+    error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}
+
+export async function listJsonRecords<T>(directory: string, schema: ZodType<T>): Promise<T[]> {
+  let names: string[];
+  try {
+    names = await readdir(directory);
+  } catch (error) {
+    if (isMissing(error)) {
+      return [];
+    }
+    throw error;
+  }
+
+  const records: T[] = [];
+  for (const name of names.filter((entry) => entry.endsWith(".json")).sort()) {
+    records.push(schema.parse(await readJsonFile(resolve(directory, name))));
+  }
+  return records;
+}
+
+export async function readJsonRecord<T>(
+  directory: string,
+  idOrPath: string,
+  schema: ZodType<T>,
+): Promise<T> {
+  const explicitPath = isAbsolute(idOrPath) || idOrPath.includes(sep);
+  const path = explicitPath ? resolve(idOrPath) : resolve(directory, `${idOrPath}.json`);
+  return schema.parse(await readJsonFile(path));
+}

--- a/src/state/run-journal.ts
+++ b/src/state/run-journal.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 
 import type { CleanupPlan } from "../contracts/plan.js";
 import type { Diagnostic } from "../contracts/diagnostic.js";
@@ -35,7 +35,7 @@ export async function createRunJournal(
     diagnostics: [],
   });
   const path = join(runsDirectory, `${run.runId}.json`);
-  const privateDirectories = [dirname(runsDirectory), runsDirectory];
+  const privateDirectories = [runsDirectory];
   await writeJsonAtomic(path, run, { privateDirectories });
 
   const persist = async (): Promise<CleanupRun> => {

--- a/src/state/run-journal.ts
+++ b/src/state/run-journal.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import type { CleanupPlan } from "../contracts/plan.js";
 import type { Diagnostic } from "../contracts/diagnostic.js";
@@ -35,11 +35,12 @@ export async function createRunJournal(
     diagnostics: [],
   });
   const path = join(runsDirectory, `${run.runId}.json`);
-  await writeJsonAtomic(path, run);
+  const privateDirectories = [dirname(runsDirectory), runsDirectory];
+  await writeJsonAtomic(path, run, { privateDirectories });
 
   const persist = async (): Promise<CleanupRun> => {
     run = cleanupRunSchema.parse(run);
-    await writeJsonAtomic(path, run);
+    await writeJsonAtomic(path, run, { privateDirectories });
     return structuredClone(run);
   };
 

--- a/src/state/run-journal.ts
+++ b/src/state/run-journal.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 
 import type { CleanupPlan } from "../contracts/plan.js";
+import type { Diagnostic } from "../contracts/diagnostic.js";
 import { cleanupRunSchema, type ActionExecution, type CleanupRun } from "../contracts/run.js";
 import { writeJsonAtomic } from "./json-file.js";
 
@@ -10,6 +11,7 @@ export type RunJournal = {
   snapshot(): CleanupRun;
   updateAction(actionId: string, patch: Partial<ActionExecution>): Promise<CleanupRun>;
   complete(completedAt?: Date): Promise<CleanupRun>;
+  interrupt(diagnostic: Diagnostic, completedAt?: Date): Promise<CleanupRun>;
 };
 
 export async function createRunJournal(
@@ -73,6 +75,15 @@ export async function createRunJournal(
         ...run,
         completedAt: completedAt.toISOString(),
         status: failed === 0 ? "completed" : applied > 0 ? "partial" : "failed",
+      };
+      return persist();
+    },
+    async interrupt(diagnostic, completedAt = new Date()) {
+      run = {
+        ...run,
+        completedAt: completedAt.toISOString(),
+        status: "interrupted",
+        diagnostics: [...run.diagnostics, diagnostic],
       };
       return persist();
     },

--- a/src/state/run-journal.ts
+++ b/src/state/run-journal.ts
@@ -84,6 +84,10 @@ export async function createRunJournal(
         ...run,
         completedAt: completedAt.toISOString(),
         status: "interrupted",
+        reclaimedBytes: run.actions.reduce(
+          (total, action) => total + (action.reclaimedBytes ?? 0),
+          0,
+        ),
         diagnostics: [...run.diagnostics, diagnostic],
       };
       return persist();

--- a/src/state/run-journal.ts
+++ b/src/state/run-journal.ts
@@ -16,10 +16,11 @@ export async function createRunJournal(
   runsDirectory: string,
   plan: CleanupPlan,
   startedAt = new Date(),
+  runId: string = randomUUID(),
 ): Promise<RunJournal> {
   let run = cleanupRunSchema.parse({
     schemaVersion: 1,
-    runId: randomUUID(),
+    runId,
     planId: plan.planId,
     startedAt: startedAt.toISOString(),
     status: "running",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.0.0";
+export const VERSION = "0.1.0";

--- a/test/commands/apply.test.ts
+++ b/test/commands/apply.test.ts
@@ -10,6 +10,7 @@ import type { CleanupPlan } from "../../src/contracts/plan.js";
 import { sha256Json } from "../../src/core/digest.js";
 import { measurePath } from "../../src/core/measure.js";
 import { cleanupPlanId } from "../../src/core/plan.js";
+import { assertDestructiveFixtureRoot } from "../../src/core/safety.js";
 import { writeJsonAtomic } from "../../src/state/json-file.js";
 
 describe("executeApplyCommand", () => {
@@ -25,6 +26,7 @@ describe("executeApplyCommand", () => {
 
   it("refuses mutation in the reservation release", async () => {
     const home = await realpath(await mkdtemp(join(tmpdir(), "agentrinse-command-")));
+    await assertDestructiveFixtureRoot(home);
     const project = join(home, "project");
     const target = join(project, "node_modules");
     const stateDir = join(home, "state");

--- a/test/commands/apply.test.ts
+++ b/test/commands/apply.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, realpath, stat, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, realpath, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -24,7 +24,7 @@ describe("executeApplyCommand", () => {
     ).rejects.toThrow("apply --json requires --yes");
   });
 
-  it("refuses mutation in the reservation release", async () => {
+  it("applies an exact guarded artifact plan and preserves project source", async () => {
     const home = await realpath(await mkdtemp(join(tmpdir(), "agentrinse-command-")));
     await assertDestructiveFixtureRoot(home);
     const project = join(home, "project");
@@ -33,6 +33,7 @@ describe("executeApplyCommand", () => {
     const configPath = join(home, "config.json");
     const planPath = join(home, "plan.json");
     await mkdir(target, { recursive: true });
+    await writeFile(join(project, "source.ts"), "keep");
     await writeFile(join(target, "cache.bin"), "remove");
     const stats = await stat(target);
     const measurement = await measurePath(target, { maxEntries: 100 });
@@ -85,16 +86,19 @@ describe("executeApplyCommand", () => {
       planId: cleanupPlanId(content),
     });
 
-    await expect(
-      executeApplyCommand({
-        plan: planPath,
-        config: configPath,
-        stateDir,
-        yes: true,
-        json: true,
-      }),
-    ).rejects.toThrow("apply is unavailable in the unsupported 0.0.0 reservation release");
+    const result = await executeApplyCommand({
+      plan: planPath,
+      config: configPath,
+      stateDir,
+      yes: true,
+      json: true,
+    });
 
-    await expect(stat(target)).resolves.toBeDefined();
+    expect(result.run.status).toBe("completed");
+    expect(result.run.actions[0]?.status).toBe("applied");
+    expect(JSON.parse(result.output)).toEqual(result.run);
+    await expect(access(target)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(join(project, "source.ts"), "utf8")).resolves.toBe("keep");
+    await expect(readFile(result.journalPath, "utf8")).resolves.toContain('"status": "completed"');
   });
 });

--- a/test/commands/apply.test.ts
+++ b/test/commands/apply.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { executeApplyCommand } from "../../src/commands/apply.js";
+import { confirmApply, executeApplyCommand } from "../../src/commands/apply.js";
 import { DEFAULT_CONFIG } from "../../src/config/defaults.js";
 import type { CleanupPlan } from "../../src/contracts/plan.js";
 import { sha256Json } from "../../src/core/digest.js";
@@ -14,6 +14,21 @@ import { assertDestructiveFixtureRoot } from "../../src/core/safety.js";
 import { writeJsonAtomic } from "../../src/state/json-file.js";
 
 describe("executeApplyCommand", () => {
+  it("propagates cancellation into interactive confirmation", async () => {
+    const controller = new AbortController();
+
+    await expect(
+      confirmApply(1, controller.signal, {
+        isInteractive: () => true,
+        question: async (_prompt, signal) => {
+          expect(signal).toBe(controller.signal);
+          controller.abort(new Error("interrupted by SIGINT"));
+          throw Object.assign(new Error("question aborted"), { name: "AbortError" });
+        },
+      }),
+    ).rejects.toMatchObject({ name: "CommandInterruptedError" });
+  });
+
   it("requires --yes before entering JSON mode", async () => {
     await expect(
       executeApplyCommand({

--- a/test/commands/audit-output.test.ts
+++ b/test/commands/audit-output.test.ts
@@ -1,0 +1,74 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { executeAuditCommand } from "../../src/commands/audit.js";
+import { commandEnvelopeSchema, commandEventSchema } from "../../src/contracts/output.js";
+import { auditReportSchema } from "../../src/contracts/report.js";
+
+describe("audit machine output", () => {
+  it("wraps JSON output while persisting the exact report", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-audit-output-"));
+    const stateDir = await mkdtemp(join(tmpdir(), "agentrinse-audit-state-"));
+    const result = await executeAuditCommand({
+      home,
+      stateDir,
+      json: true,
+      now: () => new Date("2026-07-24T00:00:00.000Z"),
+    });
+    const envelope = commandEnvelopeSchema.parse(JSON.parse(result.output));
+    const stored = auditReportSchema.parse(JSON.parse(await readFile(result.statePath, "utf8")));
+
+    expect(envelope.command).toBe("audit");
+    expect(envelope.data).toEqual(result.report);
+    expect(stored).toEqual(result.report);
+  });
+
+  it("emits ordered NDJSON lifecycle records", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-audit-output-"));
+    const stateDir = await mkdtemp(join(tmpdir(), "agentrinse-audit-state-"));
+    const result = await executeAuditCommand({
+      home,
+      stateDir,
+      ndjson: true,
+      now: () => new Date("2026-07-24T00:00:00.000Z"),
+    });
+    const events = result.output
+      .trim()
+      .split("\n")
+      .map((line) => commandEventSchema.parse(JSON.parse(line)));
+
+    expect(events[0]?.event).toBe("command.started");
+    expect(events.at(-1)?.event).toBe("command.completed");
+    expect(events.map((event) => event.sequence)).toEqual(events.map((_, index) => index + 1));
+    expect(new Set(events.map((event) => event.commandId)).size).toBe(1);
+  });
+
+  it("redacts stdout without changing persisted evidence", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-private-home-"));
+    const stateDir = await mkdtemp(join(tmpdir(), "agentrinse-audit-state-"));
+    const result = await executeAuditCommand({
+      home,
+      stateDir,
+      json: true,
+      redact: true,
+      now: () => new Date("2026-07-24T00:00:00.000Z"),
+    });
+
+    expect(result.output).not.toContain(home);
+    expect(await readFile(result.statePath, "utf8")).toContain(home);
+  });
+
+  it("rejects ambiguous or non-machine redaction modes", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-audit-output-"));
+
+    await expect(executeAuditCommand({ home, json: true, ndjson: true })).rejects.toThrow(
+      "only one",
+    );
+    await expect(executeAuditCommand({ home, redact: true })).rejects.toThrow(
+      "requires --json or --ndjson",
+    );
+  });
+});

--- a/test/commands/audit-output.test.ts
+++ b/test/commands/audit-output.test.ts
@@ -61,6 +61,31 @@ describe("audit machine output", () => {
     expect(await readFile(result.statePath, "utf8")).toContain(home);
   });
 
+  it("emits a failed terminal NDJSON event when persistence fails", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-audit-output-"));
+    const stateDir = await mkdtemp(join(tmpdir(), "agentrinse-audit-state-"));
+    const records: string[] = [];
+
+    await expect(
+      executeAuditCommand({
+        home,
+        stateDir,
+        output: stateDir,
+        ndjson: true,
+        now: () => new Date("2026-07-24T00:00:00.000Z"),
+        emit: (record) => records.push(record),
+      }),
+    ).rejects.toThrow();
+
+    const events = records.map((record) => commandEventSchema.parse(JSON.parse(record)));
+    expect(events[0]?.event).toBe("command.started");
+    expect(events.at(-1)).toMatchObject({
+      event: "command.completed",
+      data: { status: "failed" },
+    });
+    expect(events.map((event) => event.sequence)).toEqual(events.map((_, index) => index + 1));
+  });
+
   it("rejects ambiguous or non-machine redaction modes", async () => {
     const home = await mkdtemp(join(tmpdir(), "agentrinse-audit-output-"));
 

--- a/test/commands/audit-plan-state.test.ts
+++ b/test/commands/audit-plan-state.test.ts
@@ -1,0 +1,32 @@
+import { access, mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { executeAuditCommand } from "../../src/commands/audit.js";
+import { executePlanCommand } from "../../src/commands/plan.js";
+
+describe("audit and plan state persistence", () => {
+  it("stores validated audit and plan records under the selected state root", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-audit-state-home-"));
+    const stateDir = await mkdtemp(join(tmpdir(), "agentrinse-audit-state-"));
+    const auditOutput = join(stateDir, "audit-output.json");
+
+    const audit = await executeAuditCommand({
+      home,
+      json: true,
+      output: auditOutput,
+      stateDir,
+    });
+    await access(audit.statePath);
+
+    const plan = await executePlanCommand({
+      audit: auditOutput,
+      stateDir,
+    });
+    await access(plan.statePath);
+
+    expect(plan.plan.auditId).toBe(audit.report.auditId);
+  });
+});

--- a/test/commands/completion.test.ts
+++ b/test/commands/completion.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { renderCompletion } from "../../src/commands/completion.js";
+
+describe("completion command", () => {
+  it.each([
+    ["bash", "complete -F _agentrinse_completion agentrinse"],
+    ["zsh", "#compdef agentrinse"],
+    ["fish", "complete -c agentrinse"],
+  ])("generates %s completion", (shell, marker) => {
+    const output = renderCompletion(shell);
+
+    expect(output).toContain(marker);
+    expect(output).toContain("audit");
+    expect(output).toContain("doctor");
+    expect(output).toContain("recover");
+    expect(output).toContain("resource");
+  });
+
+  it("rejects unsupported shells", () => {
+    expect(() => renderCompletion("powershell")).toThrow("expected bash, zsh, or fish");
+  });
+});

--- a/test/commands/config.test.ts
+++ b/test/commands/config.test.ts
@@ -1,0 +1,57 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  executeConfigInitCommand,
+  executeConfigPathCommand,
+  executeConfigShowCommand,
+  executeConfigValidateCommand,
+} from "../../src/commands/config.js";
+
+describe("config commands", () => {
+  it("resolves, initializes, shows, and validates the default path", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-config-command-"));
+    const expectedPath = join(home, ".config", "agentrinse", "config.json");
+
+    expect(executeConfigPathCommand({ home, environment: {} }).path).toBe(expectedPath);
+
+    const initialized = await executeConfigInitCommand({ home, environment: {} });
+    expect(initialized.path).toBe(expectedPath);
+    expect(initialized.output).toBe(`created ${expectedPath}\n`);
+
+    const stored = JSON.parse(await readFile(expectedPath, "utf8"));
+    expect(stored).toMatchObject({
+      schemaVersion: 1,
+      artifacts: { projects: [] },
+    });
+
+    const shown = await executeConfigShowCommand({ home, environment: {} });
+    expect(shown.config).toEqual(stored);
+    expect(JSON.parse(shown.output)).toEqual(stored);
+
+    const validated = await executeConfigValidateCommand({ home, environment: {} });
+    expect(validated.output).toBe(`valid ${expectedPath}\n`);
+  });
+
+  it("never overwrites an existing config", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-config-command-"));
+    await executeConfigInitCommand({ home, environment: {} });
+
+    await expect(executeConfigInitCommand({ home, environment: {} })).rejects.toMatchObject({
+      code: "EEXIST",
+    });
+  });
+
+  it("shows safe defaults when the default path does not exist", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-config-command-"));
+    const shown = await executeConfigShowCommand({ home, environment: {} });
+
+    expect(shown.config).toMatchObject({
+      schemaVersion: 1,
+      artifacts: { projects: [] },
+    });
+  });
+});

--- a/test/commands/doctor.test.ts
+++ b/test/commands/doctor.test.ts
@@ -159,6 +159,50 @@ describe("doctor command", () => {
     );
   });
 
+  it("reports lock inspection failures instead of aborting doctor", async () => {
+    const value = await setup();
+    const layout = stateLayout(value.stateRoot);
+    await mkdir(layout.locks, { recursive: true });
+    const owner: ApplyLockOwner = {
+      token: "fixture-token",
+      pid: 42,
+      processStartIdentity: "fixture-start",
+      hostname: "fixture-host",
+      command: "agentrinse apply",
+      planId: "plan-1",
+      runId: "run-1",
+      createdAt: "2026-07-23T00:00:00.000Z",
+    };
+    await writeFile(join(layout.locks, "apply.lock"), `${JSON.stringify(owner)}\n`);
+
+    const result = await executeDoctorCommand({
+      home: value.home,
+      config: value.configPath,
+      stateDir: value.stateRoot,
+      json: false,
+      dependencies: {
+        platform: "darwin",
+        runCommand: healthyRunner,
+        lock: {
+          currentHostname: () => "fixture-host",
+          inspectProcess: async () => {
+            throw commandError("permission denied", "EACCES");
+          },
+        },
+      },
+    });
+
+    expect(result.report.status).toBe("error");
+    expect(result.report.checks).toContainEqual(
+      expect.objectContaining({
+        id: "apply-lock",
+        status: "error",
+        summary: "apply lock could not be inspected",
+        detail: "permission denied",
+      }),
+    );
+  });
+
   it("proves Git worktree porcelain when the adapter is enabled", async () => {
     const value = await setup();
     await writeJsonAtomic(value.configPath, {

--- a/test/commands/doctor.test.ts
+++ b/test/commands/doctor.test.ts
@@ -23,6 +23,7 @@ function healthyRunner(command: string, args: string[]): Promise<CommandResult> 
     "docker context show": "desktop-linux",
     "docker version --format {{.Server.Version}}": "28.3.0",
     "mo --version": "Mole 1.17.0",
+    "sh -c command -v lockf": "/usr/bin/lockf",
   };
   const stdout = output[key];
   return stdout === undefined
@@ -61,6 +62,9 @@ describe("doctor command", () => {
     expect(result.output).toContain("AgentRinse doctor: ok");
     expect(result.report.checks).toContainEqual(
       expect.objectContaining({ id: "process-ownership", status: "pass" }),
+    );
+    expect(result.report.checks).toContainEqual(
+      expect.objectContaining({ id: "recovery-mutex", status: "pass" }),
     );
     expect(result.report.checks).toContainEqual(
       expect.objectContaining({ id: "docker", status: "pass" }),
@@ -143,6 +147,9 @@ describe("doctor command", () => {
     );
     expect(result.report.checks).toContainEqual(
       expect.objectContaining({ id: "git", status: "error" }),
+    );
+    expect(result.report.checks).toContainEqual(
+      expect.objectContaining({ id: "recovery-mutex", status: "error" }),
     );
     expect(result.report.checks).toContainEqual(
       expect.objectContaining({ id: "docker", status: "pass" }),

--- a/test/commands/doctor.test.ts
+++ b/test/commands/doctor.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -24,6 +24,7 @@ function healthyRunner(command: string, args: string[]): Promise<CommandResult> 
     "docker version --format {{.Server.Version}}": "28.3.0",
     "mo --version": "Mole 1.17.0",
     "sh -c command -v lockf": "/usr/bin/lockf",
+    "sh -c command -v flock": "/usr/bin/flock",
   };
   const stdout = output[key];
   return stdout === undefined
@@ -200,6 +201,64 @@ describe("doctor command", () => {
         summary: "apply lock could not be inspected",
         detail: "permission denied",
       }),
+    );
+  });
+
+  it("uses lsof when Linux procfs ownership proof is unavailable", async () => {
+    const value = await setup();
+    const result = await executeDoctorCommand({
+      home: value.home,
+      config: value.configPath,
+      stateDir: value.stateRoot,
+      json: false,
+      dependencies: {
+        platform: "linux",
+        runCommand: healthyRunner,
+        readProcessStat: async () => {
+          throw commandError("procfs unavailable", "EACCES");
+        },
+      },
+    });
+
+    expect(result.report.checks).toContainEqual(
+      expect.objectContaining({
+        id: "process-ownership",
+        status: "pass",
+        summary: "lsof fallback ownership proof is available",
+      }),
+    );
+  });
+
+  it("rejects directories without search permission", async () => {
+    const value = await setup();
+    const project = join(value.home, "project");
+    await mkdir(value.stateRoot, { recursive: true });
+    await mkdir(project);
+    await chmod(value.stateRoot, 0o600);
+    await chmod(project, 0o600);
+    await writeJsonAtomic(value.configPath, {
+      ...structuredClone(DEFAULT_CONFIG),
+      artifacts: {
+        projects: [{ root: project, names: ["node_modules"] }],
+      },
+    });
+
+    const result = await executeDoctorCommand({
+      home: value.home,
+      config: value.configPath,
+      stateDir: value.stateRoot,
+      json: false,
+      dependencies: {
+        platform: "darwin",
+        runCommand: healthyRunner,
+      },
+    });
+
+    expect(result.report.checks).toContainEqual(
+      expect.objectContaining({ id: "state", status: "error" }),
+    );
+    expect(result.report.checks).toContainEqual(
+      expect.objectContaining({ id: "artifact-root:0", status: "error" }),
     );
   });
 

--- a/test/commands/doctor.test.ts
+++ b/test/commands/doctor.test.ts
@@ -289,6 +289,30 @@ describe("doctor command", () => {
     );
   });
 
+  it("rejects an existing state root owned by another UID", async () => {
+    const value = await setup();
+    await mkdir(value.stateRoot, { recursive: true });
+    const result = await executeDoctorCommand({
+      home: value.home,
+      config: value.configPath,
+      stateDir: value.stateRoot,
+      json: false,
+      dependencies: {
+        platform: "darwin",
+        runCommand: healthyRunner,
+        currentUid: () => Number.MAX_SAFE_INTEGER,
+      },
+    });
+
+    expect(result.report.checks).toContainEqual(
+      expect.objectContaining({
+        id: "state",
+        status: "error",
+        summary: "state directory is not owned by the current user",
+      }),
+    );
+  });
+
   it("proves Git worktree porcelain when the adapter is enabled", async () => {
     const value = await setup();
     await writeJsonAtomic(value.configPath, {

--- a/test/commands/doctor.test.ts
+++ b/test/commands/doctor.test.ts
@@ -1,0 +1,184 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { executeDoctorCommand, type CommandResult } from "../../src/commands/doctor.js";
+import { DEFAULT_CONFIG } from "../../src/config/defaults.js";
+import { writeJsonAtomic } from "../../src/state/json-file.js";
+import { stateLayout } from "../../src/state/layout.js";
+import type { ApplyLockOwner } from "../../src/state/lock.js";
+
+function commandError(message: string, code = "ENOENT"): Error {
+  return Object.assign(new Error(message), { code });
+}
+
+function healthyRunner(command: string, args: string[]): Promise<CommandResult> {
+  const key = `${command} ${args.join(" ")}`;
+  const output: Record<string, string> = {
+    "lsof -v": "lsof 4.99",
+    "git --version": "git version 2.50.1",
+    "docker --version": "Docker version 28.3.0",
+    "docker context show": "desktop-linux",
+    "docker version --format {{.Server.Version}}": "28.3.0",
+    "mo --version": "Mole 1.17.0",
+  };
+  const stdout = output[key];
+  return stdout === undefined
+    ? Promise.reject(commandError(`unexpected command: ${key}`))
+    : Promise.resolve({ stdout: `${stdout}\n`, stderr: "" });
+}
+
+async function setup(): Promise<{
+  home: string;
+  configPath: string;
+  stateRoot: string;
+}> {
+  const home = await mkdtemp(join(tmpdir(), "agentrinse-doctor-"));
+  const configPath = join(home, "config.json");
+  const stateRoot = join(home, "state", "agentrinse");
+  await writeJsonAtomic(configPath, DEFAULT_CONFIG);
+  return { home, configPath, stateRoot };
+}
+
+describe("doctor command", () => {
+  it("reports a healthy synthetic environment without mutation", async () => {
+    const value = await setup();
+    const result = await executeDoctorCommand({
+      home: value.home,
+      config: value.configPath,
+      stateDir: value.stateRoot,
+      json: false,
+      dependencies: {
+        platform: "darwin",
+        now: () => new Date("2026-07-24T00:00:00.000Z"),
+        runCommand: healthyRunner,
+      },
+    });
+
+    expect(result.report.status).toBe("ok");
+    expect(result.output).toContain("AgentRinse doctor: ok");
+    expect(result.report.checks).toContainEqual(
+      expect.objectContaining({ id: "process-ownership", status: "pass" }),
+    );
+    expect(result.report.checks).toContainEqual(
+      expect.objectContaining({ id: "docker", status: "pass" }),
+    );
+  });
+
+  it("isolates invalid config, Docker failure, stale lock, and schema drift", async () => {
+    const value = await setup();
+    await writeFile(value.configPath, '{"schemaVersion":2}\n');
+    const layout = stateLayout(value.stateRoot);
+    await mkdir(layout.locks, { recursive: true });
+    const owner: ApplyLockOwner = {
+      token: "fixture-token",
+      pid: 42,
+      processStartIdentity: "fixture-start",
+      hostname: "fixture-host",
+      command: "agentrinse apply",
+      planId: "plan-1",
+      runId: "run-1",
+      createdAt: "2026-07-23T00:00:00.000Z",
+    };
+    await writeFile(join(layout.locks, "apply.lock"), `${JSON.stringify(owner)}\n`);
+    await mkdir(layout.runs, { recursive: true });
+    await writeFile(join(layout.runs, "broken.json"), '{"schemaVersion":99}\n');
+
+    const result = await executeDoctorCommand({
+      home: value.home,
+      config: value.configPath,
+      stateDir: value.stateRoot,
+      json: true,
+      dependencies: {
+        platform: "darwin",
+        runCommand: async (command, args) => {
+          if (command === "docker") {
+            throw commandError("daemon unavailable", "ECONNREFUSED");
+          }
+          return healthyRunner(command, args);
+        },
+        lock: {
+          currentHostname: () => "fixture-host",
+          inspectProcess: async () => ({ status: "dead" }),
+        },
+      },
+    });
+
+    expect(result.report.status).toBe("error");
+    expect(JSON.parse(result.output)).toEqual(result.report);
+    expect(result.report.checks).toContainEqual(
+      expect.objectContaining({ id: "config", status: "error" }),
+    );
+    expect(result.report.checks).toContainEqual(
+      expect.objectContaining({ id: "docker", status: "pass" }),
+    );
+    expect(result.report.checks).toContainEqual(
+      expect.objectContaining({ id: "apply-lock", status: "warning" }),
+    );
+    expect(result.report.checks).toContainEqual(
+      expect.objectContaining({ id: "schema:runs", status: "error" }),
+    );
+  });
+
+  it("flags missing lsof and Git while treating optional tools as isolated", async () => {
+    const value = await setup();
+    const result = await executeDoctorCommand({
+      home: value.home,
+      config: value.configPath,
+      stateDir: value.stateRoot,
+      json: false,
+      dependencies: {
+        platform: "darwin",
+        runCommand: async (command) => {
+          throw commandError(`${command} unavailable`);
+        },
+      },
+    });
+
+    expect(result.report.status).toBe("error");
+    expect(result.report.checks).toContainEqual(
+      expect.objectContaining({ id: "process-ownership", status: "error" }),
+    );
+    expect(result.report.checks).toContainEqual(
+      expect.objectContaining({ id: "git", status: "error" }),
+    );
+    expect(result.report.checks).toContainEqual(
+      expect.objectContaining({ id: "docker", status: "pass" }),
+    );
+    expect(result.report.checks).toContainEqual(
+      expect.objectContaining({ id: "mole", status: "pass" }),
+    );
+  });
+
+  it("proves Git worktree porcelain when the adapter is enabled", async () => {
+    const value = await setup();
+    await writeJsonAtomic(value.configPath, {
+      ...structuredClone(DEFAULT_CONFIG),
+      adapters: {
+        ...structuredClone(DEFAULT_CONFIG.adapters),
+        git: { enabled: true, root: value.home },
+      },
+    });
+    const result = await executeDoctorCommand({
+      home: value.home,
+      config: value.configPath,
+      stateDir: value.stateRoot,
+      json: false,
+      dependencies: {
+        platform: "darwin",
+        runCommand: async (command, args) => {
+          if (command === "git" && args.includes("worktree")) {
+            return { stdout: `worktree ${value.home}\0`, stderr: "" };
+          }
+          return healthyRunner(command, args);
+        },
+      },
+    });
+
+    expect(result.report.checks).toContainEqual(
+      expect.objectContaining({ id: "git:porcelain", status: "pass" }),
+    );
+  });
+});

--- a/test/commands/doctor.test.ts
+++ b/test/commands/doctor.test.ts
@@ -160,6 +160,33 @@ describe("doctor command", () => {
     );
   });
 
+  it("passes when an installed Docker CLI has no daemon and its adapter is disabled", async () => {
+    const value = await setup();
+    const result = await executeDoctorCommand({
+      home: value.home,
+      config: value.configPath,
+      stateDir: value.stateRoot,
+      json: false,
+      dependencies: {
+        platform: "darwin",
+        runCommand: async (command, args) => {
+          if (command === "docker" && args[0] !== "--version") {
+            throw commandError("daemon unavailable", "ECONNREFUSED");
+          }
+          return healthyRunner(command, args);
+        },
+      },
+    });
+
+    expect(result.report.checks).toContainEqual(
+      expect.objectContaining({
+        id: "docker",
+        status: "pass",
+        summary: "Docker daemon is unavailable (optional)",
+      }),
+    );
+  });
+
   it("reports lock inspection failures instead of aborting doctor", async () => {
     const value = await setup();
     const layout = stateLayout(value.stateRoot);

--- a/test/commands/history.test.ts
+++ b/test/commands/history.test.ts
@@ -1,0 +1,62 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { executeHistoryCommand } from "../../src/commands/history.js";
+import type { CleanupRun } from "../../src/contracts/run.js";
+import { writeJsonAtomic } from "../../src/state/json-file.js";
+import { stateLayout } from "../../src/state/layout.js";
+
+function run(runId: string, startedAt: string, status: CleanupRun["status"]): CleanupRun {
+  return {
+    schemaVersion: 1,
+    runId,
+    planId: `plan-${runId}`,
+    startedAt,
+    completedAt: startedAt,
+    status,
+    actions: [],
+    reclaimedBytes: 0,
+    diagnostics: [],
+  };
+}
+
+describe("history command", () => {
+  it("sorts runs newest first and filters by duration", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "agentrinse-history-"));
+    const layout = stateLayout(stateRoot);
+    await writeJsonAtomic(
+      join(layout.runs, "older.json"),
+      run("older", "2026-06-01T00:00:00.000Z", "completed"),
+    );
+    await writeJsonAtomic(
+      join(layout.runs, "newer.json"),
+      run("newer", "2026-07-23T00:00:00.000Z", "partial"),
+    );
+
+    const result = await executeHistoryCommand({
+      home: "/unused",
+      stateDir: stateRoot,
+      since: "30d",
+      json: false,
+      now: new Date("2026-07-24T00:00:00.000Z"),
+    });
+
+    expect(result.runs.map((entry) => entry.runId)).toEqual(["newer"]);
+    expect(result.output).toContain("partial");
+  });
+
+  it("reports an empty state directory", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "agentrinse-history-"));
+    const result = await executeHistoryCommand({
+      home: "/unused",
+      stateDir: stateRoot,
+      json: false,
+    });
+
+    expect(result.runs).toEqual([]);
+    expect(result.output).toBe("No AgentRinse runs found.\n");
+  });
+});

--- a/test/commands/lock.test.ts
+++ b/test/commands/lock.test.ts
@@ -1,0 +1,86 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { hostname, tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { executeLockRecoverCommand, executeLockStatusCommand } from "../../src/commands/lock.js";
+import { stateLayout } from "../../src/state/layout.js";
+import type { ApplyLockOwner } from "../../src/state/lock.js";
+
+async function fixture(): Promise<{
+  home: string;
+  stateRoot: string;
+  path: string;
+  owner: ApplyLockOwner;
+}> {
+  const home = await mkdtemp(join(tmpdir(), "agentrinse-lock-command-"));
+  const stateRoot = join(home, "state");
+  const path = join(stateLayout(stateRoot).locks, "apply.lock");
+  const owner: ApplyLockOwner = {
+    token: "fixture-token",
+    pid: 42,
+    processStartIdentity: "fixture-start",
+    hostname: hostname(),
+    command: "agentrinse apply",
+    planId: "plan-1",
+    runId: "run-1",
+    createdAt: "2026-07-23T00:00:00.000Z",
+  };
+  await mkdir(stateLayout(stateRoot).locks, { recursive: true });
+  await writeFile(path, `${JSON.stringify(owner)}\n`);
+  return { home, stateRoot, path, owner };
+}
+
+describe("lock commands", () => {
+  it("renders status in human and JSON modes", async () => {
+    const value = await fixture();
+    const dependencies = {
+      inspectProcess: async () => ({ status: "alive" as const, identity: "fixture-start" }),
+    };
+
+    const human = await executeLockStatusCommand({
+      home: value.home,
+      stateDir: value.stateRoot,
+      json: false,
+      dependencies,
+    });
+    expect(human.output).toContain("apply lock: active");
+    expect(human.output).toContain("run: run-1");
+
+    const json = await executeLockStatusCommand({
+      home: value.home,
+      stateDir: value.stateRoot,
+      json: true,
+      dependencies,
+    });
+    expect(JSON.parse(json.output)).toMatchObject({ status: "active" });
+  });
+
+  it("requires explicit authorization and a proven stale owner", async () => {
+    const value = await fixture();
+    const dependencies = {
+      inspectProcess: async () => ({ status: "dead" as const }),
+    };
+
+    await expect(
+      executeLockRecoverCommand({
+        home: value.home,
+        stateDir: value.stateRoot,
+        json: false,
+        yes: false,
+        dependencies,
+      }),
+    ).rejects.toThrow("requires --yes");
+
+    const result = await executeLockRecoverCommand({
+      home: value.home,
+      stateDir: value.stateRoot,
+      json: false,
+      yes: true,
+      dependencies,
+    });
+    expect(result.output).toBe("recovered stale apply lock for run run-1\n");
+    await expect(readFile(value.path, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/test/commands/show.test.ts
+++ b/test/commands/show.test.ts
@@ -1,0 +1,130 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  executeShowPlanCommand,
+  executeShowResourceCommand,
+  executeShowRunCommand,
+} from "../../src/commands/show.js";
+import type { CleanupPlan } from "../../src/contracts/plan.js";
+import type { AuditReport } from "../../src/contracts/report.js";
+import type { CleanupRun } from "../../src/contracts/run.js";
+import { writeJsonAtomic } from "../../src/state/json-file.js";
+import { stateLayout } from "../../src/state/layout.js";
+
+const RUN: CleanupRun = {
+  schemaVersion: 1,
+  runId: "run-1",
+  planId: "plan-1",
+  startedAt: "2026-07-24T00:00:00.000Z",
+  completedAt: "2026-07-24T00:01:00.000Z",
+  status: "partial",
+  actions: [
+    {
+      actionId: "action-1",
+      type: "artifacts.remove",
+      status: "partially-applied",
+      isolationPath: "/tmp/project/.agentrinse-tombstone",
+      diagnostic: {
+        severity: "error",
+        code: "ARTIFACT_PARTIALLY_APPLIED",
+        message: "synthetic partial action",
+      },
+    },
+  ],
+  reclaimedBytes: 0,
+  diagnostics: [],
+};
+
+const PLAN: CleanupPlan = {
+  schemaVersion: 1,
+  planId: "plan-1",
+  auditId: "audit-1",
+  home: "/tmp/home",
+  createdAt: "2026-07-24T00:00:00.000Z",
+  expiresAt: "2026-07-24T00:30:00.000Z",
+  policyVersion: 1,
+  riskCeiling: "safe",
+  configDigest: "config",
+  auditDigest: "audit",
+  actions: [],
+  expectedReclaimBytes: 0,
+};
+
+const AUDIT: AuditReport = {
+  schemaVersion: 1,
+  auditId: "audit-1",
+  startedAt: "2026-07-24T00:00:00.000Z",
+  completedAt: "2026-07-24T00:00:01.000Z",
+  home: "/tmp/home",
+  probes: [],
+  findings: [
+    {
+      schemaVersion: 1,
+      findingId: "finding-1",
+      auditId: "audit-1",
+      observedAt: "2026-07-24T00:00:01.000Z",
+      resource: {
+        id: "resource-1",
+        adapter: "codex",
+        kind: "agent-session-store",
+        canonicalKey: "codex:/tmp/home/.codex/sessions",
+        displayName: "sessions",
+        path: "/tmp/home/.codex/sessions",
+      },
+      state: "protected",
+      confidence: "certain",
+      roots: [],
+      facts: {},
+      candidateActions: [],
+      warnings: [],
+    },
+  ],
+  diagnostics: [],
+};
+
+describe("show commands", () => {
+  it("shows runs with partial recovery guidance", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "agentrinse-show-"));
+    const layout = stateLayout(stateRoot);
+    await writeJsonAtomic(join(layout.runs, "run-1.json"), RUN);
+
+    const result = await executeShowRunCommand("run-1", {
+      home: "/unused",
+      stateDir: stateRoot,
+      json: false,
+    });
+
+    expect(result.output).toContain("Recovery:");
+    expect(result.output).toContain(".agentrinse-tombstone");
+  });
+
+  it("shows plans by id and resources from the latest audit", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "agentrinse-show-"));
+    const layout = stateLayout(stateRoot);
+    await writeJsonAtomic(join(layout.plans, "plan-1.json"), PLAN);
+    await writeJsonAtomic(join(layout.audits, "audit-1.json"), AUDIT);
+
+    expect(
+      (
+        await executeShowPlanCommand("plan-1", {
+          home: "/unused",
+          stateDir: stateRoot,
+          json: true,
+        })
+      ).value.planId,
+    ).toBe("plan-1");
+    expect(
+      (
+        await executeShowResourceCommand("resource-1", {
+          home: "/unused",
+          stateDir: stateRoot,
+          json: true,
+        })
+      ).value.finding.findingId,
+    ).toBe("finding-1");
+  });
+});

--- a/test/config/load.test.ts
+++ b/test/config/load.test.ts
@@ -1,10 +1,10 @@
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { loadConfig } from "../../src/config/load.js";
+import { loadConfig, loadConfigForHome } from "../../src/config/load.js";
 
 describe("loadConfig", () => {
   it("returns isolated defaults", async () => {
@@ -13,6 +13,32 @@ describe("loadConfig", () => {
 
     const second = await loadConfig();
     expect(second.adapters.codex).toEqual({ enabled: true });
+  });
+
+  it("loads the default home config when present", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-config-"));
+    const path = join(home, ".config", "agentrinse", "config.json");
+    await mkdir(join(home, ".config", "agentrinse"), { recursive: true });
+    await writeFile(
+      path,
+      JSON.stringify({
+        schemaVersion: 1,
+        audit: { measureBytes: false },
+      }),
+    );
+
+    const loaded = await loadConfigForHome(home, undefined, {});
+    expect(loaded.exists).toBe(true);
+    expect(loaded.path).toBe(path);
+    expect(loaded.config.audit.measureBytes).toBe(false);
+  });
+
+  it("uses safe defaults when the default home config is absent", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-config-"));
+    const loaded = await loadConfigForHome(home, undefined, {});
+
+    expect(loaded.exists).toBe(false);
+    expect(loaded.config.artifacts.projects).toEqual([]);
   });
 
   it("merges a partial config over defaults", async () => {

--- a/test/config/path.test.ts
+++ b/test/config/path.test.ts
@@ -18,4 +18,13 @@ describe("resolveConfigPath", () => {
       "/tmp/home/.config/agentrinse/config.json",
     );
   });
+
+  it("ignores empty or relative XDG_CONFIG_HOME values", () => {
+    expect(resolveConfigPath("/tmp/home", undefined, { XDG_CONFIG_HOME: "" })).toBe(
+      "/tmp/home/.config/agentrinse/config.json",
+    );
+    expect(resolveConfigPath("/tmp/home", undefined, { XDG_CONFIG_HOME: "relative" })).toBe(
+      "/tmp/home/.config/agentrinse/config.json",
+    );
+  });
 });

--- a/test/config/path.test.ts
+++ b/test/config/path.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveConfigPath } from "../../src/config/path.js";
+
+describe("resolveConfigPath", () => {
+  it("uses the explicit path first", () => {
+    expect(resolveConfigPath("/tmp/home", "/tmp/config.json", {})).toBe("/tmp/config.json");
+  });
+
+  it("uses XDG_CONFIG_HOME when configured", () => {
+    expect(resolveConfigPath("/tmp/home", undefined, { XDG_CONFIG_HOME: "/tmp/xdg" })).toBe(
+      "/tmp/xdg/agentrinse/config.json",
+    );
+  });
+
+  it("falls back to the audited home", () => {
+    expect(resolveConfigPath("/tmp/home", undefined, {})).toBe(
+      "/tmp/home/.config/agentrinse/config.json",
+    );
+  });
+});

--- a/test/core/apply.test.ts
+++ b/test/core/apply.test.ts
@@ -440,4 +440,71 @@ describe("applyCleanupPlan", () => {
       }),
     ).rejects.toBeInstanceOf(ApplySafetyError);
   });
+
+  it("journals interruption at a safe checkpoint and leaves the target intact", async () => {
+    const value = await fixture();
+    const controller = new AbortController();
+
+    const result = await applyCleanupPlan({
+      input: value.plan,
+      config: value.config,
+      stateRoot: value.stateRoot,
+      signal: controller.signal,
+      dependencies: {
+        clock: CLOCK,
+        createJournal: async (runsDirectory, plan, startedAt, runId) => {
+          const journal = await createRunJournal(runsDirectory, plan, startedAt, runId);
+          controller.abort(new Error("fixture interruption"));
+          return journal;
+        },
+      },
+    });
+
+    expect(result.run.status).toBe("interrupted");
+    expect(result.run.actions[0]?.status).toBe("pending");
+    expect(result.run.diagnostics[0]?.code).toBe("COMMAND_INTERRUPTED");
+    expect(await exists(value.target)).toBe(true);
+    await expect(readJsonFile(result.journalPath)).resolves.toEqual(result.run);
+
+    await expect(
+      applyCleanupPlan({
+        input: value.plan,
+        config: value.config,
+        stateRoot: value.stateRoot,
+        dependencies: {
+          clock: CLOCK,
+          revalidate: async () => ({
+            status: "stale",
+            diagnostic: {
+              severity: "warning",
+              code: "STALE",
+              message: "skip",
+            },
+          }),
+        },
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  it("does not mask a real failure just because interruption was also requested", async () => {
+    const value = await fixture();
+    const controller = new AbortController();
+
+    await expect(
+      applyCleanupPlan({
+        input: value.plan,
+        config: value.config,
+        stateRoot: value.stateRoot,
+        signal: controller.signal,
+        dependencies: {
+          clock: CLOCK,
+          revalidate: async () => {
+            controller.abort(new Error("fixture interruption"));
+            throw new Error("authoritative revalidation failure");
+          },
+        },
+      }),
+    ).rejects.toThrow("authoritative revalidation failure");
+    expect(await exists(value.target)).toBe(true);
+  });
 });

--- a/test/core/apply.test.ts
+++ b/test/core/apply.test.ts
@@ -22,6 +22,7 @@ import { ApplySafetyError, applyCleanupPlan } from "../../src/core/apply.js";
 import { sha256Json } from "../../src/core/digest.js";
 import { measurePath } from "../../src/core/measure.js";
 import { cleanupPlanId } from "../../src/core/plan.js";
+import { assertDestructiveFixtureRoot } from "../../src/core/safety.js";
 import { readJsonFile } from "../../src/state/json-file.js";
 import { createRunJournal } from "../../src/state/run-journal.js";
 
@@ -34,6 +35,7 @@ async function fixture(): Promise<{
   target: string;
 }> {
   const home = await realpath(await mkdtemp(join(tmpdir(), "agentrinse-apply-")));
+  await assertDestructiveFixtureRoot(home);
   const stateRoot = join(home, "state");
   const project = join(home, "project");
   const target = join(project, "node_modules");

--- a/test/core/apply.test.ts
+++ b/test/core/apply.test.ts
@@ -488,6 +488,37 @@ describe("applyCleanupPlan", () => {
     ).resolves.toBeDefined();
   });
 
+  it("journals interruption requested during stale revalidation", async () => {
+    const value = await fixture();
+    const controller = new AbortController();
+
+    const result = await applyCleanupPlan({
+      input: value.plan,
+      config: value.config,
+      stateRoot: value.stateRoot,
+      signal: controller.signal,
+      dependencies: {
+        clock: CLOCK,
+        revalidate: async () => {
+          controller.abort(new Error("fixture interruption"));
+          return {
+            status: "stale",
+            diagnostic: {
+              severity: "warning",
+              code: "ARTIFACT_IDENTITY_CHANGED",
+              message: "fixture changed",
+            },
+          };
+        },
+      },
+    });
+
+    expect(result.run.status).toBe("interrupted");
+    expect(result.run.actions[0]?.status).toBe("skipped-stale");
+    expect(result.run.diagnostics[0]?.code).toBe("COMMAND_INTERRUPTED");
+    expect(await exists(value.target)).toBe(true);
+  });
+
   it("does not mask a real failure just because interruption was also requested", async () => {
     const value = await fixture();
     const controller = new AbortController();

--- a/test/core/apply.test.ts
+++ b/test/core/apply.test.ts
@@ -356,8 +356,8 @@ describe("applyCleanupPlan", () => {
         stateRoot: value.stateRoot,
         dependencies: {
           clock: CLOCK,
-          createJournal: async (runsDirectory, plan, startedAt) => {
-            const journal = await createRunJournal(runsDirectory, plan, startedAt);
+          createJournal: async (runsDirectory, plan, startedAt, runId) => {
+            const journal = await createRunJournal(runsDirectory, plan, startedAt, runId);
             journalPath = journal.path;
             return {
               ...journal,

--- a/test/core/apply.test.ts
+++ b/test/core/apply.test.ts
@@ -519,6 +519,46 @@ describe("applyCleanupPlan", () => {
     expect(await exists(value.target)).toBe(true);
   });
 
+  it("journals interruption requested while finalizing a completed run", async () => {
+    const value = await fixture();
+    const controller = new AbortController();
+
+    const result = await applyCleanupPlan({
+      input: value.plan,
+      config: value.config,
+      stateRoot: value.stateRoot,
+      signal: controller.signal,
+      dependencies: {
+        clock: CLOCK,
+        createJournal: async (runsDirectory, plan, startedAt, runId) => {
+          const journal = await createRunJournal(runsDirectory, plan, startedAt, runId);
+          return {
+            ...journal,
+            complete: async (completedAt) => {
+              const run = await journal.complete(completedAt);
+              controller.abort(new Error("fixture interruption"));
+              return run;
+            },
+          };
+        },
+        revalidate: async () => ({
+          status: "stale",
+          diagnostic: {
+            severity: "warning",
+            code: "ARTIFACT_IDENTITY_CHANGED",
+            message: "fixture changed",
+          },
+        }),
+      },
+    });
+
+    expect(result.run.status).toBe("interrupted");
+    expect(result.run.actions[0]?.status).toBe("skipped-stale");
+    expect(result.run.diagnostics[0]?.code).toBe("COMMAND_INTERRUPTED");
+    expect(await exists(value.target)).toBe(true);
+    await expect(readJsonFile(result.journalPath)).resolves.toEqual(result.run);
+  });
+
   it("does not mask a real failure just because interruption was also requested", async () => {
     const value = await fixture();
     const controller = new AbortController();

--- a/test/core/artifact-executor.test.ts
+++ b/test/core/artifact-executor.test.ts
@@ -12,6 +12,7 @@ import {
   executeArtifactRemove,
 } from "../../src/core/artifact-executor.js";
 import { measurePath } from "../../src/core/measure.js";
+import { assertDestructiveFixtureRoot } from "../../src/core/safety.js";
 
 async function fixture(): Promise<{
   action: ArtifactRemoveAction;
@@ -19,6 +20,7 @@ async function fixture(): Promise<{
   target: string;
 }> {
   const root = await mkdtemp(join(tmpdir(), "agentrinse-execute-"));
+  await assertDestructiveFixtureRoot(root);
   const project = join(root, "project");
   const target = join(project, "node_modules");
   await mkdir(target, { recursive: true });

--- a/test/core/audit.test.ts
+++ b/test/core/audit.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 
 import { createAuditAdapters } from "../../src/adapters/registry.js";
 import { DEFAULT_CONFIG } from "../../src/config/defaults.js";
+import type { AuditAdapter } from "../../src/contracts/adapter.js";
 import { runAudit } from "../../src/core/audit.js";
 
 describe("runAudit", () => {
@@ -65,5 +66,43 @@ describe("runAudit", () => {
     ];
 
     expect(createAuditAdapters(config).map((adapter) => adapter.id)).toContain("artifacts");
+  });
+
+  it("streams collection diagnostics even when no resources are discovered", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-audit-diagnostic-"));
+    const events: string[] = [];
+    const adapter: AuditAdapter = {
+      id: "fixture",
+      probe: async () => ({
+        adapter: "fixture",
+        status: "available",
+        detail: "fixture adapter is available",
+        diagnostics: [],
+      }),
+      collect: async () => ({
+        resources: [],
+        diagnostics: [
+          {
+            severity: "warning",
+            code: "FIXTURE_COLLECTION_WARNING",
+            message: "collection completed with partial visibility",
+            adapter: "fixture",
+          },
+        ],
+      }),
+      classify: async () => {
+        throw new Error("classify must not run without resources");
+      },
+    };
+
+    const report = await runAudit({
+      home,
+      config: DEFAULT_CONFIG,
+      adapters: [adapter],
+      onEvent: (event) => events.push(event.type),
+    });
+
+    expect(report.diagnostics).toHaveLength(1);
+    expect(events).toEqual(["adapter.probed", "diagnostic.reported"]);
   });
 });

--- a/test/core/duration.test.ts
+++ b/test/core/duration.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { parseDurationMs } from "../../src/core/duration.js";
+
+describe("parseDurationMs", () => {
+  it("parses supported units", () => {
+    expect(parseDurationMs("250ms")).toBe(250);
+    expect(parseDurationMs("30s")).toBe(30_000);
+    expect(parseDurationMs("15m")).toBe(15 * 60_000);
+    expect(parseDurationMs("12h")).toBe(12 * 60 * 60_000);
+    expect(parseDurationMs("30d")).toBe(30 * 24 * 60 * 60_000);
+  });
+
+  it("rejects zero, negative, fractional, and unknown units", () => {
+    for (const value of ["0s", "-1h", "1.5h", "3w", "soon"]) {
+      expect(() => parseDurationMs(value)).toThrow("invalid duration");
+    }
+  });
+});

--- a/test/core/process-identity.test.ts
+++ b/test/core/process-identity.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { inspectProcessIdentity } from "../../src/core/process-identity.js";
+
+describe("inspectProcessIdentity", () => {
+  it("uses a fixed locale and timezone for the macOS start identity", async () => {
+    const runProcessCommand = vi.fn(async () => ({
+      stdout: "Fri Jul 24 00:00:00 2026\n",
+      stderr: "",
+    }));
+
+    await expect(inspectProcessIdentity(42, "darwin", { runProcessCommand })).resolves.toEqual({
+      status: "alive",
+      identity: "darwin-ps-start:Fri Jul 24 00:00:00 2026",
+    });
+    expect(runProcessCommand).toHaveBeenCalledWith(
+      "ps",
+      ["-p", "42", "-o", "lstart="],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          LANG: "C",
+          LC_ALL: "C",
+          TZ: "UTC",
+        }),
+      }),
+    );
+  });
+});

--- a/test/core/process-identity.test.ts
+++ b/test/core/process-identity.test.ts
@@ -3,6 +3,35 @@ import { describe, expect, it, vi } from "vitest";
 import { inspectProcessIdentity } from "../../src/core/process-identity.js";
 
 describe("inspectProcessIdentity", () => {
+  it("does not treat a missing procfs entry as proof that a live process is dead", async () => {
+    const missing = Object.assign(new Error("procfs unavailable"), { code: "ENOENT" });
+
+    await expect(
+      inspectProcessIdentity(42, "linux", {
+        readProcessStat: async () => {
+          throw missing;
+        },
+        probeProcess: () => "alive",
+      }),
+    ).resolves.toEqual({
+      status: "unknown",
+      reason: "could not inspect /proc/42/stat (ENOENT)",
+    });
+  });
+
+  it("accepts an independent PID probe as proof that a process is dead", async () => {
+    const missing = Object.assign(new Error("process missing"), { code: "ENOENT" });
+
+    await expect(
+      inspectProcessIdentity(42, "linux", {
+        readProcessStat: async () => {
+          throw missing;
+        },
+        probeProcess: () => "dead",
+      }),
+    ).resolves.toEqual({ status: "dead" });
+  });
+
   it("uses a fixed locale and timezone for the macOS start identity", async () => {
     const runProcessCommand = vi.fn(async () => ({
       stdout: "Fri Jul 24 00:00:00 2026\n",

--- a/test/core/redaction.test.ts
+++ b/test/core/redaction.test.ts
@@ -107,6 +107,21 @@ describe("audit redaction", () => {
     expect(output).toContain("$PATH/<path:");
   });
 
+  it("does not leak descendants of a path that is also present structurally", () => {
+    const redacted = redactAuditValue(
+      {
+        path: `${HOME}/project`,
+        message: `could not inspect ${HOME}/project/private/file`,
+      },
+      HOME,
+      "fixture-salt",
+    );
+    const output = JSON.stringify(redacted);
+
+    expect(output).not.toContain(HOME);
+    expect(output).not.toContain("private/file");
+  });
+
   it("redacts large path collections without scanning every path for every string", () => {
     const entries = Array.from({ length: 5_000 }, (_, index) => ({
       path: `${HOME}/projects/project-${index}/node_modules`,

--- a/test/core/redaction.test.ts
+++ b/test/core/redaction.test.ts
@@ -122,6 +122,21 @@ describe("audit redaction", () => {
     expect(output).not.toContain("private/file");
   });
 
+  it("removes paths adjacent to diagnostic labels", () => {
+    const redacted = redactAuditValue(
+      {
+        message: "root:/Users/alice/private-project",
+      },
+      HOME,
+      "fixture-salt",
+    );
+    const output = JSON.stringify(redacted);
+
+    expect(output).not.toContain("/Users/alice");
+    expect(output).not.toContain("private-project");
+    expect(output).toContain("root:$PATH/<path:");
+  });
+
   it("redacts large path collections without scanning every path for every string", () => {
     const entries = Array.from({ length: 5_000 }, (_, index) => ({
       path: `${HOME}/projects/project-${index}/node_modules`,

--- a/test/core/redaction.test.ts
+++ b/test/core/redaction.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import type { AuditReport } from "../../src/contracts/report.js";
+import { redactAuditReport } from "../../src/core/redaction.js";
+
+const HOME = "/tmp/private-user";
+
+const REPORT: AuditReport = {
+  schemaVersion: 1,
+  auditId: "audit-private",
+  startedAt: "2026-07-24T00:00:00.000Z",
+  completedAt: "2026-07-24T00:00:01.000Z",
+  home: HOME,
+  probes: [
+    {
+      adapter: "artifacts",
+      status: "available",
+      root: `${HOME}/src/secret-client`,
+      detail: `Root ${HOME}/src/secret-client is available`,
+      diagnostics: [],
+    },
+  ],
+  findings: [
+    {
+      schemaVersion: 1,
+      findingId: "finding-private",
+      auditId: "audit-private",
+      observedAt: "2026-07-24T00:00:00.000Z",
+      resource: {
+        id: "resource-private",
+        adapter: "artifacts",
+        kind: "build-artifact",
+        canonicalKey: `artifacts:${HOME}/src/secret-client/node_modules`,
+        displayName: "node_modules",
+        path: `${HOME}/src/secret-client/node_modules`,
+      },
+      state: "eligible",
+      confidence: "certain",
+      roots: [],
+      facts: {
+        projectRoot: `${HOME}/src/secret-client`,
+        hostname: "private-host",
+      },
+      candidateActions: [
+        {
+          actionId: "action-private",
+          type: "artifacts.remove",
+          adapter: "artifacts",
+          resourceId: "resource-private",
+          risk: "safe",
+          description: "remove private artifact",
+          expectedReclaimBytes: 10,
+          target: {
+            path: `${HOME}/src/secret-client/node_modules`,
+            projectRoot: `${HOME}/src/secret-client`,
+            name: "node_modules",
+            device: 1,
+            inode: 2,
+            mtimeMs: 3,
+            measuredBytes: 10,
+            newestMtimeMs: 4,
+            fingerprint: "a".repeat(64),
+          },
+        },
+      ],
+      warnings: [],
+    },
+  ],
+  diagnostics: [],
+};
+
+describe("audit redaction", () => {
+  it("removes exact paths, hostnames, identifiers, and executable actions", () => {
+    const redacted = redactAuditReport(REPORT, "fixture-salt");
+    const output = JSON.stringify(redacted);
+
+    expect(output).not.toContain(HOME);
+    expect(output).not.toContain("secret-client");
+    expect(output).not.toContain("private-host");
+    expect(output).not.toContain("resource-private");
+    expect(redacted.home).toBe("$HOME");
+    expect(redacted.findings[0]?.candidateActions).toEqual([]);
+    expect(redacted.findings[0]?.resource.path).toMatch(/^\$HOME\/<path:/u);
+  });
+
+  it("uses report-specific salts for unlinkable identifiers", () => {
+    const first = redactAuditReport(REPORT, "salt-one");
+    const second = redactAuditReport(REPORT, "salt-two");
+
+    expect(first.findings[0]?.resource.id).not.toBe(second.findings[0]?.resource.id);
+  });
+});

--- a/test/core/redaction.test.ts
+++ b/test/core/redaction.test.ts
@@ -155,20 +155,21 @@ describe("audit redaction", () => {
     expect(output).toContain("$PATH/<path:");
   });
 
-  it("removes UNC paths from JSON and NDJSON output", () => {
-    const redacted = redactAuditValue(
-      {
-        message: String.raw`could not inspect \\server\private-share\project`,
-      },
-      HOME,
-      "fixture-salt",
-    );
+  it("removes Windows network and rooted paths from JSON and NDJSON output", () => {
+    for (const message of [
+      String.raw`could not inspect \\server\private-share\project`,
+      String.raw`could not inspect \Users\alice\secret-project`,
+    ]) {
+      const redacted = redactAuditValue({ message }, HOME, "fixture-salt");
 
-    for (const output of [jsonDocument(redacted), ndjsonRecord(redacted)]) {
-      expect(output).not.toContain("server");
-      expect(output).not.toContain("private-share");
-      expect(output).not.toContain("project");
-      expect(output).toContain("$PATH/<path:");
+      for (const output of [jsonDocument(redacted), ndjsonRecord(redacted)]) {
+        expect(output).not.toContain("server");
+        expect(output).not.toContain("private-share");
+        expect(output).not.toContain("Users");
+        expect(output).not.toContain("alice");
+        expect(output).not.toContain("project");
+        expect(output).toContain("$PATH/<path:");
+      }
     }
   });
 

--- a/test/core/redaction.test.ts
+++ b/test/core/redaction.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { AuditReport } from "../../src/contracts/report.js";
-import { redactAuditReport } from "../../src/core/redaction.js";
+import { redactAuditReport, redactAuditValue } from "../../src/core/redaction.js";
 
 const HOME = "/tmp/private-user";
 
@@ -89,5 +89,40 @@ describe("audit redaction", () => {
     const second = redactAuditReport(REPORT, "salt-two");
 
     expect(first.findings[0]?.resource.id).not.toBe(second.findings[0]?.resource.id);
+  });
+
+  it("conservatively removes diagnostic-only paths containing spaces", () => {
+    const redacted = redactAuditValue(
+      {
+        message: "could not inspect /Users/alice/Secret Project/file after permission failure",
+      },
+      HOME,
+      "fixture-salt",
+    );
+    const output = JSON.stringify(redacted);
+
+    expect(output).not.toContain("/Users/alice");
+    expect(output).not.toContain("Secret Project");
+    expect(output).not.toContain("file after permission failure");
+    expect(output).toContain("$PATH/<path:");
+  });
+
+  it("redacts large path collections without scanning every path for every string", () => {
+    const entries = Array.from({ length: 5_000 }, (_, index) => ({
+      path: `${HOME}/projects/project-${index}/node_modules`,
+    }));
+    const redacted = redactAuditValue(
+      {
+        entries,
+        message: `changed ${HOME}/projects/project-4999/node_modules`,
+      },
+      HOME,
+      "fixture-salt",
+    );
+    const output = JSON.stringify(redacted);
+
+    expect(output).not.toContain(HOME);
+    expect(output).not.toContain("project-4999");
+    expect(output).toContain("$HOME/<path:");
   });
 });

--- a/test/core/redaction.test.ts
+++ b/test/core/redaction.test.ts
@@ -155,6 +155,20 @@ describe("audit redaction", () => {
     expect(output).toContain("$PATH/<path:");
   });
 
+  it("removes complete paths containing line breaks", () => {
+    const redacted = redactAuditValue(
+      { message: "could not inspect /Users/alice/Secret\nProject/file" },
+      HOME,
+      "fixture-salt",
+    );
+    const output = JSON.stringify(redacted);
+
+    expect(output).not.toContain("Secret");
+    expect(output).not.toContain("Project");
+    expect(output).not.toContain("file");
+    expect(output).toContain("$PATH/<path:");
+  });
+
   it("removes Windows network and rooted paths from JSON and NDJSON output", () => {
     for (const message of [
       String.raw`could not inspect \\server\private-share\project`,

--- a/test/core/redaction.test.ts
+++ b/test/core/redaction.test.ts
@@ -16,7 +16,7 @@ const REPORT: AuditReport = {
       adapter: "artifacts",
       status: "available",
       root: `${HOME}/src/secret-client`,
-      detail: `Root ${HOME}/src/secret-client is available`,
+      detail: `Root ${HOME}/src/secret-client is available; mirror /Volumes/Private/client`,
       diagnostics: [],
     },
   ],
@@ -78,6 +78,7 @@ describe("audit redaction", () => {
     expect(output).not.toContain("secret-client");
     expect(output).not.toContain("private-host");
     expect(output).not.toContain("resource-private");
+    expect(output).not.toContain("/Volumes/Private/client");
     expect(redacted.home).toBe("$HOME");
     expect(redacted.findings[0]?.candidateActions).toEqual([]);
     expect(redacted.findings[0]?.resource.path).toMatch(/^\$HOME\/<path:/u);

--- a/test/core/redaction.test.ts
+++ b/test/core/redaction.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { AuditReport } from "../../src/contracts/report.js";
 import { redactAuditReport, redactAuditValue } from "../../src/core/redaction.js";
+import { jsonDocument, ndjsonRecord } from "../../src/machine-output.js";
 
 const HOME = "/tmp/private-user";
 
@@ -152,6 +153,23 @@ describe("audit redaction", () => {
     expect(output).not.toContain("client");
     expect(output).not.toContain("draft");
     expect(output).toContain("$PATH/<path:");
+  });
+
+  it("removes UNC paths from JSON and NDJSON output", () => {
+    const redacted = redactAuditValue(
+      {
+        message: String.raw`could not inspect \\server\private-share\project`,
+      },
+      HOME,
+      "fixture-salt",
+    );
+
+    for (const output of [jsonDocument(redacted), ndjsonRecord(redacted)]) {
+      expect(output).not.toContain("server");
+      expect(output).not.toContain("private-share");
+      expect(output).not.toContain("project");
+      expect(output).toContain("$PATH/<path:");
+    }
   });
 
   it("redacts large path collections without scanning every path for every string", () => {

--- a/test/core/redaction.test.ts
+++ b/test/core/redaction.test.ts
@@ -137,6 +137,23 @@ describe("audit redaction", () => {
     expect(output).toContain("root:$PATH/<path:");
   });
 
+  it("removes complete paths containing quote and angle characters", () => {
+    const redacted = redactAuditValue(
+      {
+        message: `could not inspect /Users/alice/Secret's/"client"<draft>/file`,
+      },
+      HOME,
+      "fixture-salt",
+    );
+    const output = JSON.stringify(redacted);
+
+    expect(output).not.toContain("/Users/alice");
+    expect(output).not.toContain(`Secret's`);
+    expect(output).not.toContain("client");
+    expect(output).not.toContain("draft");
+    expect(output).toContain("$PATH/<path:");
+  });
+
   it("redacts large path collections without scanning every path for every string", () => {
     const entries = Array.from({ length: 5_000 }, (_, index) => ({
       path: `${HOME}/projects/project-${index}/node_modules`,

--- a/test/core/safety.test.ts
+++ b/test/core/safety.test.ts
@@ -81,14 +81,15 @@ describe("assertDestructiveFixtureRoot", () => {
     ).resolves.toBe(candidate);
   });
 
-  it("rejects the temporary root, real home, repository ancestors, and outside paths", async () => {
+  it("rejects the temporary root, real home, repository overlap, and outside paths", async () => {
     const parent = await realpath(await mkdtemp(join(tmpdir(), "agentrinse-destructive-parent-")));
     const temporaryRoot = join(parent, "temporary");
     const outside = join(parent, "outside");
     const repositoryRoot = join(temporaryRoot, "repo", "checkout");
     const repositoryParent = join(temporaryRoot, "repo");
+    const repositoryChild = join(repositoryRoot, "fixture");
     const realHome = join(temporaryRoot, "home");
-    await mkdir(repositoryRoot, { recursive: true });
+    await mkdir(repositoryChild, { recursive: true });
     await mkdir(realHome);
     await mkdir(outside);
 
@@ -97,6 +98,7 @@ describe("assertDestructiveFixtureRoot", () => {
       temporaryRoot,
       realHome,
       repositoryParent,
+      repositoryChild,
       outside,
     ]) {
       await expect(

--- a/test/core/safety.test.ts
+++ b/test/core/safety.test.ts
@@ -1,10 +1,16 @@
-import { mkdtemp, realpath, symlink } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, symlink } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join, parse } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { UnsafeAuditRootError, assertAuditRoot, isPathInside } from "../../src/core/safety.js";
+import {
+  UnsafeAuditRootError,
+  UnsafeDestructiveFixtureError,
+  assertAuditRoot,
+  assertDestructiveFixtureRoot,
+  isPathInside,
+} from "../../src/core/safety.js";
 
 describe("assertAuditRoot", () => {
   it("accepts an absolute synthetic root", async () => {
@@ -50,5 +56,78 @@ describe("isPathInside", () => {
 
   it("rejects sibling-prefix paths", () => {
     expect(isPathInside("/tmp/project", "/tmp/project-other")).toBe(false);
+  });
+});
+
+describe("assertDestructiveFixtureRoot", () => {
+  it("accepts a resolved child of the selected temporary root", async () => {
+    const temporaryRoot = await realpath(
+      await mkdtemp(join(tmpdir(), "agentrinse-destructive-root-")),
+    );
+    const candidate = await realpath(
+      await mkdtemp(join(temporaryRoot, "agentrinse-destructive-fixture-")),
+    );
+    const repositoryRoot = join(temporaryRoot, "repo");
+    const realHome = join(temporaryRoot, "home");
+    await mkdir(repositoryRoot);
+    await mkdir(realHome);
+
+    await expect(
+      assertDestructiveFixtureRoot(candidate, {
+        temporaryRoot,
+        repositoryRoot,
+        realHome,
+      }),
+    ).resolves.toBe(candidate);
+  });
+
+  it("rejects the temporary root, real home, repository ancestors, and outside paths", async () => {
+    const parent = await realpath(await mkdtemp(join(tmpdir(), "agentrinse-destructive-parent-")));
+    const temporaryRoot = join(parent, "temporary");
+    const outside = join(parent, "outside");
+    const repositoryRoot = join(temporaryRoot, "repo", "checkout");
+    const repositoryParent = join(temporaryRoot, "repo");
+    const realHome = join(temporaryRoot, "home");
+    await mkdir(repositoryRoot, { recursive: true });
+    await mkdir(realHome);
+    await mkdir(outside);
+
+    for (const candidate of [
+      parse(parent).root,
+      temporaryRoot,
+      realHome,
+      repositoryParent,
+      outside,
+    ]) {
+      await expect(
+        assertDestructiveFixtureRoot(candidate, {
+          temporaryRoot,
+          repositoryRoot,
+          realHome,
+        }),
+      ).rejects.toBeInstanceOf(UnsafeDestructiveFixtureError);
+    }
+  });
+
+  it("rejects a symlink that resolves outside the selected temporary root", async () => {
+    const parent = await realpath(await mkdtemp(join(tmpdir(), "agentrinse-destructive-link-")));
+    const temporaryRoot = join(parent, "temporary");
+    const outside = join(parent, "outside");
+    const link = join(temporaryRoot, "fixture-link");
+    const repositoryRoot = join(temporaryRoot, "repo");
+    const realHome = join(temporaryRoot, "home");
+    await mkdir(temporaryRoot);
+    await mkdir(outside);
+    await mkdir(repositoryRoot);
+    await mkdir(realHome);
+    await symlink(outside, link);
+
+    await expect(
+      assertDestructiveFixtureRoot(link, {
+        temporaryRoot,
+        repositoryRoot,
+        realHome,
+      }),
+    ).rejects.toBeInstanceOf(UnsafeDestructiveFixtureError);
   });
 });

--- a/test/state/json-file.test.ts
+++ b/test/state/json-file.test.ts
@@ -1,10 +1,10 @@
-import { mkdtemp, stat } from "node:fs/promises";
+import { chmod, mkdtemp, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { readJsonFile, writeJsonAtomic } from "../../src/state/json-file.js";
+import { readJsonFile, writeJsonAtomic, writeJsonExclusive } from "../../src/state/json-file.js";
 
 describe("atomic JSON files", () => {
   it("writes a complete owner-only document", async () => {
@@ -15,5 +15,16 @@ describe("atomic JSON files", () => {
 
     expect(await readJsonFile(path)).toEqual({ planId: "plan-1" });
     expect((await stat(path)).mode & 0o777).toBe(0o600);
+    expect((await stat(join(root, "plans"))).mode & 0o777).toBe(0o700);
+  });
+
+  it("does not change permissions on an existing parent directory", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agentrinse-config-parent-"));
+    await chmod(root, 0o755);
+
+    await writeJsonExclusive(join(root, "config.json"), { schemaVersion: 1 });
+
+    expect((await stat(root)).mode & 0o777).toBe(0o755);
+    expect((await stat(join(root, "config.json"))).mode & 0o777).toBe(0o600);
   });
 });

--- a/test/state/json-file.test.ts
+++ b/test/state/json-file.test.ts
@@ -27,4 +27,21 @@ describe("atomic JSON files", () => {
     expect((await stat(root)).mode & 0o777).toBe(0o755);
     expect((await stat(join(root, "config.json"))).mode & 0o777).toBe(0o600);
   });
+
+  it("repairs and verifies AgentRinse-owned state directories", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agentrinse-private-state-"));
+    const plans = join(root, "plans");
+    await chmod(root, 0o777);
+
+    await writeJsonAtomic(
+      join(plans, "plan.json"),
+      { planId: "plan-1" },
+      {
+        privateDirectories: [root, plans],
+      },
+    );
+
+    expect((await stat(root)).mode & 0o777).toBe(0o700);
+    expect((await stat(plans)).mode & 0o777).toBe(0o700);
+  });
 });

--- a/test/state/layout.test.ts
+++ b/test/state/layout.test.ts
@@ -22,6 +22,8 @@ describe("state layout", () => {
   it("builds stable state subdirectories", () => {
     expect(stateLayout("/fixture/state")).toEqual({
       root: "/fixture/state",
+      audits: "/fixture/state/audits",
+      plans: "/fixture/state/plans",
       locks: "/fixture/state/locks",
       runs: "/fixture/state/runs",
       tombstones: "/fixture/state/tombstones",

--- a/test/state/lock.test.ts
+++ b/test/state/lock.test.ts
@@ -1,63 +1,210 @@
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { hostname, tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { LockHeldError, acquireApplyLock } from "../../src/state/lock.js";
+import {
+  LockHeldError,
+  LockRecoveryError,
+  acquireApplyLock,
+  inspectApplyLock,
+  recoverStaleApplyLock,
+  type ApplyLockOwner,
+} from "../../src/state/lock.js";
+
+function request(planId = "plan-1", runId = "run-1") {
+  return { planId, runId, command: "agentrinse apply" };
+}
+
+function owner(overrides: Partial<ApplyLockOwner> = {}): ApplyLockOwner {
+  return {
+    token: "lock-token",
+    pid: 42,
+    processStartIdentity: "fixture-start",
+    hostname: hostname(),
+    command: "agentrinse apply",
+    planId: "plan-1",
+    runId: "run-1",
+    createdAt: "2026-07-23T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+async function writeOwner(root: string, value: ApplyLockOwner): Promise<string> {
+  const path = join(root, "apply.lock");
+  await writeFile(path, `${JSON.stringify(value)}\n`);
+  return path;
+}
 
 describe("apply state lock", () => {
   it("allows one owner and refuses a concurrent owner", async () => {
     const root = await mkdtemp(join(tmpdir(), "agentrinse-lock-"));
-    const first = await acquireApplyLock(root, "plan-1");
+    const first = await acquireApplyLock(root, request());
 
-    await expect(acquireApplyLock(root, "plan-2")).rejects.toBeInstanceOf(LockHeldError);
+    await expect(acquireApplyLock(root, request("plan-2", "run-2"))).rejects.toBeInstanceOf(
+      LockHeldError,
+    );
 
     await first.release();
-    const second = await acquireApplyLock(root, "plan-2");
+    const second = await acquireApplyLock(root, request("plan-2", "run-2"));
     await second.release();
+  });
+
+  it("records the plan, run, command, and process identity", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agentrinse-lock-"));
+    const lock = await acquireApplyLock(root, request());
+    const stored = JSON.parse(await readFile(lock.path, "utf8")) as ApplyLockOwner;
+
+    expect(stored).toMatchObject({
+      pid: process.pid,
+      hostname: hostname(),
+      command: "agentrinse apply",
+      planId: "plan-1",
+      runId: "run-1",
+    });
+    if (process.platform === "darwin" || process.platform === "linux") {
+      expect(stored.processStartIdentity).toBeTypeOf("string");
+    }
+    await lock.release();
   });
 
   it("makes release idempotent", async () => {
     const root = await mkdtemp(join(tmpdir(), "agentrinse-lock-"));
-    const lock = await acquireApplyLock(root, "plan-1");
+    const lock = await acquireApplyLock(root, request());
 
     await lock.release();
     await lock.release();
   });
 
-  it("fails closed when a stale-looking lock exists", async () => {
+  it("reports an absent lock", async () => {
     const root = await mkdtemp(join(tmpdir(), "agentrinse-lock-"));
-    const path = join(root, "apply.lock");
-    await writeFile(
-      path,
-      JSON.stringify({
-        token: "stale",
-        pid: 2_147_483_647,
-        hostname: hostname(),
-        planId: "old-plan",
-        createdAt: "2026-07-23T00:00:00.000Z",
-      }),
-    );
+    await expect(inspectApplyLock(root)).resolves.toMatchObject({ status: "absent" });
+  });
 
-    await expect(acquireApplyLock(root, "new-plan")).rejects.toThrow(
-      "verify its recorded process before removing a stale lock",
-    );
-    expect(JSON.parse(await readFile(path, "utf8")).planId).toBe("old-plan");
+  it("reports an active owner when PID and process start identity match", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agentrinse-lock-"));
+    await writeOwner(root, owner({ createdAt: "2000-01-01T00:00:00.000Z" }));
+
+    await expect(
+      inspectApplyLock(root, {
+        inspectProcess: async () => ({ status: "alive", identity: "fixture-start" }),
+      }),
+    ).resolves.toMatchObject({ status: "active" });
+  });
+
+  it("does not treat age as proof that a lock is stale", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agentrinse-lock-"));
+    await writeOwner(root, owner({ createdAt: "2000-01-01T00:00:00.000Z" }));
+
+    await expect(
+      recoverStaleApplyLock(root, {
+        inspectProcess: async () => ({ status: "alive", identity: "fixture-start" }),
+      }),
+    ).rejects.toThrow("apply lock is active");
+  });
+
+  it("reports and recovers a lock whose recorded process is dead", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agentrinse-lock-"));
+    const path = await writeOwner(root, owner());
+    const dependencies = {
+      inspectProcess: async () => ({ status: "dead" as const }),
+    };
+
+    await expect(inspectApplyLock(root, dependencies)).resolves.toMatchObject({
+      status: "stale",
+      reason: "recorded process 42 no longer exists",
+    });
+    await expect(recoverStaleApplyLock(root, dependencies)).resolves.toMatchObject({
+      runId: "run-1",
+    });
+    await expect(readFile(path, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("reports PID reuse as stale", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agentrinse-lock-"));
+    await writeOwner(root, owner());
+
+    await expect(
+      inspectApplyLock(root, {
+        inspectProcess: async () => ({ status: "alive", identity: "different-start" }),
+      }),
+    ).resolves.toMatchObject({
+      status: "stale",
+      reason: "PID 42 was reused by a different process",
+    });
+  });
+
+  it("refuses recovery when a live PID has no recorded start identity", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agentrinse-lock-"));
+    const value = owner();
+    delete value.processStartIdentity;
+    await writeOwner(root, value);
+
+    await expect(
+      inspectApplyLock(root, {
+        inspectProcess: async () => ({ status: "alive", identity: "fixture-start" }),
+      }),
+    ).resolves.toMatchObject({ status: "unknown" });
+    await expect(
+      recoverStaleApplyLock(root, {
+        inspectProcess: async () => ({ status: "alive", identity: "fixture-start" }),
+      }),
+    ).rejects.toBeInstanceOf(LockRecoveryError);
+  });
+
+  it("refuses recovery for a lock recorded on another host", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agentrinse-lock-"));
+    await writeOwner(root, owner({ hostname: "another-host" }));
+
+    await expect(inspectApplyLock(root)).resolves.toMatchObject({ status: "remote" });
+    await expect(recoverStaleApplyLock(root)).rejects.toThrow("apply lock is remote");
+  });
+
+  it("refuses recovery for malformed lock records", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agentrinse-lock-"));
+    await writeFile(join(root, "apply.lock"), '{"pid":42}\n');
+
+    await expect(inspectApplyLock(root)).resolves.toMatchObject({ status: "malformed" });
+    await expect(recoverStaleApplyLock(root)).rejects.toThrow("apply lock is malformed");
+  });
+
+  it("does not remove a replacement lock during recovery", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agentrinse-lock-"));
+    const path = await writeOwner(root, owner());
+    const replacement = owner({
+      token: "replacement",
+      pid: process.pid,
+      processStartIdentity: "replacement-start",
+      planId: "plan-2",
+      runId: "run-2",
+    });
+
+    await expect(
+      recoverStaleApplyLock(root, {
+        inspectProcess: async () => ({ status: "dead" }),
+        beforeRecoveryRemove: async () => {
+          await rm(path);
+          await writeFile(path, `${JSON.stringify(replacement)}\n`);
+        },
+      }),
+    ).rejects.toThrow("apply lock changed before recovery");
+    expect(JSON.parse(await readFile(path, "utf8"))).toMatchObject({ token: "replacement" });
   });
 
   it("does not remove a replacement lock during release", async () => {
     const root = await mkdtemp(join(tmpdir(), "agentrinse-lock-"));
-    const lock = await acquireApplyLock(root, "plan-1");
+    const lock = await acquireApplyLock(root, request());
     await writeFile(
       lock.path,
-      JSON.stringify({
-        token: "replacement",
-        pid: process.pid,
-        hostname: hostname(),
-        planId: "plan-2",
-        createdAt: "2026-07-23T00:00:00.000Z",
-      }),
+      JSON.stringify(
+        owner({
+          token: "replacement",
+          pid: process.pid,
+          planId: "plan-2",
+          runId: "run-2",
+        }),
+      ),
     );
 
     await lock.release();

--- a/test/state/lock.test.ts
+++ b/test/state/lock.test.ts
@@ -227,6 +227,18 @@ describe("apply state lock", () => {
     await replacement.release();
   });
 
+  it("ignores an orphaned recovery marker when no process holds its kernel lock", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agentrinse-lock-"));
+    await writeOwner(root, owner());
+    await writeFile(join(root, "apply.recovery.lock"), "orphaned marker\n");
+
+    await expect(
+      recoverStaleApplyLock(root, {
+        inspectProcess: async () => ({ status: "dead" }),
+      }),
+    ).resolves.toMatchObject({ token: "lock-token" });
+  });
+
   it("does not remove a replacement lock during release", async () => {
     const root = await mkdtemp(join(tmpdir(), "agentrinse-lock-"));
     const lock = await acquireApplyLock(root, request());

--- a/test/state/lock.test.ts
+++ b/test/state/lock.test.ts
@@ -192,6 +192,41 @@ describe("apply state lock", () => {
     expect(JSON.parse(await readFile(path, "utf8"))).toMatchObject({ token: "replacement" });
   });
 
+  it("serializes stale recovery before inspecting the apply lock", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agentrinse-lock-"));
+    await writeOwner(root, owner());
+    let continueFirst!: () => void;
+    let firstEntered!: () => void;
+    const firstEnteredPromise = new Promise<void>((resolve) => {
+      firstEntered = resolve;
+    });
+    const continueFirstPromise = new Promise<void>((resolve) => {
+      continueFirst = resolve;
+    });
+    const dependencies = {
+      inspectProcess: async () => ({ status: "dead" as const }),
+    };
+
+    const firstRecovery = recoverStaleApplyLock(root, {
+      ...dependencies,
+      beforeRecoveryRemove: async () => {
+        firstEntered();
+        await continueFirstPromise;
+      },
+    });
+    await firstEnteredPromise;
+
+    await expect(recoverStaleApplyLock(root, dependencies)).rejects.toThrow(
+      "apply lock recovery is already in progress",
+    );
+    continueFirst();
+    await expect(firstRecovery).resolves.toMatchObject({ token: "lock-token" });
+
+    const replacement = await acquireApplyLock(root, request("plan-2", "run-2"));
+    await expect(readFile(replacement.path, "utf8")).resolves.toContain('"planId":"plan-2"');
+    await replacement.release();
+  });
+
   it("does not remove a replacement lock during release", async () => {
     const root = await mkdtemp(join(tmpdir(), "agentrinse-lock-"));
     const lock = await acquireApplyLock(root, request());

--- a/test/state/records.test.ts
+++ b/test/state/records.test.ts
@@ -1,0 +1,21 @@
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { resolveJsonRecordPath } from "../../src/state/records.js";
+
+describe("resolveJsonRecordPath", () => {
+  it("treats JSON basenames and either separator as explicit paths", () => {
+    expect(resolveJsonRecordPath("/state/runs", "run.json")).toBe(resolve("run.json"));
+    expect(resolveJsonRecordPath("/state/runs", "records/run.json")).toBe(
+      resolve("records/run.json"),
+    );
+    expect(resolveJsonRecordPath("/state/runs", String.raw`records\run.json`)).toBe(
+      resolve(String.raw`records\run.json`),
+    );
+  });
+
+  it("resolves bare record IDs inside the selected state directory", () => {
+    expect(resolveJsonRecordPath("/state/runs", "run-1")).toBe("/state/runs/run-1.json");
+  });
+});

--- a/test/state/run-journal.test.ts
+++ b/test/state/run-journal.test.ts
@@ -121,6 +121,9 @@ describe("run journal", () => {
 
     expect(interrupted.status).toBe("interrupted");
     expect(interrupted.actions[0]?.status).toBe("applying");
+    expect(interrupted.reclaimedBytes).toBe(
+      interrupted.actions.reduce((total, action) => total + (action.reclaimedBytes ?? 0), 0),
+    );
     expect(interrupted.diagnostics[0]?.code).toBe("COMMAND_INTERRUPTED");
     expect(await readJsonFile(journal.path)).toEqual(interrupted);
   });

--- a/test/state/run-journal.test.ts
+++ b/test/state/run-journal.test.ts
@@ -47,7 +47,12 @@ const PLAN: CleanupPlan = {
 describe("run journal", () => {
   it("persists every action transition", async () => {
     const root = await mkdtemp(join(tmpdir(), "agentrinse-run-"));
-    const journal = await createRunJournal(root, PLAN, new Date("2026-07-23T00:00:00.000Z"));
+    const journal = await createRunJournal(
+      root,
+      PLAN,
+      new Date("2026-07-23T00:00:00.000Z"),
+      "run-1",
+    );
 
     await journal.updateAction("action-1", {
       status: "applied",
@@ -58,6 +63,7 @@ describe("run journal", () => {
     const completed = await journal.complete(new Date("2026-07-23T00:00:03.000Z"));
 
     expect(completed.status).toBe("completed");
+    expect(completed.runId).toBe("run-1");
     expect(completed.reclaimedBytes).toBe(10);
     expect(await readJsonFile(journal.path)).toEqual(completed);
   });

--- a/test/state/run-journal.test.ts
+++ b/test/state/run-journal.test.ts
@@ -101,4 +101,27 @@ describe("run journal", () => {
 
     expect((await journal.complete()).status).toBe("failed");
   });
+
+  it("persists an interrupted run without rewriting action truth", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agentrinse-run-"));
+    const journal = await createRunJournal(root, PLAN);
+    await journal.updateAction("action-1", {
+      status: "applying",
+      isolationPath: "/tmp/fixture/.agentrinse-tombstone",
+    });
+
+    const interrupted = await journal.interrupt(
+      {
+        severity: "warning",
+        code: "COMMAND_INTERRUPTED",
+        message: "fixture interrupted",
+      },
+      new Date("2026-07-23T00:00:03.000Z"),
+    );
+
+    expect(interrupted.status).toBe("interrupted");
+    expect(interrupted.actions[0]?.status).toBe("applying");
+    expect(interrupted.diagnostics[0]?.code).toBe("COMMAND_INTERRUPTED");
+    expect(await readJsonFile(journal.path)).toEqual(interrupted);
+  });
 });


### PR DESCRIPTION
## Summary

Ships the supported AgentRinse 0.1.0 workflow: configuration, persisted audit/plan/run state, guarded artifact apply, lock recovery, doctor diagnostics, machine output, shell completions, package smoke, and release automation.

## Safety model

- Resource owner: explicitly configured project artifact directories only.
- Discovery evidence: canonical path, device/inode, timestamps, measured bytes, newest mtime, and content fingerprint.
- Protection roots: filesystem root, real home ancestors, repository overlap, state directories, symlinks, mount boundaries, active processes, and expired or changed plans.
- Risk class: only exact `artifacts.remove` actions are enabled for 0.1.0; provider stores and Docker remain report-only.
- Revalidation: every action rechecks identity, size/fingerprint, authorization expiry, process ownership, and isolation constraints immediately before mutation.
- Recovery: owner-verified apply locks, crash-safe stale-lock mutexes, atomic owner-only journals, interruption records, and same-parent isolation/rollback outcomes.

## Proof

- macOS: 38 test files, 194 tests; typecheck, oxlint, oxfmt, six schema checks, publint, and installed-tarball smoke.
- Linux: fresh AWS Crabbox `c7a.large`, Node 24.15.0 archive checksum verified, 38 test files/194 tests, full check, and installed-tarball audit/plan/apply smoke.
- Autoreview: clean, no accepted/actionable findings.
- TruffleHog pre-review scan: clean.

## Release

The tag-triggered workflow builds one checksummed tarball, smokes the exact package, publishes to npm through OIDC, and idempotently verifies/uploads GitHub release assets.