### PR TITLE
fix(release): publish the local tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: Publish to npm
         if: env.RELEASE_TAG != 'v0.0.0'
-        run: npm publish release/agentrinse-*.tgz --access public
+        run: npm publish ./release/agentrinse-*.tgz --access public
 
   release-assets:
     if: github.event_name == 'release'


### PR DESCRIPTION
## Summary

Fixes the failed v0.1.0 npm publish by making the tarball argument explicitly filesystem-relative. Without `./`, npm interprets `release/agentrinse-0.1.0.tgz` as GitHub shorthand and attempts an SSH Git fetch.

## Proof

- release log: npm invoked `git ls-remote ssh://git@github.com/release/agentrinse-0.1.0.tgz.git`
- workflow YAML parses successfully
- oxfmt and `git diff --check` pass
- autoreview clean, confidence 0.98

No package contents or runtime behavior change.