### PR TITLE
feat(release): ship AgentRinse 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The project follows semantic versioning after its first supported release.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-24
+
 ### Added
 
 - path, resource-id, and Git-ref pins with optional expiry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,15 @@ The project follows semantic versioning after its first supported release.
 - path, resource-id, and Git-ref pins with optional expiry
 - Codex and Claude workspace roots derived from metadata without reading
   transcript bodies
+- repository-scoped `clean --profile closeout` with persisted audit, plan,
+  exact derived config, optional safe apply, compact JSON, and external Mole
+  dry-run suggestions
 
 ### Safety
 
 - malformed or unreadable provider metadata protects all affected Git
   worktrees instead of being treated as empty
+- worktree and session roots suppress nested artifact actions
 
 ## [0.1.0] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The project follows semantic versioning after its first supported release.
 
 ## [Unreleased]
 
+### Added
+
+- path, resource-id, and Git-ref pins with optional expiry
+- Codex and Claude workspace roots derived from metadata without reading
+  transcript bodies
+
+### Safety
+
+- malformed or unreadable provider metadata protects all affected Git
+  worktrees instead of being treated as empty
+
 ## [0.1.0] - 2026-07-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The project follows semantic versioning after its first supported release.
 - repository-scoped `clean --profile closeout` with persisted audit, plan,
   exact derived config, optional safe apply, compact JSON, and external Mole
   dry-run suggestions
+- opt-in report-only inventory for selected agent executables and Claude
+  native installed versions
 
 ### Safety
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ AgentRinse inventories agent state and developer residue, explains why each
 resource is protected or eligible, creates content-addressed cleanup plans,
 and applies only actions that still pass every safety check.
 
-Version `0.1.0` supports one mutating action: removing exact rebuildable
-artifact directories declared under explicit project roots. Provider state,
-Git worktrees, and Docker resources remain report-only.
+Version `0.2.0` adds Git reachability proof, live-process and Codex/Claude
+workspace roots, explicit pins, a repository closeout profile, and opt-in
+runtime inventory. Its only mutating action remains removal of exact
+rebuildable artifact directories declared under explicit project roots.
+Provider state, Git worktrees, runtimes, and Docker resources are report-only.
 
 ## Install
 
@@ -22,7 +24,7 @@ agentrinse --version
 One-off use also works:
 
 ```bash
-npx agentrinse@0.1.0 doctor
+npx agentrinse@0.2.0 doctor
 ```
 
 ## Quickstart
@@ -85,6 +87,30 @@ agentrinse apply --plan plan.json
 
 Interactive apply asks for confirmation. Automation must pass `--yes`.
 
+## Agent Closeout
+
+From a Git worktree, create a repository-scoped audit and plan:
+
+```bash
+agentrinse clean --profile closeout
+```
+
+The current worktree is always protected. The profile inventories its
+repository's linked worktrees, loads Codex and Claude reachability metadata,
+and ignores unrelated configured artifact projects. It does not infer that a
+task is finished.
+
+After reviewing the summary, a fresh closeout can apply only existing `safe`
+artifact actions:
+
+```bash
+agentrinse clean --profile closeout --apply
+agentrinse clean --profile closeout --apply --yes --max-risk safe --json
+```
+
+On macOS, an installed Mole binary adds external `mo purge --dry-run` and
+`mo clean --dry-run` suggestions. AgentRinse never runs those commands.
+
 ## Mutation Boundary
 
 AgentRinse can remove only these configured artifact names:
@@ -109,7 +135,7 @@ to a same-parent tombstone and verified again before deletion.
 AgentRinse never removes provider sessions, transcripts, databases,
 credentials, configuration, plugins, skills, memories, Git branches, stashes,
 worktrees, Docker images, containers, networks, volumes, or build cache in
-`0.1.0`.
+`0.2.0`.
 
 ## Operations
 
@@ -119,6 +145,17 @@ agentrinse show run <run-id>
 agentrinse show plan <plan-id>
 agentrinse show resource <resource-id>
 agentrinse lock status
+```
+
+Opt into report-only selected runtime inventory:
+
+```json
+{
+  "schemaVersion": 1,
+  "adapters": {
+    "runtime": { "enabled": true }
+  }
+}
 ```
 
 A stale lock can be recovered only after AgentRinse proves the recorded local
@@ -158,7 +195,7 @@ exact so they can be used for planning.
 
 ## Platform Support
 
-| Platform       | `0.1.0` support                                     |
+| Platform       | `0.2.0` support                                     |
 | -------------- | --------------------------------------------------- |
 | macOS          | audit and safe artifact apply                       |
 | Linux          | audit and safe artifact apply                       |

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -62,8 +62,13 @@ directory-level size reporting.
 ### Git
 
 The Git adapter is disabled by default and requires an explicit repository
-root. It uses `git worktree list --porcelain -z` and still protects every
-worktree until activity and push-state collectors exist.
+root. It uses `git worktree list --porcelain -z`, porcelain v2 status, local
+ref containment, configured remote-tracking refs, operation markers, and live
+process ownership. Whole-worktree removal remains unavailable in `0.2.0`.
+
+Codex and Claude metadata roots, explicit config pins, and the closeout
+current-worktree root are shared with artifact classification. A nested
+artifact never remains eligible after one of those roots is added.
 
 ### Docker
 

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -12,6 +12,7 @@ separately scoped to explicitly configured rebuildable directories.
 | Zed            | user-data root                                             | all             |
 | OpenCode       | database, logs, snapshots                                  | all             |
 | Grok Build     | version-gated data root                                    | all             |
+| Runtime        | opt-in selected executable and Claude native versions      | all             |
 | Git            | explicit repository worktree porcelain                     | all             |
 | Docker         | opt-in structured image/container inventory                | all             |
 | Artifacts      | exact configured rebuildable directories                   | conditional     |
@@ -69,6 +70,18 @@ process ownership. Whole-worktree removal remains unavailable in `0.2.0`.
 Codex and Claude metadata roots, explicit config pins, and the closeout
 current-worktree root are shared with artifact classification. A nested
 artifact never remains eligible after one of those roots is added.
+
+### Runtime
+
+Runtime inventory is opt-in. It reports selected Codex, Claude, Cursor,
+Copilot, OpenCode, and Grok executables found on `PATH`. Unknown installation
+managers remain `unknown`; AgentRinse recommends the owning installer or
+package manager and proposes no action.
+
+For Claude's documented native macOS/Linux layout, AgentRinse inventories
+regular files under `$HOME/.local/share/claude/versions` and marks the version
+selected by `$HOME/.local/bin/claude`. It does not infer staging names or
+remove superseded versions.
 
 ### Docker
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -104,3 +104,37 @@ Current `0.1.0` behavior:
 | `130` | apply was interrupted at a safe checkpoint   |
 
 The run journal remains the source of truth for apply outcomes.
+
+## Closeout Profile
+
+The closeout profile starts from the current Git worktree, inventories every
+worktree registered to that repository, loads only Codex and Claude
+reachability metadata, and filters configured artifact projects to those
+worktrees:
+
+```bash
+agentrinse clean --profile closeout
+agentrinse clean --profile closeout --json
+```
+
+The current worktree is always a root. A dry run persists the exact audit,
+plan, and derived scoped config. The printed config path can be supplied if
+the persisted plan is applied separately:
+
+```bash
+agentrinse apply --plan <plan-path> --config <config-path> --yes
+```
+
+For a fresh one-command apply of existing `safe` artifact actions:
+
+```bash
+agentrinse clean --profile closeout --apply
+agentrinse clean --profile closeout --apply --yes --max-risk safe --json
+```
+
+The profile does not infer that work is complete. Call it only after the task
+has landed, been handed off, or otherwise reached a terminal state.
+
+On macOS, an installed Mole binary adds two external suggestions:
+`mo purge --dry-run` and `mo clean --dry-run`. AgentRinse does not execute or
+parse either command.

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -105,6 +105,10 @@ Current `0.2.0` behavior:
 
 The run journal remains the source of truth for apply outcomes.
 
+A degraded `audit` remains report-only and exits `0`. A degraded `clean`
+closeout exits `1` so automation does not treat incomplete safety evidence as
+a clean closeout.
+
 ## Closeout Profile
 
 The closeout profile starts from the current Git worktree, inventories every

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -25,7 +25,7 @@ schemas.
 {
   "schemaVersion": 1,
   "command": "audit",
-  "agentrinseVersion": "0.1.0",
+  "agentrinseVersion": "0.2.0",
   "startedAt": "2026-07-24T00:00:00.000Z",
   "completedAt": "2026-07-24T00:00:01.000Z",
   "status": "ok",
@@ -94,7 +94,7 @@ resource is skipped rather than substituted.
 
 ## Exit Status
 
-Current `0.1.0` behavior:
+Current `0.2.0` behavior:
 
 | Code  | Meaning                                      |
 | ----- | -------------------------------------------- |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,14 @@ An explicitly requested missing or invalid file is an error.
     "minBytes": 67108864,
     "processCheck": "required"
   },
+  "pins": [
+    { "path": "/absolute/project-worktree" },
+    { "resourceId": "git:git-worktree:..." },
+    {
+      "gitRef": "refs/heads/release",
+      "expiresAt": "2026-08-01T00:00:00.000Z"
+    }
+  ],
   "plan": {
     "ttlMinutes": 30,
     "maxRisk": "safe"
@@ -65,6 +73,16 @@ An explicitly requested missing or invalid file is an error.
 Unknown keys are discarded by the current schema. Project roots must be
 unique absolute paths. Cleanup targets from different project entries may not
 overlap.
+
+## Pins
+
+Pins are explicit user-owned protection roots. A pin may name one absolute
+path, one exact AgentRinse resource ID, or one full Git ref under
+`refs/heads`, `refs/remotes`, or `refs/tags`.
+
+`expiresAt` is optional and must be an ISO 8601 timestamp. An expired pin is
+ignored. Pin evidence is hashed in findings; AgentRinse does not emit the
+configured path or ref as the evidence reference.
 
 ## Provider Adapters
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,7 @@ An explicitly requested missing or invalid file is an error.
     "zed": { "enabled": true },
     "opencode": { "enabled": true },
     "grok": { "enabled": true },
+    "runtime": { "enabled": false },
     "git": { "enabled": false, "root": "/absolute/repository" },
     "docker": { "enabled": false }
   },
@@ -91,9 +92,11 @@ are enabled for read-only inventory by default. Each accepts an optional
 `root`. Missing default roots mean the provider is absent, not broken. A
 missing explicit root is a doctor warning.
 
-Git is disabled by default and requires an explicit repository root. Docker is
-disabled by default and uses the active Docker context when enabled. Both
-adapters remain report-only in `0.1.0`.
+Git is disabled by default and requires an explicit repository root. Runtime
+inventory is disabled by default because it searches `PATH` and may execute
+selected binaries with `--version`. Docker is disabled by default and uses
+the active Docker context when enabled. All three adapters remain report-only
+in `0.2.0`.
 
 ## Artifact Projects
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,10 @@ path, one exact AgentRinse resource ID, or one full Git ref under
 ignored. Pin evidence is hashed in findings; AgentRinse does not emit the
 configured path or ref as the evidence reference.
 
+Git ref pins resolve through the Git adapter before artifact classification.
+If Git is disabled or ref inspection is incomplete, AgentRinse conservatively
+protects the unresolved scope instead of allowing an artifact action.
+
 ## Provider Adapters
 
 Codex, Claude Code, Cursor, GitHub Copilot CLI, Zed, OpenCode, and Grok Build

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -25,8 +25,11 @@ macOS is Tier 1 for `0.1.0`.
 - `lsof` process ownership proof
 - safe configured artifact apply
 - optional Mole detection through `mo --version`
+- external `mo purge --dry-run` and `mo clean --dry-run` suggestions from the
+  closeout profile
 
-Mole remains external. AgentRinse does not embed or invoke Mole cleanup.
+Mole remains external. AgentRinse does not embed, invoke, or parse Mole
+cleanup.
 
 ## Linux
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -3381,12 +3381,12 @@ decision-log entry. They must not be smuggled in as adapter fixes.
 - [x] initial Claude inventory
 - [x] initial Docker inventory
 - [x] Cursor, Copilot CLI, Zed, OpenCode, and Grok inventory
-- [ ] runtime audit
+- [x] runtime audit
 - [x] Mole probe
 - [x] exact configured artifact removal
-- [ ] Git dirty, staged, untracked, operation, detached, and push-state proof
-- [ ] Codex and Claude session-to-worktree roots
-- [ ] provider-managed worktree and pin roots
+- [x] Git dirty, staged, untracked, operation, detached, and push-state proof
+- [x] Codex and Claude session-to-worktree roots
+- [x] provider-managed worktree and pin roots
 - [ ] Docker safe cleanup
 - [ ] worktree quarantine
 - [ ] worktree undo

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -3356,7 +3356,7 @@ decision-log entry. They must not be smuggled in as adapter fixes.
 - [x] define initial exit codes
 - [x] implement canonical JSON hashing
 - [x] implement initial schema compatibility tests
-- [ ] define `0.2.0` reachability facts and roots
+- [x] define `0.2.0` reachability facts and roots
 - [ ] define `0.3.0` quarantine, recovery, undo, and purge records
 
 ### Core safety

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -45,7 +45,7 @@ This phase requires a separate mutation-boundary decision.
 - Cursor database diagnostics and optional compaction
 - provider-native retention operations
 - filtered Docker build-cache cleanup
-- old agent runtime inventory and owner-managed removal
+- owner-managed old agent runtime removal
 
 Every owner-specific mutation remains disabled until its current upstream
 contract, offline requirements, and recovery behavior are proven.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,16 +22,17 @@ Shipped:
 
 ## 0.2: Agent-Aware Reachability
 
+Shipped:
+
 - Git dirty, staged, untracked, operation, detached, and push-state proof
 - provider session-to-worktree roots
 - provider-managed worktree and pin roots
 - runtime installation inventory
 - report-only cleanup recommendations for protected provider state
+- repository-scoped closeout profile and Mole dry-run handoff
 
 ## 0.3: Recoverable Worktrees
 
-- dirty, staged, untracked, stash, detached, and unpushed proof
-- live process and session roots
 - recovery refs
 - same-filesystem quarantine
 - tested undo and expiry

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentrinse",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": false,
   "description": "Safe, local-first cleanup for agentic development.",
   "keywords": [

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -2,16 +2,18 @@ import { execFile } from "node:child_process";
 import { access, mkdir, mkdtemp, readFile, realpath, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 const packageJson = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"));
 const { assertDestructiveFixtureRoot } = await import("../dist/core/safety.js");
 const installedCli = process.env.AGENTRINSE_SMOKE_CLI;
-const runCli = (args) =>
+const sourceCli = fileURLToPath(new URL("../dist/cli.js", import.meta.url));
+const runCli = (args, cwd = process.cwd()) =>
   installedCli
-    ? execFileAsync(installedCli, args, { cwd: process.cwd() })
-    : execFileAsync(process.execPath, ["dist/cli.js", ...args], { cwd: process.cwd() });
+    ? execFileAsync(installedCli, args, { cwd })
+    : execFileAsync(process.execPath, [sourceCli, ...args], { cwd });
 const root = await realpath(await mkdtemp(join(tmpdir(), "agentrinse-smoke-")));
 await assertDestructiveFixtureRoot(root);
 const home = join(root, "home");
@@ -27,6 +29,14 @@ await mkdir(join(home, ".local", "share", "opencode", "snapshot"), {
   recursive: true,
 });
 await writeFile(join(home, ".codex", "sessions", "thread.jsonl"), "synthetic fixture\n");
+await writeFile(
+  join(home, ".codex", ".codex-global-state.json"),
+  `${JSON.stringify({
+    "active-workspace-roots": [],
+    "electron-saved-workspace-roots": [],
+    "thread-workspace-root-hints": {},
+  })}\n`,
+);
 await writeFile(
   join(home, ".local", "share", "opencode", "snapshot", "object"),
   "synthetic snapshot\n",
@@ -98,6 +108,46 @@ try {
     throw error;
   }
 }
+
+await execFileAsync("git", ["init", "-b", "main"], { cwd: project });
+await execFileAsync("git", ["add", "source.ts"], { cwd: project });
+await execFileAsync(
+  "git",
+  [
+    "-c",
+    "user.name=AgentRinse",
+    "-c",
+    "user.email=fixture@example.invalid",
+    "commit",
+    "-m",
+    "fixture",
+  ],
+  { cwd: project },
+);
+const closeoutOutput = await runCli(
+  [
+    "clean",
+    "--profile",
+    "closeout",
+    "--home",
+    home,
+    "--config",
+    configPath,
+    "--state-dir",
+    statePath,
+    "--json",
+  ],
+  project,
+);
+const closeout = JSON.parse(closeoutOutput.stdout);
+if (
+  closeout.command !== "clean" ||
+  closeout.data?.profile !== "closeout" ||
+  closeout.data?.worktrees !== 1 ||
+  closeout.data?.eligibleActions !== 0
+) {
+  throw new Error("smoke closeout profile did not produce the expected bounded summary");
+}
 process.stdout.write(
   `${JSON.stringify({
     version: packageJson.version,
@@ -106,6 +156,7 @@ process.stdout.write(
     protected: 2,
     planActions: plan.actions.length,
     applied: 1,
+    closeoutWorktrees: closeout.data.worktrees,
     reclaimedBytes: run.reclaimedBytes,
   })}\n`,
 );

--- a/src/adapters/artifacts/adapter.ts
+++ b/src/adapters/artifacts/adapter.ts
@@ -19,6 +19,13 @@ import type { ReachabilityIndex } from "../../core/reachability.js";
 import { isPathInside } from "../../core/safety.js";
 
 type ArtifactOptions = AgentRinseConfig["artifacts"] & AgentRinseConfig["audit"];
+const ARTIFACT_PROTECTION_ROOTS = new Set([
+  "active-session",
+  "current-worktree",
+  "provider-managed-worktree",
+  "recent-session",
+  "user-pin",
+]);
 
 export type ProcessProbe = (path: string) => Promise<ProcessOwnershipResult>;
 export type MountProbe = (path: string) => Promise<MountBoundaryResult>;
@@ -354,11 +361,9 @@ export class ArtifactAuditAdapter implements AuditAdapter {
       });
     }
 
-    const reachabilityRoots = this.reachability?.rootsForResource(
-      resource.resource,
-      resource.facts,
-      context.now.toISOString(),
-    );
+    const reachabilityRoots = this.reachability
+      ?.rootsForResource(resource.resource, resource.facts, context.now.toISOString())
+      .filter((root) => ARTIFACT_PROTECTION_ROOTS.has(root.code));
     if (reachabilityRoots !== undefined && reachabilityRoots.length > 0) {
       roots.push(...reachabilityRoots);
       if (state === "eligible") {

--- a/src/adapters/artifacts/adapter.ts
+++ b/src/adapters/artifacts/adapter.ts
@@ -15,6 +15,7 @@ import {
   findProcessesUsingPath,
   type ProcessOwnershipResult,
 } from "../../core/process-ownership.js";
+import type { ReachabilityIndex } from "../../core/reachability.js";
 import { isPathInside } from "../../core/safety.js";
 
 type ArtifactOptions = AgentRinseConfig["artifacts"] & AgentRinseConfig["audit"];
@@ -44,6 +45,7 @@ export class ArtifactAuditAdapter implements AuditAdapter {
     private readonly options: ArtifactOptions,
     private readonly processProbe: ProcessProbe = findProcessesUsingPath,
     private readonly mountProbe: MountProbe = findMountBoundaries,
+    private readonly reachability?: ReachabilityIndex,
   ) {}
 
   private async validProjects(context: AuditContext): Promise<{
@@ -351,6 +353,22 @@ export class ArtifactAuditAdapter implements AuditAdapter {
         resourceId: resource.resource.id,
       });
     }
+
+    const reachabilityRoots = this.reachability?.rootsForResource(
+      resource.resource,
+      resource.facts,
+      context.now.toISOString(),
+    );
+    if (reachabilityRoots !== undefined && reachabilityRoots.length > 0) {
+      roots.push(...reachabilityRoots);
+      if (state === "eligible") {
+        state = "protected";
+      }
+    }
+    roots.sort((left, right) => {
+      const byCode = left.code.localeCompare(right.code);
+      return byCode !== 0 ? byCode : left.source.localeCompare(right.source);
+    });
 
     const candidateActions: ArtifactRemoveAction[] =
       state === "eligible" ? [this.actionFor(resource)] : [];

--- a/src/adapters/git/adapter.ts
+++ b/src/adapters/git/adapter.ts
@@ -4,15 +4,26 @@ import { resolve } from "node:path";
 import { promisify } from "node:util";
 
 import type { AuditAdapter, AuditContext, CollectionResult } from "../../contracts/adapter.js";
+import type { Diagnostic } from "../../contracts/diagnostic.js";
 import type { Finding, RootEvidence } from "../../contracts/finding.js";
 import type { AdapterProbe } from "../../contracts/report.js";
 import type { ResourceSnapshot } from "../../contracts/resource.js";
 import { sha256 } from "../../core/digest.js";
 import { parseWorktreePorcelain } from "./porcelain.js";
+import { parseGitStatusPorcelainV2, type GitStatusFacts } from "./status.js";
 
 const execFileAsync = promisify(execFile);
+const OPERATION_MARKERS = [
+  ["merge", "MERGE_HEAD"],
+  ["rebase", "rebase-merge"],
+  ["rebase", "rebase-apply"],
+  ["cherry-pick", "CHERRY_PICK_HEAD"],
+  ["revert", "REVERT_HEAD"],
+  ["bisect", "BISECT_LOG"],
+] as const;
 
 export type GitRunner = (args: string[]) => Promise<string>;
+export type GitPathExists = (path: string) => Promise<boolean>;
 
 async function defaultGitRunner(args: string[]): Promise<string> {
   const result = await execFileAsync("git", args, {
@@ -29,12 +40,32 @@ function isMissing(error: unknown): boolean {
   );
 }
 
+async function defaultPathExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return true;
+  } catch (error) {
+    if (isMissing(error)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function lines(input: string): string[] {
+  return input
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "");
+}
+
 export class GitWorktreeAuditAdapter implements AuditAdapter {
   readonly id = "git";
 
   constructor(
     private readonly root: string | undefined,
     private readonly runGit: GitRunner = defaultGitRunner,
+    private readonly pathExists: GitPathExists = defaultPathExists,
   ) {}
 
   async probe(_context: AuditContext): Promise<AdapterProbe> {
@@ -92,6 +123,7 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
     const output = await this.runGit(["-C", probe.root, "worktree", "list", "--porcelain", "-z"]);
     const records = parseWorktreePorcelain(output);
     const resources: ResourceSnapshot[] = [];
+    const diagnostics: Diagnostic[] = [];
 
     for (const record of records) {
       let exists = true;
@@ -105,7 +137,70 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
         exists = false;
       }
 
-      const canonicalKey = `git:git-worktree:${resolve(record.path)}`;
+      const worktreePath = resolve(record.path);
+      const canonicalKey = `git:git-worktree:${worktreePath}`;
+      let inspectionComplete = exists;
+      let status: GitStatusFacts | undefined;
+      let containingRefs: string[] = [];
+      let remotes: string[] = [];
+      const operations = new Set<string>();
+
+      if (exists) {
+        try {
+          status = parseGitStatusPorcelainV2(
+            await this.runGit([
+              "-C",
+              worktreePath,
+              "status",
+              "--porcelain=v2",
+              "--branch",
+              "-z",
+              "--untracked-files=all",
+            ]),
+          );
+          remotes = lines(await this.runGit(["-C", worktreePath, "remote"]));
+          const head = status.head ?? record.head;
+          if (head !== undefined) {
+            containingRefs = lines(
+              await this.runGit([
+                "-C",
+                worktreePath,
+                "for-each-ref",
+                "--contains",
+                head,
+                "--format=%(refname)",
+                "refs/heads",
+                "refs/remotes",
+              ]),
+            );
+          }
+          for (const [operation, marker] of OPERATION_MARKERS) {
+            const markerPath = (
+              await this.runGit(["-C", worktreePath, "rev-parse", "--git-path", marker])
+            ).trim();
+            if (markerPath !== "" && (await this.pathExists(markerPath))) {
+              operations.add(operation);
+            }
+          }
+        } catch (error) {
+          inspectionComplete = false;
+          diagnostics.push({
+            severity: "warning",
+            code: "GIT_WORKTREE_INSPECTION_FAILED",
+            message: error instanceof Error ? error.message : String(error),
+            adapter: this.id,
+          });
+        }
+      }
+
+      const localReachable = containingRefs.some((ref) => ref.startsWith("refs/heads/"));
+      const remoteReachable = containingRefs.some((ref) => ref.startsWith("refs/remotes/"));
+      const remoteConfigured = remotes.length > 0;
+      const ahead = status?.ahead ?? 0;
+      const staged = status?.staged ?? 0;
+      const modified = status?.modified ?? 0;
+      const untracked = status?.untracked ?? 0;
+      const conflicted = status?.conflicted ?? 0;
       resources.push({
         resource: {
           id: `git:git-worktree:${sha256(canonicalKey)}`,
@@ -113,24 +208,39 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
           kind: "git-worktree",
           canonicalKey,
           displayName: record.path === probe.root ? "Main worktree" : "Linked worktree",
-          path: resolve(record.path),
+          path: worktreePath,
         },
         observedAt: context.now.toISOString(),
         exists,
         facts: {
-          isMain: resolve(record.path) === resolve(probe.root),
-          head: record.head,
-          branch: record.branch,
+          isMain: worktreePath === resolve(probe.root),
+          head: status?.head ?? record.head,
+          branch: status?.branch ?? record.branch,
+          upstream: status?.upstream,
           detached: record.detached,
           bare: record.bare,
           locked: record.locked,
           prunable: record.prunable,
+          staged,
+          modified,
+          untracked,
+          conflicted,
+          dirty: staged + modified + untracked + conflicted > 0,
+          ahead,
+          behind: status?.behind ?? 0,
+          operations: [...operations].sort(),
+          localReachable,
+          remoteReachable,
+          remoteConfigured,
+          unpushed: ahead > 0 || (remoteConfigured && localReachable && !remoteReachable),
+          remoteProof: remoteConfigured ? "local-remote-tracking-refs" : "unavailable",
+          inspectionComplete,
           reportOnly: true,
         },
       });
     }
 
-    return { resources, diagnostics: [] };
+    return { resources, diagnostics };
   }
 
   async classify(context: AuditContext, resource: ResourceSnapshot): Promise<Finding> {
@@ -155,12 +265,65 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
       });
     }
 
+    if (resource.facts.dirty === true) {
+      roots.push({
+        code: "dirty-worktree",
+        source: "git",
+        observedAt,
+        detail: "Git reports staged, modified, conflicted, or untracked work.",
+      });
+    }
+    if (Array.isArray(resource.facts.operations) && resource.facts.operations.length > 0) {
+      roots.push({
+        code: "git-operation-in-progress",
+        source: "git",
+        observedAt,
+        detail: `Git operation in progress: ${resource.facts.operations.join(", ")}.`,
+      });
+    }
+    if (resource.facts.unpushed === true) {
+      roots.push({
+        code: "unpushed-commit",
+        source: "git",
+        observedAt,
+        detail: "The worktree HEAD is ahead of or absent from local remote-tracking refs.",
+      });
+    }
+    if (resource.facts.remoteConfigured !== true) {
+      roots.push({
+        code: "unknown-remote",
+        source: "git",
+        observedAt,
+        detail: "No configured remote is available for reachability proof.",
+      });
+    }
+    if (
+      resource.facts.detached === true &&
+      resource.facts.localReachable !== true &&
+      resource.facts.remoteReachable !== true
+    ) {
+      roots.push({
+        code: "unreachable-detached-commit",
+        source: "git",
+        observedAt,
+        detail: "The detached HEAD is not contained by a local or remote-tracking ref.",
+      });
+    }
+    if (resource.facts.inspectionComplete !== true) {
+      roots.push({
+        code: "git-inspection-incomplete",
+        source: "git",
+        observedAt,
+        detail: "Git state or reachability could not be proven completely.",
+      });
+    }
     roots.push({
-      code: "git-audit-only",
+      code: "worktree-removal-unavailable",
       source: "git",
       observedAt,
-      detail: "The Git adapter does not yet prove dirty, process, session, or push state.",
+      detail: "AgentRinse 0.2 reports reachability but does not remove worktrees.",
     });
+    roots.sort((left, right) => left.code.localeCompare(right.code));
 
     return {
       schemaVersion: 1,
@@ -168,8 +331,10 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
       auditId: context.auditId,
       observedAt,
       resource: resource.resource,
-      state: resource.exists ? "protected" : "unknown",
-      confidence: resource.exists ? "certain" : "unknown",
+      state:
+        resource.exists && resource.facts.inspectionComplete === true ? "protected" : "unknown",
+      confidence:
+        resource.exists && resource.facts.inspectionComplete === true ? "certain" : "unknown",
       roots,
       facts: resource.facts,
       candidateActions: [],

--- a/src/adapters/git/adapter.ts
+++ b/src/adapters/git/adapter.ts
@@ -65,6 +65,20 @@ function lines(input: string): string[] {
     .filter((line) => line !== "");
 }
 
+function branchRef(branch: string | undefined): string | undefined {
+  if (branch === undefined) {
+    return undefined;
+  }
+  return branch.startsWith("refs/") ? branch : `refs/heads/${branch}`;
+}
+
+function upstreamRef(upstream: string | undefined): string | undefined {
+  if (upstream === undefined) {
+    return undefined;
+  }
+  return upstream.startsWith("refs/") ? upstream : `refs/remotes/${upstream}`;
+}
+
 export class GitWorktreeAuditAdapter implements AuditAdapter {
   readonly id = "git";
 
@@ -125,6 +139,7 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
 
   async collect(context: AuditContext, probe: AdapterProbe): Promise<CollectionResult> {
     if (probe.status !== "available" || probe.root === undefined) {
+      this.reachability?.protectUnresolvedGitRefs(context.now.toISOString());
       return { resources: [], diagnostics: [] };
     }
 
@@ -151,6 +166,8 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
       let inspectionComplete = exists;
       let status: GitStatusFacts | undefined;
       let containingRefs: string[] = [];
+      let gitRefs: string[] = [];
+      let gitRefInspectionComplete = false;
       let remotes: string[] = [];
       const operations = new Set<string>();
       let processOwnership: ProcessOwnershipResult = {
@@ -187,6 +204,27 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
                 "refs/remotes",
               ]),
             );
+            const tagRefs = lines(
+              await this.runGit([
+                "-C",
+                worktreePath,
+                "for-each-ref",
+                "--points-at",
+                head,
+                "--format=%(refname)",
+                "refs/tags",
+              ]),
+            );
+            gitRefs = [
+              record.branch,
+              branchRef(status.branch),
+              upstreamRef(status.upstream),
+              ...tagRefs,
+            ]
+              .filter((value): value is string => value !== undefined)
+              .filter((value, index, values) => values.indexOf(value) === index)
+              .sort();
+            gitRefInspectionComplete = true;
           }
           for (const [operation, marker] of OPERATION_MARKERS) {
             const reportedMarkerPath = (
@@ -214,6 +252,12 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
           });
         }
       }
+      this.reachability?.bindGitRefsToPath(
+        worktreePath,
+        gitRefs,
+        context.now.toISOString(),
+        gitRefInspectionComplete,
+      );
 
       const localReachable = containingRefs.some((ref) => ref.startsWith("refs/heads/"));
       const remoteReachable = containingRefs.some((ref) => ref.startsWith("refs/remotes/"));
@@ -239,6 +283,7 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
           head: status?.head ?? record.head,
           branch: status?.branch ?? record.branch,
           upstream: status?.upstream,
+          gitRefs,
           detached: record.detached,
           bare: record.bare,
           locked: record.locked,
@@ -270,6 +315,9 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
           reportOnly: true,
         },
       });
+    }
+    if (records.length === 0) {
+      this.reachability?.protectUnresolvedGitRefs(context.now.toISOString());
     }
 
     return { resources, diagnostics };

--- a/src/adapters/git/adapter.ts
+++ b/src/adapters/git/adapter.ts
@@ -9,6 +9,10 @@ import type { Finding, RootEvidence } from "../../contracts/finding.js";
 import type { AdapterProbe } from "../../contracts/report.js";
 import type { ResourceSnapshot } from "../../contracts/resource.js";
 import { sha256 } from "../../core/digest.js";
+import {
+  findProcessesUsingPath,
+  type ProcessOwnershipResult,
+} from "../../core/process-ownership.js";
 import { parseWorktreePorcelain } from "./porcelain.js";
 import { parseGitStatusPorcelainV2, type GitStatusFacts } from "./status.js";
 
@@ -24,6 +28,7 @@ const OPERATION_MARKERS = [
 
 export type GitRunner = (args: string[]) => Promise<string>;
 export type GitPathExists = (path: string) => Promise<boolean>;
+export type GitProcessProbe = (path: string) => Promise<ProcessOwnershipResult>;
 
 async function defaultGitRunner(args: string[]): Promise<string> {
   const result = await execFileAsync("git", args, {
@@ -66,6 +71,7 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
     private readonly root: string | undefined,
     private readonly runGit: GitRunner = defaultGitRunner,
     private readonly pathExists: GitPathExists = defaultPathExists,
+    private readonly processProbe: GitProcessProbe = (path) => findProcessesUsingPath(path),
   ) {}
 
   async probe(_context: AuditContext): Promise<AdapterProbe> {
@@ -144,6 +150,11 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
       let containingRefs: string[] = [];
       let remotes: string[] = [];
       const operations = new Set<string>();
+      let processOwnership: ProcessOwnershipResult = {
+        status: "unknown",
+        matches: [],
+        reason: "worktree does not exist",
+      };
 
       if (exists) {
         try {
@@ -181,6 +192,10 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
             if (markerPath !== "" && (await this.pathExists(markerPath))) {
               operations.add(operation);
             }
+          }
+          processOwnership = await this.processProbe(worktreePath);
+          if (processOwnership.status === "unknown") {
+            inspectionComplete = false;
           }
         } catch (error) {
           inspectionComplete = false;
@@ -229,6 +244,16 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
           ahead,
           behind: status?.behind ?? 0,
           operations: [...operations].sort(),
+          processOwnership: processOwnership.status,
+          processMatches:
+            processOwnership.status === "busy"
+              ? processOwnership.matches.map((match) => ({
+                  pid: match.pid,
+                  source: match.source,
+                }))
+              : [],
+          processReason:
+            processOwnership.status === "unknown" ? processOwnership.reason : undefined,
           localReachable,
           remoteReachable,
           remoteConfigured,
@@ -287,6 +312,22 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
         source: "git",
         observedAt,
         detail: "The worktree HEAD is ahead of or absent from local remote-tracking refs.",
+      });
+    }
+    if (resource.facts.processOwnership === "busy") {
+      roots.push({
+        code: "live-process-worktree",
+        source: "process",
+        observedAt,
+        detail: "A live process has its CWD or an open file inside this worktree.",
+      });
+    }
+    if (resource.facts.processOwnership === "unknown") {
+      roots.push({
+        code: "process-ownership-incomplete",
+        source: "process",
+        observedAt,
+        detail: "Live process ownership could not be proven completely.",
       });
     }
     if (resource.facts.remoteConfigured !== true) {

--- a/src/adapters/git/adapter.ts
+++ b/src/adapters/git/adapter.ts
@@ -13,6 +13,7 @@ import {
   findProcessesUsingPath,
   type ProcessOwnershipResult,
 } from "../../core/process-ownership.js";
+import type { ReachabilityIndex } from "../../core/reachability.js";
 import { parseWorktreePorcelain } from "./porcelain.js";
 import { parseGitStatusPorcelainV2, type GitStatusFacts } from "./status.js";
 
@@ -72,6 +73,7 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
     private readonly runGit: GitRunner = defaultGitRunner,
     private readonly pathExists: GitPathExists = defaultPathExists,
     private readonly processProbe: GitProcessProbe = (path) => findProcessesUsingPath(path),
+    private readonly reachability?: ReachabilityIndex,
   ) {}
 
   async probe(_context: AuditContext): Promise<AdapterProbe> {
@@ -357,6 +359,9 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
         observedAt,
         detail: "Git state or reachability could not be proven completely.",
       });
+    }
+    if (resource.resource.path !== undefined) {
+      roots.push(...(this.reachability?.rootsFor(resource.resource.path, observedAt) ?? []));
     }
     roots.push({
       code: "worktree-removal-unavailable",

--- a/src/adapters/git/adapter.ts
+++ b/src/adapters/git/adapter.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { lstat } from "node:fs/promises";
-import { resolve } from "node:path";
+import { isAbsolute, resolve } from "node:path";
 import { promisify } from "node:util";
 
 import type { AuditAdapter, AuditContext, CollectionResult } from "../../contracts/adapter.js";
@@ -130,6 +130,7 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
 
     const output = await this.runGit(["-C", probe.root, "worktree", "list", "--porcelain", "-z"]);
     const records = parseWorktreePorcelain(output);
+    const mainWorktreePath = records[0] === undefined ? undefined : resolve(records[0].path);
     const resources: ResourceSnapshot[] = [];
     const diagnostics: Diagnostic[] = [];
 
@@ -188,9 +189,13 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
             );
           }
           for (const [operation, marker] of OPERATION_MARKERS) {
-            const markerPath = (
+            const reportedMarkerPath = (
               await this.runGit(["-C", worktreePath, "rev-parse", "--git-path", marker])
             ).trim();
+            const markerPath =
+              reportedMarkerPath === "" || isAbsolute(reportedMarkerPath)
+                ? reportedMarkerPath
+                : resolve(worktreePath, reportedMarkerPath);
             if (markerPath !== "" && (await this.pathExists(markerPath))) {
               operations.add(operation);
             }
@@ -224,13 +229,13 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
           adapter: this.id,
           kind: "git-worktree",
           canonicalKey,
-          displayName: record.path === probe.root ? "Main worktree" : "Linked worktree",
+          displayName: worktreePath === mainWorktreePath ? "Main worktree" : "Linked worktree",
           path: worktreePath,
         },
         observedAt: context.now.toISOString(),
         exists,
         facts: {
-          isMain: worktreePath === resolve(probe.root),
+          isMain: worktreePath === mainWorktreePath,
           head: status?.head ?? record.head,
           branch: status?.branch ?? record.branch,
           upstream: status?.upstream,

--- a/src/adapters/git/adapter.ts
+++ b/src/adapters/git/adapter.ts
@@ -360,9 +360,9 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
         detail: "Git state or reachability could not be proven completely.",
       });
     }
-    if (resource.resource.path !== undefined) {
-      roots.push(...(this.reachability?.rootsFor(resource.resource.path, observedAt) ?? []));
-    }
+    roots.push(
+      ...(this.reachability?.rootsForResource(resource.resource, resource.facts, observedAt) ?? []),
+    );
     roots.push({
       code: "worktree-removal-unavailable",
       source: "git",

--- a/src/adapters/git/status.ts
+++ b/src/adapters/git/status.ts
@@ -1,0 +1,96 @@
+export type GitStatusFacts = {
+  head?: string;
+  branch?: string;
+  upstream?: string;
+  ahead: number;
+  behind: number;
+  staged: number;
+  modified: number;
+  untracked: number;
+  conflicted: number;
+  ignored: number;
+};
+
+function changeFlags(token: string): { staged: boolean; modified: boolean } {
+  return {
+    staged: token[0] !== undefined && token[0] !== ".",
+    modified: token[1] !== undefined && token[1] !== ".",
+  };
+}
+
+export function parseGitStatusPorcelainV2(input: string): GitStatusFacts {
+  const facts: GitStatusFacts = {
+    ahead: 0,
+    behind: 0,
+    staged: 0,
+    modified: 0,
+    untracked: 0,
+    conflicted: 0,
+    ignored: 0,
+  };
+  let expectRenameSource = false;
+
+  for (const token of input.split("\0")) {
+    if (token === "") {
+      continue;
+    }
+    if (expectRenameSource) {
+      expectRenameSource = false;
+      continue;
+    }
+    if (token.startsWith("# branch.oid ")) {
+      const value = token.slice("# branch.oid ".length);
+      if (value !== "(initial)") {
+        facts.head = value;
+      }
+      continue;
+    }
+    if (token.startsWith("# branch.head ")) {
+      const value = token.slice("# branch.head ".length);
+      if (value !== "(detached)") {
+        facts.branch = value;
+      }
+      continue;
+    }
+    if (token.startsWith("# branch.upstream ")) {
+      facts.upstream = token.slice("# branch.upstream ".length);
+      continue;
+    }
+    if (token.startsWith("# branch.ab ")) {
+      const match = /^# branch\.ab \+(\d+) -(\d+)$/u.exec(token);
+      if (match === null) {
+        throw new Error(`invalid branch.ab record: ${token}`);
+      }
+      facts.ahead = Number.parseInt(match[1]!, 10);
+      facts.behind = Number.parseInt(match[2]!, 10);
+      continue;
+    }
+    if (token.startsWith("1 ") || token.startsWith("2 ")) {
+      const flags = changeFlags(token.slice(2, 4));
+      facts.staged += Number(flags.staged);
+      facts.modified += Number(flags.modified);
+      expectRenameSource = token.startsWith("2 ");
+      continue;
+    }
+    if (token.startsWith("u ")) {
+      facts.conflicted += 1;
+      facts.staged += 1;
+      facts.modified += 1;
+      continue;
+    }
+    if (token.startsWith("? ")) {
+      facts.untracked += 1;
+      continue;
+    }
+    if (token.startsWith("! ")) {
+      facts.ignored += 1;
+      continue;
+    }
+    if (token.startsWith("# ")) {
+      continue;
+    }
+    throw new Error(`unknown porcelain v2 record: ${token}`);
+  }
+
+  return facts;
+}

--- a/src/adapters/provider-adapter.ts
+++ b/src/adapters/provider-adapter.ts
@@ -8,6 +8,8 @@ import type { AdapterProbe } from "../contracts/report.js";
 import type { ResourceSnapshot } from "../contracts/resource.js";
 import { sha256 } from "../core/digest.js";
 import { measurePath } from "../core/measure.js";
+import type { ReachabilityIndex } from "../core/reachability.js";
+import { collectProviderReachability } from "./provider-reachability.js";
 import type { ProviderSpec } from "./provider-specs.js";
 
 export type ProviderAdapterOptions = {
@@ -15,6 +17,7 @@ export type ProviderAdapterOptions = {
   platform?: NodeJS.Platform;
   measureBytes: boolean;
   maxEntries: number;
+  reachability?: ReachabilityIndex;
 };
 
 function isMissing(error: unknown): boolean {
@@ -116,11 +119,33 @@ export class ProviderAuditAdapter implements AuditAdapter {
 
   async collect(context: AuditContext, probe: AdapterProbe): Promise<CollectionResult> {
     if (probe.status !== "available" || probe.root === undefined) {
+      if (
+        probe.status === "degraded" &&
+        this.options.reachability !== undefined &&
+        (this.spec.id === "codex" || this.spec.id === "claude")
+      ) {
+        this.options.reachability.addGlobal({
+          code: "unknown-provider-state",
+          source: this.spec.id,
+          detail: `${this.spec.displayName} ownership metadata could not be inspected.`,
+        });
+      }
       return { resources: [], diagnostics: [] };
     }
 
     const resources: ResourceSnapshot[] = [];
     const diagnostics: Diagnostic[] = [];
+
+    if (this.options.reachability !== undefined) {
+      diagnostics.push(
+        ...(await collectProviderReachability(
+          this.spec.id,
+          context,
+          probe.root,
+          this.options.reachability,
+        )),
+      );
+    }
 
     for (const candidate of this.spec.resources) {
       context.signal?.throwIfAborted();

--- a/src/adapters/provider-adapter.ts
+++ b/src/adapters/provider-adapter.ts
@@ -18,6 +18,7 @@ export type ProviderAdapterOptions = {
   measureBytes: boolean;
   maxEntries: number;
   reachability?: ReachabilityIndex;
+  inventoryResources?: boolean;
 };
 
 function isMissing(error: unknown): boolean {
@@ -145,6 +146,9 @@ export class ProviderAuditAdapter implements AuditAdapter {
           this.options.reachability,
         )),
       );
+    }
+    if (this.options.inventoryResources === false) {
+      return { resources: [], diagnostics };
     }
 
     for (const candidate of this.spec.resources) {

--- a/src/adapters/provider-reachability.ts
+++ b/src/adapters/provider-reachability.ts
@@ -66,7 +66,7 @@ function addPathRoot(
     source: ProviderAdapterId;
     detail: string;
     field: string;
-    scope?: "exact" | "subtree";
+    scope?: "overlap" | "subtree";
   },
 ): boolean {
   if (!isAbsolute(input.path)) {

--- a/src/adapters/provider-reachability.ts
+++ b/src/adapters/provider-reachability.ts
@@ -1,0 +1,318 @@
+import { lstat, readFile } from "node:fs/promises";
+import { isAbsolute, join, resolve } from "node:path";
+
+import type { AuditContext } from "../contracts/adapter.js";
+import type { Diagnostic } from "../contracts/diagnostic.js";
+import { sha256 } from "../core/digest.js";
+import type { ReachabilityIndex } from "../core/reachability.js";
+import type { ProviderAdapterId } from "./provider-specs.js";
+
+type JsonObject = Record<string, unknown>;
+
+function isMissing(error: unknown): boolean {
+  return (
+    error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function diagnostic(adapter: ProviderAdapterId, code: string, message: string): Diagnostic {
+  return {
+    severity: "warning",
+    code,
+    message,
+    adapter,
+  };
+}
+
+async function readMetadataObject(
+  path: string,
+): Promise<
+  | { status: "absent" }
+  | { status: "invalid"; message: string }
+  | { status: "available"; value: JsonObject }
+> {
+  try {
+    const stats = await lstat(path);
+    if (stats.isSymbolicLink()) {
+      return { status: "invalid", message: "Metadata symlinks are not followed." };
+    }
+    if (!stats.isFile()) {
+      return { status: "invalid", message: "Metadata path is not a regular file." };
+    }
+    const value: unknown = JSON.parse(await readFile(path, "utf8"));
+    return isObject(value)
+      ? { status: "available", value }
+      : { status: "invalid", message: "Metadata root must be a JSON object." };
+  } catch (error) {
+    if (isMissing(error)) {
+      return { status: "absent" };
+    }
+    return {
+      status: "invalid",
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function addPathRoot(
+  index: ReachabilityIndex,
+  input: {
+    path: string;
+    code: string;
+    source: ProviderAdapterId;
+    detail: string;
+    field: string;
+    scope?: "exact" | "subtree";
+  },
+): boolean {
+  if (!isAbsolute(input.path)) {
+    return false;
+  }
+  const path = resolve(input.path);
+  index.add({
+    path,
+    code: input.code,
+    source: input.source,
+    detail: input.detail,
+    evidenceRef: sha256(`${input.source}\0${input.field}\0${path}`),
+    ...(input.scope === undefined ? {} : { scope: input.scope }),
+  });
+  return true;
+}
+
+async function addManagedRoot(
+  adapter: ProviderAdapterId,
+  root: string,
+  index: ReachabilityIndex,
+): Promise<Diagnostic[]> {
+  const worktrees = join(root, "worktrees");
+  try {
+    const stats = await lstat(worktrees);
+    if (stats.isSymbolicLink() || !stats.isDirectory()) {
+      index.addGlobal({
+        code: "unknown-provider-state",
+        source: adapter,
+        detail: `${adapter} managed worktree ownership could not be proven.`,
+      });
+      return [
+        diagnostic(
+          adapter,
+          "PROVIDER_WORKTREE_ROOT_UNSAFE",
+          "The managed worktree root must be a real directory.",
+        ),
+      ];
+    }
+    addPathRoot(index, {
+      path: worktrees,
+      code: "provider-managed-worktree",
+      source: adapter,
+      detail: `${adapter} owns this managed worktree.`,
+      field: "worktrees",
+      scope: "subtree",
+    });
+    return [];
+  } catch (error) {
+    if (isMissing(error)) {
+      return [];
+    }
+    index.addGlobal({
+      code: "unknown-provider-state",
+      source: adapter,
+      detail: `${adapter} managed worktree ownership could not be proven.`,
+    });
+    return [
+      diagnostic(
+        adapter,
+        "PROVIDER_WORKTREE_ROOT_UNREADABLE",
+        error instanceof Error ? error.message : String(error),
+      ),
+    ];
+  }
+}
+
+function parsePathArray(
+  value: unknown,
+  add: (path: string) => void,
+): "absent" | "valid" | "invalid" {
+  if (value === undefined) {
+    return "absent";
+  }
+  if (!Array.isArray(value) || value.some((path) => typeof path !== "string")) {
+    return "invalid";
+  }
+  for (const path of value) {
+    add(path as string);
+  }
+  return "valid";
+}
+
+function parsePathRecord(
+  value: unknown,
+  add: (path: string) => void,
+): "absent" | "valid" | "invalid" {
+  if (value === undefined) {
+    return "absent";
+  }
+  if (!isObject(value) || Object.values(value).some((path) => typeof path !== "string")) {
+    return "invalid";
+  }
+  for (const path of Object.values(value)) {
+    add(path as string);
+  }
+  return "valid";
+}
+
+async function collectCodexReachability(
+  root: string,
+  index: ReachabilityIndex,
+): Promise<Diagnostic[]> {
+  const diagnostics = await addManagedRoot("codex", root, index);
+  const metadata = await readMetadataObject(join(root, ".codex-global-state.json"));
+  if (metadata.status !== "available") {
+    index.addGlobal({
+      code: "unknown-provider-state",
+      source: "codex",
+      detail: "Codex workspace metadata could not be proven.",
+    });
+    diagnostics.push(
+      diagnostic(
+        "codex",
+        metadata.status === "absent"
+          ? "CODEX_WORKSPACE_METADATA_MISSING"
+          : "CODEX_WORKSPACE_METADATA_INVALID",
+        metadata.status === "absent"
+          ? "Codex workspace metadata is unavailable."
+          : metadata.message,
+      ),
+    );
+    return diagnostics;
+  }
+
+  let invalidPath = false;
+  const add = (code: string, detail: string, field: string) => (path: string) => {
+    if (!addPathRoot(index, { path, code, source: "codex", detail, field })) {
+      invalidPath = true;
+    }
+  };
+  const fieldStates = [
+    parsePathArray(
+      metadata.value["active-workspace-roots"],
+      add("active-session", "Codex marks this workspace as active.", "active-workspace-roots"),
+    ),
+    parsePathArray(
+      metadata.value["electron-saved-workspace-roots"],
+      add(
+        "recent-session",
+        "Codex retains this saved workspace.",
+        "electron-saved-workspace-roots",
+      ),
+    ),
+    parsePathRecord(
+      metadata.value["thread-workspace-root-hints"],
+      add(
+        "recent-session",
+        "Codex thread metadata references this workspace.",
+        "thread-workspace-root-hints",
+      ),
+    ),
+  ];
+
+  if (
+    invalidPath ||
+    fieldStates.includes("invalid") ||
+    fieldStates.every((state) => state === "absent")
+  ) {
+    index.addGlobal({
+      code: "unknown-provider-state",
+      source: "codex",
+      detail: "Codex workspace metadata is unsupported or incomplete.",
+    });
+    diagnostics.push(
+      diagnostic(
+        "codex",
+        "CODEX_WORKSPACE_METADATA_UNSUPPORTED",
+        "Codex workspace metadata contains unsupported path fields.",
+      ),
+    );
+  }
+  return diagnostics;
+}
+
+async function collectClaudeReachability(
+  context: AuditContext,
+  root: string,
+  index: ReachabilityIndex,
+): Promise<Diagnostic[]> {
+  const diagnostics = await addManagedRoot("claude", root, index);
+  const metadata = await readMetadataObject(join(context.home, ".claude.json"));
+  if (metadata.status !== "available" || !isObject(metadata.value.projects)) {
+    index.addGlobal({
+      code: "unknown-provider-state",
+      source: "claude",
+      detail: "Claude project metadata could not be proven.",
+    });
+    diagnostics.push(
+      diagnostic(
+        "claude",
+        metadata.status === "absent"
+          ? "CLAUDE_PROJECT_METADATA_MISSING"
+          : "CLAUDE_PROJECT_METADATA_INVALID",
+        metadata.status === "available"
+          ? "Claude project metadata must contain a projects object."
+          : metadata.status === "absent"
+            ? "Claude project metadata is unavailable."
+            : metadata.message,
+      ),
+    );
+    return diagnostics;
+  }
+
+  let invalidPath = false;
+  for (const path of Object.keys(metadata.value.projects)) {
+    if (
+      !addPathRoot(index, {
+        path,
+        code: "recent-session",
+        source: "claude",
+        detail: "Claude project metadata references this workspace.",
+        field: "projects",
+      })
+    ) {
+      invalidPath = true;
+    }
+  }
+  if (invalidPath) {
+    index.addGlobal({
+      code: "unknown-provider-state",
+      source: "claude",
+      detail: "Claude project metadata contains unsupported workspace paths.",
+    });
+    diagnostics.push(
+      diagnostic(
+        "claude",
+        "CLAUDE_PROJECT_METADATA_UNSUPPORTED",
+        "Claude project metadata contains non-absolute workspace paths.",
+      ),
+    );
+  }
+  return diagnostics;
+}
+
+export async function collectProviderReachability(
+  adapter: ProviderAdapterId,
+  context: AuditContext,
+  root: string,
+  index: ReachabilityIndex,
+): Promise<Diagnostic[]> {
+  if (adapter === "codex") {
+    return collectCodexReachability(root, index);
+  }
+  if (adapter === "claude") {
+    return collectClaudeReachability(context, root, index);
+  }
+  return [];
+}

--- a/src/adapters/provider-specs.ts
+++ b/src/adapters/provider-specs.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import type { AdapterId } from "../config/schema.js";
 import type { ResourceKind } from "../contracts/resource.js";
 
-export type ProviderAdapterId = Exclude<AdapterId, "git" | "docker">;
+export type ProviderAdapterId = Exclude<AdapterId, "git" | "docker" | "runtime">;
 
 export type ProviderResourceSpec = {
   relativePath: string;

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -1,5 +1,6 @@
 import type { AgentRinseConfig } from "../config/schema.js";
 import type { AuditAdapter } from "../contracts/adapter.js";
+import { ReachabilityIndex } from "../core/reachability.js";
 import { ArtifactAuditAdapter } from "./artifacts/adapter.js";
 import { DockerAuditAdapter } from "./docker/adapter.js";
 import { GitWorktreeAuditAdapter } from "./git/adapter.js";
@@ -12,6 +13,7 @@ export function createAuditAdapters(
   config: AgentRinseConfig,
   platform: NodeJS.Platform = process.platform,
 ): AuditAdapter[] {
+  const reachability = new ReachabilityIndex();
   const adapters: AuditAdapter[] = PROVIDER_IDS.filter(
     (id) => config.adapters[id]?.enabled !== false,
   ).map(
@@ -21,6 +23,7 @@ export function createAuditAdapters(
         platform,
         measureBytes: config.audit.measureBytes,
         maxEntries: config.audit.maxEntries,
+        reachability,
       }),
   );
 
@@ -34,7 +37,15 @@ export function createAuditAdapters(
   }
 
   if (config.adapters.git?.enabled === true) {
-    adapters.push(new GitWorktreeAuditAdapter(config.adapters.git.root));
+    adapters.push(
+      new GitWorktreeAuditAdapter(
+        config.adapters.git.root,
+        undefined,
+        undefined,
+        undefined,
+        reachability,
+      ),
+    );
   }
 
   if (config.adapters.docker?.enabled === true) {

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -7,12 +7,14 @@ import { DockerAuditAdapter } from "./docker/adapter.js";
 import { GitWorktreeAuditAdapter } from "./git/adapter.js";
 import { ProviderAuditAdapter } from "./provider-adapter.js";
 import { PROVIDER_SPECS, type ProviderAdapterId } from "./provider-specs.js";
+import { RuntimeAuditAdapter } from "./runtime/adapter.js";
 
 const PROVIDER_IDS = Object.keys(PROVIDER_SPECS) as ProviderAdapterId[];
 
 export type AuditAdapterRegistryOptions = {
   providerInventory?: boolean;
   roots?: ReachabilityRoot[];
+  environment?: NodeJS.ProcessEnv;
 };
 
 export function createAuditAdapters(
@@ -65,6 +67,15 @@ export function createAuditAdapters(
         undefined,
         reachability,
       ),
+    );
+  }
+
+  if (config.adapters.runtime?.enabled !== false) {
+    adapters.push(
+      new RuntimeAuditAdapter({
+        platform,
+        ...(options.environment === undefined ? {} : { environment: options.environment }),
+      }),
     );
   }
 

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -23,6 +23,7 @@ export function createAuditAdapters(
   options: AuditAdapterRegistryOptions = {},
 ): AuditAdapter[] {
   const reachability = new ReachabilityIndex();
+  const gitEnabled = config.adapters.git?.enabled === true;
   for (const root of options.roots ?? []) {
     reachability.add(root);
   }
@@ -38,8 +39,13 @@ export function createAuditAdapters(
       reachability.add({ ...root, path: pin.path });
     } else if ("resourceId" in pin) {
       reachability.addResource(pin.resourceId, root);
-    } else {
+    } else if (gitEnabled) {
       reachability.addGitRef(pin.gitRef, root);
+    } else {
+      reachability.addGlobal({
+        ...root,
+        detail: "Git ref pin resolution requires the Git adapter.",
+      });
     }
   }
   const adapters: AuditAdapter[] = PROVIDER_IDS.filter(
@@ -55,6 +61,18 @@ export function createAuditAdapters(
         inventoryResources: options.providerInventory ?? true,
       }),
   );
+
+  if (gitEnabled) {
+    adapters.push(
+      new GitWorktreeAuditAdapter(
+        config.adapters.git?.root,
+        undefined,
+        undefined,
+        undefined,
+        reachability,
+      ),
+    );
+  }
 
   if (config.artifacts.projects.length > 0) {
     adapters.push(
@@ -76,18 +94,6 @@ export function createAuditAdapters(
         platform,
         ...(options.environment === undefined ? {} : { environment: options.environment }),
       }),
-    );
-  }
-
-  if (config.adapters.git?.enabled === true) {
-    adapters.push(
-      new GitWorktreeAuditAdapter(
-        config.adapters.git.root,
-        undefined,
-        undefined,
-        undefined,
-        reachability,
-      ),
     );
   }
 

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -1,5 +1,6 @@
 import type { AgentRinseConfig } from "../config/schema.js";
 import type { AuditAdapter } from "../contracts/adapter.js";
+import { sha256 } from "../core/digest.js";
 import { ReachabilityIndex } from "../core/reachability.js";
 import { ArtifactAuditAdapter } from "./artifacts/adapter.js";
 import { DockerAuditAdapter } from "./docker/adapter.js";
@@ -14,6 +15,22 @@ export function createAuditAdapters(
   platform: NodeJS.Platform = process.platform,
 ): AuditAdapter[] {
   const reachability = new ReachabilityIndex();
+  for (const pin of config.pins) {
+    const root = {
+      code: "user-pin",
+      source: "config",
+      detail: "User configuration pins this resource.",
+      evidenceRef: sha256(JSON.stringify(pin)),
+      ...(pin.expiresAt === undefined ? {} : { expiresAt: pin.expiresAt }),
+    };
+    if ("path" in pin) {
+      reachability.add({ ...root, path: pin.path });
+    } else if ("resourceId" in pin) {
+      reachability.addResource(pin.resourceId, root);
+    } else {
+      reachability.addGitRef(pin.gitRef, root);
+    }
+  }
   const adapters: AuditAdapter[] = PROVIDER_IDS.filter(
     (id) => config.adapters[id]?.enabled !== false,
   ).map(

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -1,7 +1,7 @@
 import type { AgentRinseConfig } from "../config/schema.js";
 import type { AuditAdapter } from "../contracts/adapter.js";
 import { sha256 } from "../core/digest.js";
-import { ReachabilityIndex } from "../core/reachability.js";
+import { ReachabilityIndex, type ReachabilityRoot } from "../core/reachability.js";
 import { ArtifactAuditAdapter } from "./artifacts/adapter.js";
 import { DockerAuditAdapter } from "./docker/adapter.js";
 import { GitWorktreeAuditAdapter } from "./git/adapter.js";
@@ -10,11 +10,20 @@ import { PROVIDER_SPECS, type ProviderAdapterId } from "./provider-specs.js";
 
 const PROVIDER_IDS = Object.keys(PROVIDER_SPECS) as ProviderAdapterId[];
 
+export type AuditAdapterRegistryOptions = {
+  providerInventory?: boolean;
+  roots?: ReachabilityRoot[];
+};
+
 export function createAuditAdapters(
   config: AgentRinseConfig,
   platform: NodeJS.Platform = process.platform,
+  options: AuditAdapterRegistryOptions = {},
 ): AuditAdapter[] {
   const reachability = new ReachabilityIndex();
+  for (const root of options.roots ?? []) {
+    reachability.add(root);
+  }
   for (const pin of config.pins) {
     const root = {
       code: "user-pin",
@@ -41,15 +50,21 @@ export function createAuditAdapters(
         measureBytes: config.audit.measureBytes,
         maxEntries: config.audit.maxEntries,
         reachability,
+        inventoryResources: options.providerInventory ?? true,
       }),
   );
 
   if (config.artifacts.projects.length > 0) {
     adapters.push(
-      new ArtifactAuditAdapter({
-        ...config.artifacts,
-        ...config.audit,
-      }),
+      new ArtifactAuditAdapter(
+        {
+          ...config.artifacts,
+          ...config.audit,
+        },
+        undefined,
+        undefined,
+        reachability,
+      ),
     );
   }
 

--- a/src/adapters/runtime/adapter.ts
+++ b/src/adapters/runtime/adapter.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
-import { lstat, readdir, realpath } from "node:fs/promises";
+import { constants } from "node:fs";
+import { access, lstat, readdir, realpath } from "node:fs/promises";
 import { delimiter, join, resolve } from "node:path";
 import { promisify } from "node:util";
 
@@ -31,6 +32,14 @@ export type RuntimeAdapterOptions = {
 function isMissing(error: unknown): boolean {
   return (
     error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}
+
+function isUnavailableExecutable(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    ["EACCES", "ENOENT", "EPERM"].includes((error as NodeJS.ErrnoException).code ?? "")
   );
 }
 
@@ -74,6 +83,16 @@ export class RuntimeAuditAdapter implements AuditAdapter {
         try {
           const stats = await lstat(candidate);
           if (stats.isFile() || stats.isSymbolicLink()) {
+            if (this.options.platform !== "win32") {
+              try {
+                await access(candidate, constants.X_OK);
+              } catch (error) {
+                if (isUnavailableExecutable(error)) {
+                  continue;
+                }
+                throw error;
+              }
+            }
             return candidate;
           }
         } catch (error) {

--- a/src/adapters/runtime/adapter.ts
+++ b/src/adapters/runtime/adapter.ts
@@ -1,0 +1,344 @@
+import { execFile } from "node:child_process";
+import { lstat, readdir, realpath } from "node:fs/promises";
+import { delimiter, join, resolve } from "node:path";
+import { promisify } from "node:util";
+
+import type { AuditAdapter, AuditContext, CollectionResult } from "../../contracts/adapter.js";
+import type { Diagnostic } from "../../contracts/diagnostic.js";
+import type { Finding } from "../../contracts/finding.js";
+import type { AdapterProbe } from "../../contracts/report.js";
+import type { ResourceSnapshot } from "../../contracts/resource.js";
+import { sha256 } from "../../core/digest.js";
+
+const execFileAsync = promisify(execFile);
+const RUNTIMES = [
+  { tool: "codex", command: "codex", displayName: "Codex CLI" },
+  { tool: "claude", command: "claude", displayName: "Claude Code" },
+  { tool: "cursor", command: "cursor-agent", displayName: "Cursor Agent" },
+  { tool: "copilot", command: "copilot", displayName: "GitHub Copilot CLI" },
+  { tool: "opencode", command: "opencode", displayName: "OpenCode" },
+  { tool: "grok", command: "grok", displayName: "Grok Build" },
+] as const;
+
+export type RuntimeVersionRunner = (executable: string) => Promise<string>;
+
+export type RuntimeAdapterOptions = {
+  environment?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  runVersion?: RuntimeVersionRunner;
+};
+
+function isMissing(error: unknown): boolean {
+  return (
+    error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}
+
+async function defaultRunVersion(executable: string): Promise<string> {
+  const result = await execFileAsync(executable, ["--version"], {
+    encoding: "utf8",
+    maxBuffer: 256 * 1024,
+    timeout: 5_000,
+  });
+  return result.stdout.trim() === "" ? result.stderr : result.stdout;
+}
+
+function versionLine(output: string): string | undefined {
+  const value = output.split(/\r?\n/u)[0]?.trim();
+  return value === undefined || value === "" ? undefined : value.slice(0, 200);
+}
+
+export class RuntimeAuditAdapter implements AuditAdapter {
+  readonly id = "runtime";
+
+  constructor(private readonly options: RuntimeAdapterOptions = {}) {}
+
+  private executableNames(command: string): string[] {
+    return this.options.platform === "win32"
+      ? [`${command}.exe`, `${command}.cmd`, command]
+      : [command];
+  }
+
+  private async resolveCommand(command: string): Promise<string | undefined> {
+    const environment = this.options.environment ?? process.env;
+    const pathValue = environment.PATH ?? environment.Path;
+    if (pathValue === undefined || pathValue === "") {
+      return undefined;
+    }
+    for (const directory of pathValue.split(delimiter)) {
+      if (directory === "") {
+        continue;
+      }
+      for (const name of this.executableNames(command)) {
+        const candidate = resolve(directory, name);
+        try {
+          const stats = await lstat(candidate);
+          if (stats.isFile() || stats.isSymbolicLink()) {
+            return candidate;
+          }
+        } catch (error) {
+          if (!isMissing(error)) {
+            throw error;
+          }
+        }
+      }
+    }
+    return undefined;
+  }
+
+  private async discovered(context: AuditContext): Promise<boolean> {
+    for (const runtime of RUNTIMES) {
+      if ((await this.resolveCommand(runtime.command)) !== undefined) {
+        return true;
+      }
+    }
+    try {
+      const stats = await lstat(join(context.home, ".local", "share", "claude", "versions"));
+      return stats.isDirectory() && !stats.isSymbolicLink();
+    } catch (error) {
+      if (isMissing(error)) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async probe(context: AuditContext): Promise<AdapterProbe> {
+    try {
+      return (await this.discovered(context))
+        ? {
+            adapter: this.id,
+            status: "available",
+            detail: "Agent runtime installations found",
+            diagnostics: [],
+          }
+        : {
+            adapter: this.id,
+            status: "absent",
+            detail: "No supported agent runtime installation found",
+            diagnostics: [],
+          };
+    } catch (error) {
+      return {
+        adapter: this.id,
+        status: "degraded",
+        detail: "Agent runtime installations could not be inspected",
+        diagnostics: [
+          {
+            severity: "warning",
+            code: "RUNTIME_PROBE_FAILED",
+            message: error instanceof Error ? error.message : String(error),
+            adapter: this.id,
+          },
+        ],
+      };
+    }
+  }
+
+  private resource(
+    context: AuditContext,
+    input: {
+      tool: string;
+      displayName: string;
+      path: string;
+      measuredBytes?: number;
+      facts: Record<string, unknown>;
+    },
+  ): ResourceSnapshot {
+    const path = resolve(input.path);
+    const canonicalKey = `runtime:agent-runtime:${input.tool}:${path}`;
+    return {
+      resource: {
+        id: `runtime:agent-runtime:${sha256(canonicalKey)}`,
+        adapter: this.id,
+        kind: "agent-runtime",
+        canonicalKey,
+        displayName: input.displayName,
+        path,
+      },
+      observedAt: context.now.toISOString(),
+      exists: true,
+      ...(input.measuredBytes === undefined ? {} : { measuredBytes: input.measuredBytes }),
+      facts: {
+        tool: input.tool,
+        reportOnly: true,
+        ...input.facts,
+      },
+    };
+  }
+
+  private async collectClaudeNative(
+    context: AuditContext,
+    activeExecutable: string | undefined,
+  ): Promise<{ resources: ResourceSnapshot[]; paths: Set<string>; diagnostics: Diagnostic[] }> {
+    const root = join(context.home, ".local", "share", "claude", "versions");
+    const resources: ResourceSnapshot[] = [];
+    const paths = new Set<string>();
+    const diagnostics: Diagnostic[] = [];
+    let activePath: string | undefined;
+    if (activeExecutable !== undefined) {
+      try {
+        activePath = await realpath(activeExecutable);
+      } catch {
+        activePath = undefined;
+      }
+    }
+
+    try {
+      const rootStats = await lstat(root);
+      if (rootStats.isSymbolicLink() || !rootStats.isDirectory()) {
+        diagnostics.push({
+          severity: "warning",
+          code: "CLAUDE_RUNTIME_ROOT_UNSAFE",
+          message: "Claude native version root must be a real directory.",
+          adapter: this.id,
+        });
+        return { resources, paths, diagnostics };
+      }
+      for (const entry of await readdir(root, { withFileTypes: true })) {
+        context.signal?.throwIfAborted();
+        if (!entry.isFile()) {
+          continue;
+        }
+        const path = await realpath(resolve(root, entry.name));
+        const stats = await lstat(path);
+        paths.add(path);
+        resources.push(
+          this.resource(context, {
+            tool: "claude",
+            displayName: `Claude Code ${entry.name}`,
+            path,
+            measuredBytes: stats.size,
+            facts: {
+              version: entry.name,
+              selected: activePath === path,
+              installManager: "claude-native",
+              recommendation: "Use `claude install stable` to manage this installation.",
+              mtimeMs: stats.mtimeMs,
+            },
+          }),
+        );
+      }
+    } catch (error) {
+      if (!isMissing(error)) {
+        diagnostics.push({
+          severity: "warning",
+          code: "CLAUDE_RUNTIME_INSPECTION_FAILED",
+          message: error instanceof Error ? error.message : String(error),
+          adapter: this.id,
+        });
+      }
+    }
+    return { resources, paths, diagnostics };
+  }
+
+  async collect(context: AuditContext, probe: AdapterProbe): Promise<CollectionResult> {
+    if (probe.status !== "available") {
+      return { resources: [], diagnostics: [] };
+    }
+    const resources: ResourceSnapshot[] = [];
+    const diagnostics: Diagnostic[] = [];
+    const resolved = new Map<string, string>();
+    for (const runtime of RUNTIMES) {
+      const executable = await this.resolveCommand(runtime.command);
+      if (executable !== undefined) {
+        resolved.set(runtime.tool, executable);
+      }
+    }
+
+    const claudeNative = await this.collectClaudeNative(context, resolved.get("claude"));
+    resources.push(...claudeNative.resources);
+    diagnostics.push(...claudeNative.diagnostics);
+
+    for (const runtime of RUNTIMES) {
+      context.signal?.throwIfAborted();
+      const launcherPath = resolved.get(runtime.tool);
+      if (launcherPath === undefined) {
+        continue;
+      }
+      let executablePath: string;
+      try {
+        executablePath = await realpath(launcherPath);
+      } catch (error) {
+        diagnostics.push({
+          severity: "warning",
+          code: "RUNTIME_EXECUTABLE_UNREADABLE",
+          message: error instanceof Error ? error.message : String(error),
+          adapter: this.id,
+        });
+        continue;
+      }
+      const stats = await lstat(executablePath);
+      if (!stats.isFile()) {
+        diagnostics.push({
+          severity: "warning",
+          code: "RUNTIME_EXECUTABLE_INVALID",
+          message: "Resolved runtime executable is not a regular file.",
+          adapter: this.id,
+        });
+        continue;
+      }
+      if (runtime.tool === "claude" && claudeNative.paths.has(executablePath)) {
+        continue;
+      }
+      let version: string | undefined;
+      try {
+        version = versionLine(await (this.options.runVersion ?? defaultRunVersion)(executablePath));
+      } catch (error) {
+        diagnostics.push({
+          severity: "warning",
+          code: "RUNTIME_VERSION_FAILED",
+          message: error instanceof Error ? error.message : String(error),
+          adapter: this.id,
+        });
+      }
+      resources.push(
+        this.resource(context, {
+          tool: runtime.tool,
+          displayName: runtime.displayName,
+          path: executablePath,
+          measuredBytes: stats.size,
+          facts: {
+            selected: true,
+            launcherPath,
+            executablePath,
+            installManager: "unknown",
+            recommendation: "Use the owning installer or package manager for updates and removal.",
+            ...(version === undefined ? {} : { version }),
+            mtimeMs: stats.mtimeMs,
+          },
+        }),
+      );
+    }
+
+    resources.sort((left, right) =>
+      left.resource.canonicalKey.localeCompare(right.resource.canonicalKey),
+    );
+    return { resources, diagnostics };
+  }
+
+  async classify(context: AuditContext, resource: ResourceSnapshot): Promise<Finding> {
+    const observedAt = context.now.toISOString();
+    return {
+      schemaVersion: 1,
+      findingId: `${resource.resource.id}:${sha256(context.auditId)}`,
+      auditId: context.auditId,
+      observedAt,
+      resource: resource.resource,
+      state: "protected",
+      confidence: "certain",
+      roots: [
+        {
+          code: "runtime-owner-report-only",
+          source: this.id,
+          observedAt,
+          detail: "Agent runtime maintenance remains owned by its installer or package manager.",
+        },
+      ],
+      facts: resource.facts,
+      candidateActions: [],
+      ...(resource.measuredBytes === undefined ? {} : { measuredBytes: resource.measuredBytes }),
+      warnings: [],
+    };
+  }
+}

--- a/src/adapters/runtime/adapter.ts
+++ b/src/adapters/runtime/adapter.ts
@@ -188,19 +188,17 @@ export class RuntimeAuditAdapter implements AuditAdapter {
 
   private async collectClaudeNative(
     context: AuditContext,
-    activeExecutable: string | undefined,
   ): Promise<{ resources: ResourceSnapshot[]; paths: Set<string>; diagnostics: Diagnostic[] }> {
     const root = join(context.home, ".local", "share", "claude", "versions");
+    const launcher = join(context.home, ".local", "bin", "claude");
     const resources: ResourceSnapshot[] = [];
     const paths = new Set<string>();
     const diagnostics: Diagnostic[] = [];
     let activePath: string | undefined;
-    if (activeExecutable !== undefined) {
-      try {
-        activePath = await realpath(activeExecutable);
-      } catch {
-        activePath = undefined;
-      }
+    try {
+      activePath = await realpath(launcher);
+    } catch {
+      activePath = undefined;
     }
 
     try {
@@ -265,7 +263,7 @@ export class RuntimeAuditAdapter implements AuditAdapter {
       }
     }
 
-    const claudeNative = await this.collectClaudeNative(context, resolved.get("claude"));
+    const claudeNative = await this.collectClaudeNative(context);
     resources.push(...claudeNative.resources);
     diagnostics.push(...claudeNative.diagnostics);
 

--- a/src/commands/adapters.ts
+++ b/src/commands/adapters.ts
@@ -9,6 +9,7 @@ export function renderAdapters(): string {
       .map((spec) => `${spec.id.padEnd(10)} audit-only  ${spec.displayName}`),
     "",
     "git        audit-only  Git worktrees (explicit root)",
+    "runtime    audit-only  Installed agent runtimes",
     "docker     audit-only  Docker images and containers (opt-in)",
     "artifacts  safe-clean  Explicit rebuildable project directories",
     "",

--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -1,0 +1,302 @@
+import { execFile } from "node:child_process";
+import { isAbsolute, relative, resolve } from "node:path";
+import { promisify } from "node:util";
+
+import { parseWorktreePorcelain } from "../adapters/git/porcelain.js";
+import { createAuditAdapters } from "../adapters/registry.js";
+import { confirmApply } from "./apply.js";
+import { loadConfigForHome } from "../config/load.js";
+import type { AgentRinseConfig } from "../config/schema.js";
+import { actionRiskSchema, type ActionRisk } from "../contracts/action.js";
+import type { CleanupPlan } from "../contracts/plan.js";
+import type { AuditReport } from "../contracts/report.js";
+import type { CleanupRun } from "../contracts/run.js";
+import { applyCleanupPlan } from "../core/apply.js";
+import { runAudit } from "../core/audit.js";
+import { CommandInterruptedError } from "../core/interruption.js";
+import { createCleanupPlan } from "../core/plan.js";
+import { createCommandEnvelope, jsonDocument } from "../machine-output.js";
+import { writeJsonAtomic } from "../state/json-file.js";
+import { resolveStateRoot, stateLayout } from "../state/layout.js";
+
+const execFileAsync = promisify(execFile);
+
+export type CleanCommandOptions = {
+  home: string;
+  config?: string;
+  stateDir?: string;
+  profile: "closeout";
+  cwd?: string;
+  apply: boolean;
+  yes: boolean;
+  json: boolean;
+  maxRisk?: ActionRisk;
+  signal?: AbortSignal;
+  dependencies?: {
+    platform?: NodeJS.Platform;
+    now?: () => Date;
+    runCommand?: (command: string, args: string[]) => Promise<{ stdout: string; stderr: string }>;
+  };
+};
+
+export type MoleHandoff = {
+  status: "available" | "absent" | "not-applicable";
+  suggestions: string[];
+};
+
+export type CloseoutSummary = {
+  profile: "closeout";
+  repositoryRoot: string;
+  currentWorktree: string;
+  auditId: string;
+  planId: string;
+  auditPath: string;
+  planPath: string;
+  configPath: string;
+  worktrees: number;
+  protectedWorktrees: number;
+  eligibleActions: number;
+  expectedReclaimBytes: number;
+  mole: MoleHandoff;
+  run?: {
+    runId: string;
+    status: CleanupRun["status"];
+    journalPath: string;
+    reclaimedBytes: number;
+  };
+};
+
+export type CleanCommandResult = {
+  audit: AuditReport;
+  plan: CleanupPlan;
+  run?: CleanupRun;
+  summary: CloseoutSummary;
+  output: string;
+};
+
+async function defaultRunCommand(
+  command: string,
+  args: string[],
+): Promise<{ stdout: string; stderr: string }> {
+  const result = await execFileAsync(command, args, {
+    encoding: "utf8",
+    maxBuffer: 4 * 1024 * 1024,
+    timeout: 10_000,
+  });
+  return { stdout: result.stdout, stderr: result.stderr };
+}
+
+function isInside(root: string, candidate: string): boolean {
+  const result = relative(resolve(root), resolve(candidate));
+  return result === "" || (!result.startsWith("..") && !isAbsolute(result));
+}
+
+function scopedConfig(
+  config: AgentRinseConfig,
+  currentWorktree: string,
+  worktrees: string[],
+  maxRisk: ActionRisk | undefined,
+): AgentRinseConfig {
+  const scoped = structuredClone(config);
+  for (const id of ["cursor", "copilot", "zed", "opencode", "grok", "docker"] as const) {
+    scoped.adapters[id] = { enabled: false };
+  }
+  scoped.adapters.git = { enabled: true, root: currentWorktree };
+  scoped.artifacts.projects = scoped.artifacts.projects.filter((project) =>
+    worktrees.some((worktree) => isInside(worktree, project.root)),
+  );
+  if (maxRisk !== undefined) {
+    scoped.plan.maxRisk = maxRisk;
+  }
+  return scoped;
+}
+
+async function moleHandoff(
+  platform: NodeJS.Platform,
+  runCommand: (command: string, args: string[]) => Promise<{ stdout: string; stderr: string }>,
+): Promise<MoleHandoff> {
+  if (platform !== "darwin") {
+    return { status: "not-applicable", suggestions: [] };
+  }
+  try {
+    await runCommand("mo", ["--version"]);
+    return {
+      status: "available",
+      suggestions: ["mo purge --dry-run", "mo clean --dry-run"],
+    };
+  } catch {
+    return {
+      status: "absent",
+      suggestions: ["Install Mole to preview broad macOS cleanup outside AgentRinse."],
+    };
+  }
+}
+
+function renderCloseout(summary: CloseoutSummary): string {
+  const lines = [
+    "AgentRinse closeout",
+    "",
+    `Repository: ${summary.repositoryRoot}`,
+    `Worktrees: ${summary.worktrees} (${summary.protectedWorktrees} protected)`,
+    `Eligible actions: ${summary.eligibleActions}`,
+    `Expected reclaim: ${summary.expectedReclaimBytes} bytes`,
+    `Audit: ${summary.auditPath}`,
+    `Plan: ${summary.planPath}`,
+    `Config: ${summary.configPath}`,
+  ];
+  if (summary.run !== undefined) {
+    lines.push(
+      `Run: ${summary.run.status} (${summary.run.reclaimedBytes} bytes)`,
+      `Journal: ${summary.run.journalPath}`,
+    );
+  }
+  if (summary.mole.suggestions.length > 0) {
+    lines.push("", "Mole handoff:", ...summary.mole.suggestions.map((item) => `  ${item}`));
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function interruptionFrom(signal?: AbortSignal): CommandInterruptedError | undefined {
+  if (signal?.aborted !== true) {
+    return undefined;
+  }
+  return signal.reason instanceof CommandInterruptedError
+    ? signal.reason
+    : new CommandInterruptedError("clean interrupted");
+}
+
+export async function executeCleanCommand(
+  options: CleanCommandOptions,
+): Promise<CleanCommandResult> {
+  if (options.profile !== "closeout") {
+    throw new Error(`unsupported clean profile: ${options.profile}`);
+  }
+  if (options.json && options.apply && !options.yes) {
+    throw new Error("clean --json --apply requires --yes");
+  }
+  const runCommand = options.dependencies?.runCommand ?? defaultRunCommand;
+  const platform = options.dependencies?.platform ?? process.platform;
+  const clock = options.dependencies?.now ?? (() => new Date());
+  const cwd = resolve(options.cwd ?? process.cwd());
+  const home = resolve(options.home);
+  const currentWorktree = (
+    await runCommand("git", ["-C", cwd, "rev-parse", "--show-toplevel"])
+  ).stdout.trim();
+  if (currentWorktree === "") {
+    throw new Error("closeout requires a Git worktree");
+  }
+  const worktreeOutput = (
+    await runCommand("git", ["-C", currentWorktree, "worktree", "list", "--porcelain", "-z"])
+  ).stdout;
+  const worktrees = parseWorktreePorcelain(worktreeOutput).map((record) => resolve(record.path));
+  const repositoryRoot = worktrees[0] ?? currentWorktree;
+  const { config } = await loadConfigForHome(home, options.config);
+  const maxRisk =
+    options.maxRisk === undefined ? undefined : actionRiskSchema.parse(options.maxRisk);
+  const scoped = scopedConfig(config, currentWorktree, worktrees, maxRisk);
+  const audit = await runAudit({
+    home,
+    config: scoped,
+    adapters: createAuditAdapters(scoped, platform, {
+      providerInventory: false,
+      roots: [
+        {
+          path: currentWorktree,
+          code: "current-worktree",
+          source: "closeout",
+          detail: "The worktree running the closeout profile is protected.",
+        },
+      ],
+    }),
+    now: clock,
+    ...(options.signal === undefined ? {} : { signal: options.signal }),
+  });
+  const plan = createCleanupPlan(audit, scoped, clock());
+  const layout = stateLayout(resolveStateRoot(home, options.stateDir));
+  const auditPath = resolve(layout.audits, `${audit.auditId}.json`);
+  const planPath = resolve(layout.plans, `${plan.planId}.json`);
+  const configPath = resolve(layout.plans, `${plan.planId}.config.json`);
+  await writeJsonAtomic(auditPath, audit, {
+    privateDirectories: [layout.root, layout.audits],
+  });
+  await writeJsonAtomic(planPath, plan, {
+    privateDirectories: [layout.root, layout.plans],
+  });
+  await writeJsonAtomic(configPath, scoped, {
+    privateDirectories: [layout.root, layout.plans],
+  });
+
+  let run: CleanupRun | undefined;
+  let journalPath: string | undefined;
+  if (options.apply) {
+    const interruption = interruptionFrom(options.signal);
+    if (interruption !== undefined) {
+      throw interruption;
+    }
+    if (!options.yes && !(await confirmApply(plan.actions.length, options.signal))) {
+      throw new Error("clean apply cancelled");
+    }
+    const result = await applyCleanupPlan({
+      input: plan,
+      config: scoped,
+      stateRoot: layout.root,
+      ...(options.signal === undefined ? {} : { signal: options.signal }),
+      dependencies: { clock },
+    });
+    run = result.run;
+    journalPath = result.journalPath;
+  }
+
+  const gitFindings = audit.findings.filter((finding) => finding.resource.kind === "git-worktree");
+  const summary: CloseoutSummary = {
+    profile: "closeout",
+    repositoryRoot,
+    currentWorktree,
+    auditId: audit.auditId,
+    planId: plan.planId,
+    auditPath,
+    planPath,
+    configPath,
+    worktrees: gitFindings.length,
+    protectedWorktrees: gitFindings.filter((finding) => finding.state !== "eligible").length,
+    eligibleActions: plan.actions.length,
+    expectedReclaimBytes: plan.expectedReclaimBytes,
+    mole: await moleHandoff(platform, runCommand),
+    ...(run === undefined || journalPath === undefined
+      ? {}
+      : {
+          run: {
+            runId: run.runId,
+            status: run.status,
+            journalPath,
+            reclaimedBytes: run.reclaimedBytes,
+          },
+        }),
+  };
+  const startedAt = audit.startedAt;
+  const completedAt = clock().toISOString();
+  const status =
+    run !== undefined && ["failed", "partial"].includes(run.status)
+      ? "failed"
+      : audit.diagnostics.length === 0
+        ? "ok"
+        : "degraded";
+  return {
+    audit,
+    plan,
+    ...(run === undefined ? {} : { run }),
+    summary,
+    output: options.json
+      ? jsonDocument(
+          createCommandEnvelope({
+            command: "clean",
+            startedAt,
+            completedAt,
+            status,
+            data: summary,
+            diagnostics: audit.diagnostics,
+          }),
+        )
+      : renderCloseout(summary),
+  };
+}

--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -87,6 +87,18 @@ export function cleanCommandExitCode(
   return result.status === "degraded" ? 1 : undefined;
 }
 
+export function cleanCommandStatus(
+  audit: Pick<AuditReport, "diagnostics" | "probes">,
+  run?: Pick<CleanupRun, "status">,
+): CleanCommandResult["status"] {
+  if (run !== undefined && ["failed", "interrupted", "partial"].includes(run.status)) {
+    return "failed";
+  }
+  return audit.probes.some((probe) => probe.status === "degraded") || audit.diagnostics.length > 0
+    ? "degraded"
+    : "ok";
+}
+
 async function defaultRunCommand(
   command: string,
   args: string[],
@@ -288,12 +300,7 @@ export async function executeCleanCommand(
   };
   const startedAt = audit.startedAt;
   const completedAt = clock().toISOString();
-  const status =
-    run !== undefined && ["failed", "partial"].includes(run.status)
-      ? "failed"
-      : audit.probes.some((probe) => probe.status === "degraded") || audit.diagnostics.length > 0
-        ? "degraded"
-        : "ok";
+  const status = cleanCommandStatus(audit, run);
   return {
     audit,
     plan,

--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -70,9 +70,22 @@ export type CleanCommandResult = {
   audit: AuditReport;
   plan: CleanupPlan;
   run?: CleanupRun;
+  status: "ok" | "degraded" | "failed";
   summary: CloseoutSummary;
   output: string;
 };
+
+export function cleanCommandExitCode(
+  result: Pick<CleanCommandResult, "run" | "status">,
+): number | undefined {
+  if (result.run?.status === "interrupted") {
+    return 130;
+  }
+  if (result.run !== undefined && ["failed", "partial"].includes(result.run.status)) {
+    return 2;
+  }
+  return result.status === "degraded" ? 1 : undefined;
+}
 
 async function defaultRunCommand(
   command: string,
@@ -278,13 +291,14 @@ export async function executeCleanCommand(
   const status =
     run !== undefined && ["failed", "partial"].includes(run.status)
       ? "failed"
-      : audit.diagnostics.length === 0
-        ? "ok"
-        : "degraded";
+      : audit.probes.some((probe) => probe.status === "degraded") || audit.diagnostics.length > 0
+        ? "degraded"
+        : "ok";
   return {
     audit,
     plan,
     ...(run === undefined ? {} : { run }),
+    status,
     summary,
     output: options.json
       ? jsonDocument(

--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -98,7 +98,7 @@ function scopedConfig(
   maxRisk: ActionRisk | undefined,
 ): AgentRinseConfig {
   const scoped = structuredClone(config);
-  for (const id of ["cursor", "copilot", "zed", "opencode", "grok", "docker"] as const) {
+  for (const id of ["cursor", "copilot", "zed", "opencode", "grok", "runtime", "docker"] as const) {
     scoped.adapters[id] = { enabled: false };
   }
   scoped.adapters.git = { enabled: true, root: currentWorktree };

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -5,6 +5,7 @@ const COMMANDS = [
   "adapters",
   "apply",
   "audit",
+  "clean",
   "completion",
   "config",
   "doctor",
@@ -38,7 +39,7 @@ _agentrinse_completion() {
     config) COMPREPLY=( $(compgen -W "${SUBCOMMANDS.config.join(" ")}" -- "\${current}") ) ;;
     lock) COMPREPLY=( $(compgen -W "${SUBCOMMANDS.lock.join(" ")}" -- "\${current}") ) ;;
     show) COMPREPLY=( $(compgen -W "${SUBCOMMANDS.show.join(" ")}" -- "\${current}") ) ;;
-    *) COMPREPLY=( $(compgen -W "--help --version --home --config --state-dir --json --ndjson --redact --yes --output --audit --plan --since" -- "\${current}") ) ;;
+    *) COMPREPLY=( $(compgen -W "--help --version --home --config --state-dir --json --ndjson --redact --yes --output --audit --plan --since --profile --apply --max-risk" -- "\${current}") ) ;;
   esac
 }
 complete -F _agentrinse_completion agentrinse

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -10,6 +10,7 @@ export const DEFAULT_CONFIG: AgentRinseConfig = {
     zed: { enabled: true },
     opencode: { enabled: true },
     grok: { enabled: true },
+    runtime: { enabled: false },
     git: { enabled: false },
     docker: { enabled: false },
   },

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -23,6 +23,7 @@ export const DEFAULT_CONFIG: AgentRinseConfig = {
     minBytes: 64 * 1024 * 1024,
     processCheck: "required",
   },
+  pins: [],
   plan: {
     ttlMinutes: 30,
     maxRisk: "safe",

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -29,6 +29,29 @@ export const artifactProjectSchema = z.object({
     .refine((names) => new Set(names).size === names.length, "artifact names must be unique"),
 });
 
+const expiresAtSchema = z.string().datetime().optional();
+
+export const pinSchema = z.union([
+  z
+    .object({
+      path: z.string().min(1).refine(isAbsolute, "pin path must be absolute"),
+      expiresAt: expiresAtSchema,
+    })
+    .strict(),
+  z
+    .object({
+      resourceId: z.string().min(1),
+      expiresAt: expiresAtSchema,
+    })
+    .strict(),
+  z
+    .object({
+      gitRef: z.string().regex(/^refs\/(?:heads|remotes|tags)\//u, "pin Git ref is invalid"),
+      expiresAt: expiresAtSchema,
+    })
+    .strict(),
+]);
+
 function isInside(root: string, candidate: string): boolean {
   const result = relative(resolve(root), resolve(candidate));
   return result === "" || (!result.startsWith("..") && !isAbsolute(result));
@@ -65,6 +88,7 @@ export const agentRinseConfigSchema = z
         minBytes: 64 * 1024 * 1024,
         processCheck: "required" as const,
       })),
+    pins: z.array(pinSchema).default([]),
     plan: z
       .object({
         ttlMinutes: z
@@ -118,4 +142,5 @@ export type AdapterId = z.infer<typeof adapterIdSchema>;
 export { artifactNameSchema };
 export type { ArtifactName };
 export type ArtifactProject = z.infer<typeof artifactProjectSchema>;
+export type Pin = z.infer<typeof pinSchema>;
 export type AgentRinseConfig = z.infer<typeof agentRinseConfigSchema>;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -32,6 +32,34 @@ export const artifactProjectSchema = z.object({
 
 const expiresAtSchema = z.string().datetime().optional();
 
+function isValidGitRef(value: string): boolean {
+  const match = /^refs\/(?:heads|remotes|tags)\/(.+)$/u.exec(value);
+  if (match === null) {
+    return false;
+  }
+  const suffix = match[1]!;
+  if (
+    suffix.endsWith(".") ||
+    suffix.includes("..") ||
+    suffix.includes("@{") ||
+    suffix.includes("//")
+  ) {
+    return false;
+  }
+  for (const component of suffix.split("/")) {
+    if (component === "" || component.startsWith(".") || component.endsWith(".lock")) {
+      return false;
+    }
+  }
+  for (const character of value) {
+    const code = character.codePointAt(0)!;
+    if (code <= 0x20 || code === 0x7f || ["~", "^", ":", "?", "*", "[", "\\"].includes(character)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export const pinSchema = z.union([
   z
     .object({
@@ -47,7 +75,7 @@ export const pinSchema = z.union([
     .strict(),
   z
     .object({
-      gitRef: z.string().regex(/^refs\/(?:heads|remotes|tags)\//u, "pin Git ref is invalid"),
+      gitRef: z.string().refine(isValidGitRef, "pin Git ref is invalid"),
       expiresAt: expiresAtSchema,
     })
     .strict(),

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -12,6 +12,7 @@ export const adapterIdSchema = z.enum([
   "zed",
   "opencode",
   "grok",
+  "runtime",
   "git",
   "docker",
 ]);

--- a/src/core/reachability.ts
+++ b/src/core/reachability.ts
@@ -1,0 +1,39 @@
+import { isAbsolute, relative, resolve } from "node:path";
+
+import type { RootEvidence } from "../contracts/finding.js";
+
+export type ReachabilityRoot = Omit<RootEvidence, "observedAt"> & {
+  path: string;
+};
+
+function isInside(root: string, candidate: string): boolean {
+  const result = relative(root, candidate);
+  return result === "" || (!result.startsWith("..") && !isAbsolute(result));
+}
+
+export class ReachabilityIndex {
+  private readonly roots = new Map<string, ReachabilityRoot>();
+
+  add(root: ReachabilityRoot): void {
+    const path = resolve(root.path);
+    const key = `${root.code}\0${root.source}\0${path}\0${root.evidenceRef ?? ""}`;
+    this.roots.set(key, { ...root, path });
+  }
+
+  rootsFor(path: string, observedAt: string): RootEvidence[] {
+    const target = resolve(path);
+    return [...this.roots.values()]
+      .filter((root) => isInside(target, root.path))
+      .map(({ path: _path, ...root }) => ({ ...root, observedAt }))
+      .sort((left, right) => {
+        const byCode = left.code.localeCompare(right.code);
+        return byCode !== 0
+          ? byCode
+          : (left.evidenceRef ?? "").localeCompare(right.evidenceRef ?? "");
+      });
+  }
+
+  size(): number {
+    return this.roots.size;
+  }
+}

--- a/src/core/reachability.ts
+++ b/src/core/reachability.ts
@@ -9,7 +9,7 @@ type ReachabilityEvidence = Omit<RootEvidence, "observedAt"> & {
 
 export type ReachabilityRoot = ReachabilityEvidence & {
   path: string;
-  scope?: "exact" | "subtree";
+  scope?: "overlap" | "subtree";
 };
 
 function isInside(root: string, candidate: string): boolean {
@@ -25,7 +25,7 @@ export class ReachabilityIndex {
 
   add(root: ReachabilityRoot): void {
     const path = resolve(root.path);
-    const key = `${root.code}\0${root.source}\0${path}\0${root.scope ?? "exact"}\0${root.evidenceRef ?? ""}`;
+    const key = `${root.code}\0${root.source}\0${path}\0${root.scope ?? "overlap"}\0${root.evidenceRef ?? ""}`;
     this.roots.set(key, { ...root, path });
   }
 
@@ -71,7 +71,9 @@ export class ReachabilityIndex {
     const matchingRoots = [...this.roots.values()]
       .filter((root) => this.isCurrent(root, observedAt))
       .filter((root) =>
-        root.scope === "subtree" ? isInside(root.path, target) : isInside(target, root.path),
+        root.scope === "subtree"
+          ? isInside(root.path, target)
+          : isInside(root.path, target) || isInside(target, root.path),
       )
       .map(({ path: _path, scope: _scope, ...root }) => this.evidence(root, observedAt));
     const globalRoots = [...this.globalRoots.values()]

--- a/src/core/reachability.ts
+++ b/src/core/reachability.ts
@@ -29,7 +29,7 @@ export class ReachabilityIndex {
     this.roots.set(key, { ...root, path });
   }
 
-  addGlobal(root: Omit<RootEvidence, "observedAt">): void {
+  addGlobal(root: ReachabilityEvidence): void {
     const key = `${root.code}\0${root.source}\0${root.evidenceRef ?? ""}`;
     this.globalRoots.set(key, root);
   }
@@ -42,6 +42,43 @@ export class ReachabilityIndex {
   addGitRef(gitRef: string, root: ReachabilityEvidence): void {
     const key = `${gitRef}\0${root.code}\0${root.source}\0${root.evidenceRef ?? ""}`;
     this.gitRefRoots.set(key, root);
+  }
+
+  bindGitRefsToPath(
+    path: string,
+    gitRefs: Iterable<string>,
+    observedAt: string,
+    inspectionComplete = true,
+  ): void {
+    const refs = new Set(gitRefs);
+    for (const [key, root] of this.gitRefRoots) {
+      if (!this.isCurrent(root, observedAt)) {
+        continue;
+      }
+      const gitRef = key.slice(0, key.indexOf("\0"));
+      if (inspectionComplete && !refs.has(gitRef)) {
+        continue;
+      }
+      this.add({
+        ...root,
+        path,
+        scope: "subtree",
+        ...(inspectionComplete
+          ? {}
+          : { detail: "A configured Git ref pin could not be ruled out for this worktree." }),
+      });
+    }
+  }
+
+  protectUnresolvedGitRefs(observedAt: string): void {
+    for (const root of this.gitRefRoots.values()) {
+      if (this.isCurrent(root, observedAt)) {
+        this.addGlobal({
+          ...root,
+          detail: "Configured Git ref pins could not be resolved.",
+        });
+      }
+    }
   }
 
   private isCurrent(root: ReachabilityEvidence, observedAt: string): boolean {
@@ -100,6 +137,11 @@ export class ReachabilityIndex {
 
     const branch = typeof facts.branch === "string" ? facts.branch : undefined;
     const upstream = typeof facts.upstream === "string" ? facts.upstream : undefined;
+    const gitRefs = new Set(
+      Array.isArray(facts.gitRefs)
+        ? facts.gitRefs.filter((value): value is string => typeof value === "string")
+        : [],
+    );
     for (const [key, root] of this.gitRefRoots) {
       const gitRef = key.slice(0, key.indexOf("\0"));
       const matchesBranch =
@@ -108,7 +150,10 @@ export class ReachabilityIndex {
       const matchesUpstream =
         upstream === gitRef ||
         (gitRef.startsWith("refs/remotes/") && upstream === gitRef.slice("refs/remotes/".length));
-      if ((matchesBranch || matchesUpstream) && this.isCurrent(root, observedAt)) {
+      if (
+        (matchesBranch || matchesUpstream || gitRefs.has(gitRef)) &&
+        this.isCurrent(root, observedAt)
+      ) {
         roots.push(this.evidence(root, observedAt));
       }
     }

--- a/src/core/reachability.ts
+++ b/src/core/reachability.ts
@@ -4,6 +4,7 @@ import type { RootEvidence } from "../contracts/finding.js";
 
 export type ReachabilityRoot = Omit<RootEvidence, "observedAt"> & {
   path: string;
+  scope?: "exact" | "subtree";
 };
 
 function isInside(root: string, candidate: string): boolean {
@@ -13,27 +14,40 @@ function isInside(root: string, candidate: string): boolean {
 
 export class ReachabilityIndex {
   private readonly roots = new Map<string, ReachabilityRoot>();
+  private readonly globalRoots = new Map<string, Omit<RootEvidence, "observedAt">>();
 
   add(root: ReachabilityRoot): void {
     const path = resolve(root.path);
-    const key = `${root.code}\0${root.source}\0${path}\0${root.evidenceRef ?? ""}`;
+    const key = `${root.code}\0${root.source}\0${path}\0${root.scope ?? "exact"}\0${root.evidenceRef ?? ""}`;
     this.roots.set(key, { ...root, path });
+  }
+
+  addGlobal(root: Omit<RootEvidence, "observedAt">): void {
+    const key = `${root.code}\0${root.source}\0${root.evidenceRef ?? ""}`;
+    this.globalRoots.set(key, root);
   }
 
   rootsFor(path: string, observedAt: string): RootEvidence[] {
     const target = resolve(path);
-    return [...this.roots.values()]
-      .filter((root) => isInside(target, root.path))
-      .map(({ path: _path, ...root }) => ({ ...root, observedAt }))
-      .sort((left, right) => {
-        const byCode = left.code.localeCompare(right.code);
-        return byCode !== 0
-          ? byCode
-          : (left.evidenceRef ?? "").localeCompare(right.evidenceRef ?? "");
-      });
+    const matchingRoots = [...this.roots.values()]
+      .filter((root) =>
+        root.scope === "subtree" ? isInside(root.path, target) : isInside(target, root.path),
+      )
+      .map(({ path: _path, scope: _scope, ...root }) => ({ ...root, observedAt }));
+    const globalRoots = [...this.globalRoots.values()].map((root) => ({
+      ...root,
+      observedAt,
+    }));
+
+    return [...matchingRoots, ...globalRoots].sort((left, right) => {
+      const byCode = left.code.localeCompare(right.code);
+      return byCode !== 0
+        ? byCode
+        : (left.evidenceRef ?? "").localeCompare(right.evidenceRef ?? "");
+    });
   }
 
   size(): number {
-    return this.roots.size;
+    return this.roots.size + this.globalRoots.size;
   }
 }

--- a/src/core/reachability.ts
+++ b/src/core/reachability.ts
@@ -1,8 +1,13 @@
 import { isAbsolute, relative, resolve } from "node:path";
 
 import type { RootEvidence } from "../contracts/finding.js";
+import type { ResourceRef } from "../contracts/resource.js";
 
-export type ReachabilityRoot = Omit<RootEvidence, "observedAt"> & {
+type ReachabilityEvidence = Omit<RootEvidence, "observedAt"> & {
+  expiresAt?: string;
+};
+
+export type ReachabilityRoot = ReachabilityEvidence & {
   path: string;
   scope?: "exact" | "subtree";
 };
@@ -14,7 +19,9 @@ function isInside(root: string, candidate: string): boolean {
 
 export class ReachabilityIndex {
   private readonly roots = new Map<string, ReachabilityRoot>();
-  private readonly globalRoots = new Map<string, Omit<RootEvidence, "observedAt">>();
+  private readonly resourceRoots = new Map<string, ReachabilityEvidence>();
+  private readonly gitRefRoots = new Map<string, ReachabilityEvidence>();
+  private readonly globalRoots = new Map<string, ReachabilityEvidence>();
 
   add(root: ReachabilityRoot): void {
     const path = resolve(root.path);
@@ -27,27 +34,88 @@ export class ReachabilityIndex {
     this.globalRoots.set(key, root);
   }
 
-  rootsFor(path: string, observedAt: string): RootEvidence[] {
-    const target = resolve(path);
-    const matchingRoots = [...this.roots.values()]
-      .filter((root) =>
-        root.scope === "subtree" ? isInside(root.path, target) : isInside(target, root.path),
-      )
-      .map(({ path: _path, scope: _scope, ...root }) => ({ ...root, observedAt }));
-    const globalRoots = [...this.globalRoots.values()].map((root) => ({
-      ...root,
-      observedAt,
-    }));
+  addResource(resourceId: string, root: ReachabilityEvidence): void {
+    const key = `${resourceId}\0${root.code}\0${root.source}\0${root.evidenceRef ?? ""}`;
+    this.resourceRoots.set(key, root);
+  }
 
-    return [...matchingRoots, ...globalRoots].sort((left, right) => {
+  addGitRef(gitRef: string, root: ReachabilityEvidence): void {
+    const key = `${gitRef}\0${root.code}\0${root.source}\0${root.evidenceRef ?? ""}`;
+    this.gitRefRoots.set(key, root);
+  }
+
+  private isCurrent(root: ReachabilityEvidence, observedAt: string): boolean {
+    return root.expiresAt === undefined || Date.parse(root.expiresAt) > Date.parse(observedAt);
+  }
+
+  private evidence(root: ReachabilityEvidence, observedAt: string): RootEvidence {
+    const { expiresAt: _expiresAt, ...evidence } = root;
+    return { ...evidence, observedAt };
+  }
+
+  private sort(roots: RootEvidence[]): RootEvidence[] {
+    return roots.sort((left, right) => {
       const byCode = left.code.localeCompare(right.code);
-      return byCode !== 0
-        ? byCode
+      if (byCode !== 0) {
+        return byCode;
+      }
+      const bySource = left.source.localeCompare(right.source);
+      return bySource !== 0
+        ? bySource
         : (left.evidenceRef ?? "").localeCompare(right.evidenceRef ?? "");
     });
   }
 
+  rootsFor(path: string, observedAt: string): RootEvidence[] {
+    const target = resolve(path);
+    const matchingRoots = [...this.roots.values()]
+      .filter((root) => this.isCurrent(root, observedAt))
+      .filter((root) =>
+        root.scope === "subtree" ? isInside(root.path, target) : isInside(target, root.path),
+      )
+      .map(({ path: _path, scope: _scope, ...root }) => this.evidence(root, observedAt));
+    const globalRoots = [...this.globalRoots.values()]
+      .filter((root) => this.isCurrent(root, observedAt))
+      .map((root) => this.evidence(root, observedAt));
+
+    return this.sort([...matchingRoots, ...globalRoots]);
+  }
+
+  rootsForResource(
+    resource: ResourceRef,
+    facts: Record<string, unknown>,
+    observedAt: string,
+  ): RootEvidence[] {
+    const roots =
+      resource.path === undefined
+        ? this.rootsFor("/", observedAt)
+        : this.rootsFor(resource.path, observedAt);
+    for (const [key, root] of this.resourceRoots) {
+      if (key.startsWith(`${resource.id}\0`) && this.isCurrent(root, observedAt)) {
+        roots.push(this.evidence(root, observedAt));
+      }
+    }
+
+    const branch = typeof facts.branch === "string" ? facts.branch : undefined;
+    const upstream = typeof facts.upstream === "string" ? facts.upstream : undefined;
+    for (const [key, root] of this.gitRefRoots) {
+      const gitRef = key.slice(0, key.indexOf("\0"));
+      const matchesBranch =
+        branch === gitRef ||
+        (gitRef.startsWith("refs/heads/") && branch === gitRef.slice("refs/heads/".length));
+      const matchesUpstream =
+        upstream === gitRef ||
+        (gitRef.startsWith("refs/remotes/") && upstream === gitRef.slice("refs/remotes/".length));
+      if ((matchesBranch || matchesUpstream) && this.isCurrent(root, observedAt)) {
+        roots.push(this.evidence(root, observedAt));
+      }
+    }
+    return this.sort(roots);
+  }
+
   size(): number {
-    return this.roots.size + this.globalRoots.size;
+    return (
+      this.roots.size + this.resourceRoots.size + this.gitRefRoots.size + this.globalRoots.size
+    );
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import { homedir } from "node:os";
 import { executeAuditCommand } from "./commands/audit.js";
 import { renderAdapters } from "./commands/adapters.js";
 import { executeApplyCommand } from "./commands/apply.js";
-import { executeCleanCommand } from "./commands/clean.js";
+import { cleanCommandExitCode, executeCleanCommand } from "./commands/clean.js";
 import {
   executeConfigInitCommand,
   executeConfigPathCommand,
@@ -113,13 +113,9 @@ export function buildProgram(): Command {
             signal: controller.signal,
           });
           process.stdout.write(result.output);
-          if (result.run?.status === "interrupted") {
-            process.exitCode = 130;
-          } else if (
-            result.run !== undefined &&
-            ["failed", "partial"].includes(result.run.status)
-          ) {
-            process.exitCode = 2;
+          const exitCode = cleanCommandExitCode(result);
+          if (exitCode !== undefined) {
+            process.exitCode = exitCode;
           }
         } finally {
           process.removeListener("SIGINT", interrupt);

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { executeAuditCommand } from "./commands/audit.js";
 import { renderAdapters } from "./commands/adapters.js";
 import { executeApplyCommand } from "./commands/apply.js";
+import { executeCleanCommand } from "./commands/clean.js";
 import {
   executeConfigInitCommand,
   executeConfigPathCommand,
@@ -71,6 +72,58 @@ export function buildProgram(): Command {
       async (options: { audit: string; config?: string; output?: string; stateDir?: string }) => {
         const result = await executePlanCommand(options);
         process.stdout.write(result.output);
+      },
+    );
+
+  program
+    .command("clean")
+    .description("Audit and plan repository-scoped agent cleanup.")
+    .option("--profile <name>", "cleanup profile", "closeout")
+    .option("--home <path>", "home directory to audit")
+    .option("--config <path>", "explicit JSON config")
+    .option("--state-dir <path>", "override the AgentRinse state directory")
+    .option("--max-risk <risk>", "safe, recoverable, destructive, or experimental")
+    .option("--apply", "apply the fresh plan after confirmation", false)
+    .option("--yes", "authorize non-interactive apply", false)
+    .option("--json", "emit a compact versioned closeout summary", false)
+    .action(
+      async (options: {
+        profile: string;
+        home?: string;
+        config?: string;
+        stateDir?: string;
+        maxRisk?: "safe" | "recoverable" | "destructive" | "experimental";
+        apply: boolean;
+        yes: boolean;
+        json: boolean;
+      }) => {
+        if (options.profile !== "closeout") {
+          throw new Error(`unsupported clean profile: ${options.profile}`);
+        }
+        const controller = new AbortController();
+        const interrupt = () => {
+          controller.abort(new CommandInterruptedError("interrupted by SIGINT"));
+        };
+        process.on("SIGINT", interrupt);
+        try {
+          const result = await executeCleanCommand({
+            ...options,
+            profile: "closeout",
+            home: options.home ?? homedir(),
+            signal: controller.signal,
+          });
+          process.stdout.write(result.output);
+          if (result.run?.status === "interrupted") {
+            process.exitCode = 130;
+          } else if (
+            result.run !== undefined &&
+            ["failed", "partial"].includes(result.run.status)
+          ) {
+            process.exitCode = 2;
+          }
+        } finally {
+          process.removeListener("SIGINT", interrupt);
+        }
       },
     );
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.1.0";
+export const VERSION = "0.2.0";

--- a/test/adapters/artifact-adapter.test.ts
+++ b/test/adapters/artifact-adapter.test.ts
@@ -113,6 +113,36 @@ describe("ArtifactAuditAdapter", () => {
     expect(finding.candidateActions).toEqual([]);
   });
 
+  it("does not treat global unknown provider state as artifact ownership", async () => {
+    const { context, projectRoot } = await fixture();
+    const reachability = new ReachabilityIndex();
+    reachability.addGlobal({
+      code: "unknown-provider-state",
+      source: "codex",
+      detail: "Codex workspace metadata could not be proven.",
+    });
+    const adapter = new ArtifactAuditAdapter(
+      {
+        projects: [{ root: projectRoot, names: ["node_modules"] }],
+        minAgeMinutes: 60,
+        minBytes: 1,
+        processCheck: "required",
+        measureBytes: true,
+        maxEntries: 100,
+      },
+      async () => ({ status: "idle", matches: [] }),
+      async () => ({ status: "clear", paths: [] }),
+      reachability,
+    );
+
+    const probe = await adapter.probe(context);
+    const collection = await adapter.collect(context, probe);
+    const finding = await adapter.classify(context, collection.resources[0]!);
+
+    expect(finding.state).toBe("eligible");
+    expect(finding.candidateActions).toHaveLength(1);
+  });
+
   it("uses the newest descendant for the age threshold", async () => {
     const { context, adapter, artifactFile } = await fixture();
     await utimes(artifactFile, NOW, NOW);

--- a/test/adapters/artifact-adapter.test.ts
+++ b/test/adapters/artifact-adapter.test.ts
@@ -10,6 +10,7 @@ import { ArtifactAuditAdapter } from "../../src/adapters/artifacts/adapter.js";
 import type { AuditContext } from "../../src/contracts/adapter.js";
 import type { MountBoundaryResult } from "../../src/core/mount-boundaries.js";
 import type { ProcessOwnershipResult } from "../../src/core/process-ownership.js";
+import { ReachabilityIndex } from "../../src/core/reachability.js";
 
 const NOW = new Date("2026-07-23T12:00:00.000Z");
 
@@ -77,6 +78,38 @@ describe("ArtifactAuditAdapter", () => {
     expect(artifact).toContain("node_modules");
     expect(finding.state).toBe("protected");
     expect(finding.roots[0]?.code).toBe("live-process");
+    expect(finding.candidateActions).toEqual([]);
+  });
+
+  it("suppresses actions inside a rooted worktree", async () => {
+    const { context, projectRoot } = await fixture();
+    const reachability = new ReachabilityIndex();
+    reachability.add({
+      path: projectRoot,
+      code: "active-session",
+      source: "codex",
+      detail: "Codex marks this workspace as active.",
+    });
+    const adapter = new ArtifactAuditAdapter(
+      {
+        projects: [{ root: projectRoot, names: ["node_modules"] }],
+        minAgeMinutes: 60,
+        minBytes: 1,
+        processCheck: "required",
+        measureBytes: true,
+        maxEntries: 100,
+      },
+      async () => ({ status: "idle", matches: [] }),
+      async () => ({ status: "clear", paths: [] }),
+      reachability,
+    );
+
+    const probe = await adapter.probe(context);
+    const collection = await adapter.collect(context, probe);
+    const finding = await adapter.classify(context, collection.resources[0]!);
+
+    expect(finding.state).toBe("protected");
+    expect(finding.roots.map((root) => root.code)).toContain("active-session");
     expect(finding.candidateActions).toEqual([]);
   });
 

--- a/test/adapters/git-adapter.test.ts
+++ b/test/adapters/git-adapter.test.ts
@@ -71,6 +71,9 @@ describe("GitWorktreeAuditAdapter", () => {
         return "origin\n";
       }
       if (command === "for-each-ref") {
+        if (args.includes("--points-at")) {
+          return worktree === linked ? "refs/tags/v0.2.0\n" : "";
+        }
         return worktree === linked
           ? "refs/heads/task\n"
           : "refs/heads/main\nrefs/remotes/origin/main\n";
@@ -91,6 +94,13 @@ describe("GitWorktreeAuditAdapter", () => {
       code: "user-pin",
       source: "config",
       detail: "User configuration pins this resource.",
+      evidenceRef: "pin:branch",
+    });
+    reachability.addGitRef("refs/tags/v0.2.0", {
+      code: "user-pin",
+      source: "config",
+      detail: "User configuration pins this resource.",
+      evidenceRef: "pin:tag",
     });
     const adapter = new GitWorktreeAuditAdapter(
       main,
@@ -134,6 +144,11 @@ describe("GitWorktreeAuditAdapter", () => {
       processMatches: [{ pid: 42, source: "cwd" }],
       inspectionComplete: true,
     });
+    expect(
+      reachability
+        .rootsFor(join(linked, "node_modules"), context.now.toISOString())
+        .filter((root) => root.code === "user-pin"),
+    ).toHaveLength(2);
   });
 
   it("keeps the primary worktree identity when auditing from a linked worktree", async () => {

--- a/test/adapters/git-adapter.test.ts
+++ b/test/adapters/git-adapter.test.ts
@@ -83,6 +83,10 @@ describe("GitWorktreeAuditAdapter", () => {
       main,
       runner,
       async (path) => path.startsWith(linked) && path.endsWith("MERGE_HEAD"),
+      async (path) =>
+        path === linked
+          ? { status: "busy", matches: [{ pid: 42, source: "cwd", path: linked }] }
+          : { status: "idle", matches: [] },
     );
 
     const probe = await adapter.probe(context);
@@ -95,7 +99,12 @@ describe("GitWorktreeAuditAdapter", () => {
     expect(findings.map((finding) => finding.state)).toEqual(["protected", "protected"]);
     expect(findings[0]?.roots.map((root) => root.code)).toContain("main-worktree");
     expect(findings[1]?.roots.map((root) => root.code)).toEqual(
-      expect.arrayContaining(["dirty-worktree", "git-operation-in-progress", "unpushed-commit"]),
+      expect.arrayContaining([
+        "dirty-worktree",
+        "git-operation-in-progress",
+        "live-process-worktree",
+        "unpushed-commit",
+      ]),
     );
     expect(collection.resources[1]?.facts).toMatchObject({
       staged: 1,
@@ -105,6 +114,8 @@ describe("GitWorktreeAuditAdapter", () => {
       remoteReachable: false,
       unpushed: true,
       operations: ["merge"],
+      processOwnership: "busy",
+      processMatches: [{ pid: 42, source: "cwd" }],
       inspectionComplete: true,
     });
   });

--- a/test/adapters/git-adapter.test.ts
+++ b/test/adapters/git-adapter.test.ts
@@ -76,7 +76,7 @@ describe("GitWorktreeAuditAdapter", () => {
           : "refs/heads/main\nrefs/remotes/origin/main\n";
       }
       if (command === "rev-parse" && args.includes("--git-path")) {
-        return join(worktree!, ".git", args.at(-1)!);
+        return `.git/${args.at(-1)!}`;
       }
       throw new Error(`unexpected Git command: ${args.join(" ")}`);
     };
@@ -95,7 +95,7 @@ describe("GitWorktreeAuditAdapter", () => {
     const adapter = new GitWorktreeAuditAdapter(
       main,
       runner,
-      async (path) => path.startsWith(linked) && path.endsWith("MERGE_HEAD"),
+      async (path) => path === join(linked, ".git", "MERGE_HEAD"),
       async (path) =>
         path === linked
           ? { status: "busy", matches: [{ pid: 42, source: "cwd", path: linked }] }
@@ -134,5 +134,66 @@ describe("GitWorktreeAuditAdapter", () => {
       processMatches: [{ pid: 42, source: "cwd" }],
       inspectionComplete: true,
     });
+  });
+
+  it("keeps the primary worktree identity when auditing from a linked worktree", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-git-"));
+    const main = join(home, "repo");
+    const linked = join(home, "task");
+    await mkdir(main);
+    await mkdir(linked);
+    const context: AuditContext = {
+      home,
+      now: new Date("2026-07-23T00:00:00.000Z"),
+      auditId: "audit-linked-root",
+    };
+    const runner = async (args: string[]) => {
+      if (args.includes("--show-toplevel")) {
+        return `${linked}\n`;
+      }
+      const worktree = args[1];
+      const command = args[2];
+      if (command === "worktree") {
+        return [
+          `worktree ${main}`,
+          "HEAD aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "branch refs/heads/main",
+          "",
+          `worktree ${linked}`,
+          "HEAD bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "branch refs/heads/task",
+          "",
+        ].join("\0");
+      }
+      if (command === "status") {
+        const branch = worktree === main ? "main" : "task";
+        const head =
+          worktree === main
+            ? "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            : "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        return [`# branch.oid ${head}`, `# branch.head ${branch}`, ""].join("\0");
+      }
+      if (command === "remote" || command === "for-each-ref") {
+        return "";
+      }
+      if (command === "rev-parse" && args.includes("--git-path")) {
+        return `.git/${args.at(-1)!}`;
+      }
+      throw new Error(`unexpected Git command: ${args.join(" ")}`);
+    };
+    const adapter = new GitWorktreeAuditAdapter(
+      linked,
+      runner,
+      async () => false,
+      async () => ({ status: "idle", matches: [] }),
+    );
+
+    const collection = await adapter.collect(context, await adapter.probe(context));
+
+    expect(collection.resources.map((resource) => resource.resource.displayName)).toEqual([
+      "Main worktree",
+      "Linked worktree",
+    ]);
+    expect(collection.resources.map((resource) => resource.facts.isMain)).toEqual([true, false]);
   });
 });

--- a/test/adapters/git-adapter.test.ts
+++ b/test/adapters/git-adapter.test.ts
@@ -87,6 +87,11 @@ describe("GitWorktreeAuditAdapter", () => {
       source: "codex",
       detail: "Codex metadata references this workspace.",
     });
+    reachability.addGitRef("refs/heads/task", {
+      code: "user-pin",
+      source: "config",
+      detail: "User configuration pins this resource.",
+    });
     const adapter = new GitWorktreeAuditAdapter(
       main,
       runner,
@@ -114,6 +119,7 @@ describe("GitWorktreeAuditAdapter", () => {
         "live-process-worktree",
         "recent-session",
         "unpushed-commit",
+        "user-pin",
       ]),
     );
     expect(collection.resources[1]?.facts).toMatchObject({

--- a/test/adapters/git-adapter.test.ts
+++ b/test/adapters/git-adapter.test.ts
@@ -34,18 +34,56 @@ describe("GitWorktreeAuditAdapter", () => {
       if (args.includes("--show-toplevel")) {
         return `${main}\n`;
       }
-      return [
-        `worktree ${main}`,
-        "HEAD aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "branch refs/heads/main",
-        "",
-        `worktree ${linked}`,
-        "HEAD bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        "branch refs/heads/task",
-        "",
-      ].join("\0");
+      const worktree = args[1];
+      const command = args[2];
+      if (command === "worktree") {
+        return [
+          `worktree ${main}`,
+          "HEAD aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "branch refs/heads/main",
+          "",
+          `worktree ${linked}`,
+          "HEAD bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "branch refs/heads/task",
+          "",
+        ].join("\0");
+      }
+      if (command === "status") {
+        return worktree === linked
+          ? [
+              "# branch.oid bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+              "# branch.head task",
+              "# branch.upstream origin/task",
+              "# branch.ab +1 -0",
+              "1 M. N... 100644 100644 100644 a a staged.ts",
+              "",
+            ].join("\0")
+          : [
+              "# branch.oid aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "# branch.head main",
+              "# branch.upstream origin/main",
+              "# branch.ab +0 -0",
+              "",
+            ].join("\0");
+      }
+      if (command === "remote") {
+        return "origin\n";
+      }
+      if (command === "for-each-ref") {
+        return worktree === linked
+          ? "refs/heads/task\n"
+          : "refs/heads/main\nrefs/remotes/origin/main\n";
+      }
+      if (command === "rev-parse" && args.includes("--git-path")) {
+        return join(worktree!, ".git", args.at(-1)!);
+      }
+      throw new Error(`unexpected Git command: ${args.join(" ")}`);
     };
-    const adapter = new GitWorktreeAuditAdapter(main, runner);
+    const adapter = new GitWorktreeAuditAdapter(
+      main,
+      runner,
+      async (path) => path.startsWith(linked) && path.endsWith("MERGE_HEAD"),
+    );
 
     const probe = await adapter.probe(context);
     const collection = await adapter.collect(context, probe);
@@ -56,5 +94,18 @@ describe("GitWorktreeAuditAdapter", () => {
     expect(collection.resources).toHaveLength(2);
     expect(findings.map((finding) => finding.state)).toEqual(["protected", "protected"]);
     expect(findings[0]?.roots.map((root) => root.code)).toContain("main-worktree");
+    expect(findings[1]?.roots.map((root) => root.code)).toEqual(
+      expect.arrayContaining(["dirty-worktree", "git-operation-in-progress", "unpushed-commit"]),
+    );
+    expect(collection.resources[1]?.facts).toMatchObject({
+      staged: 1,
+      dirty: true,
+      ahead: 1,
+      localReachable: true,
+      remoteReachable: false,
+      unpushed: true,
+      operations: ["merge"],
+      inspectionComplete: true,
+    });
   });
 });

--- a/test/adapters/git-adapter.test.ts
+++ b/test/adapters/git-adapter.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 
 import { GitWorktreeAuditAdapter } from "../../src/adapters/git/adapter.js";
 import type { AuditContext } from "../../src/contracts/adapter.js";
+import { ReachabilityIndex } from "../../src/core/reachability.js";
 
 describe("GitWorktreeAuditAdapter", () => {
   it("requires an explicit repository root", async () => {
@@ -79,6 +80,13 @@ describe("GitWorktreeAuditAdapter", () => {
       }
       throw new Error(`unexpected Git command: ${args.join(" ")}`);
     };
+    const reachability = new ReachabilityIndex();
+    reachability.add({
+      path: linked,
+      code: "recent-session",
+      source: "codex",
+      detail: "Codex metadata references this workspace.",
+    });
     const adapter = new GitWorktreeAuditAdapter(
       main,
       runner,
@@ -87,6 +95,7 @@ describe("GitWorktreeAuditAdapter", () => {
         path === linked
           ? { status: "busy", matches: [{ pid: 42, source: "cwd", path: linked }] }
           : { status: "idle", matches: [] },
+      reachability,
     );
 
     const probe = await adapter.probe(context);
@@ -103,6 +112,7 @@ describe("GitWorktreeAuditAdapter", () => {
         "dirty-worktree",
         "git-operation-in-progress",
         "live-process-worktree",
+        "recent-session",
         "unpushed-commit",
       ]),
     );

--- a/test/adapters/git-status.test.ts
+++ b/test/adapters/git-status.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { parseGitStatusPorcelainV2 } from "../../src/adapters/git/status.js";
+
+describe("parseGitStatusPorcelainV2", () => {
+  it("collects branch, push, staged, modified, untracked, and conflict facts", () => {
+    const input = [
+      "# branch.oid aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "# branch.head task",
+      "# branch.upstream origin/task",
+      "# branch.ab +2 -1",
+      "1 M. N... 100644 100644 100644 a a staged.ts",
+      "1 .M N... 100644 100644 100644 a a modified.ts",
+      "2 MM N... 100644 100644 100644 a a R100 renamed.ts",
+      "old.ts",
+      "u UU N... 100644 100644 100644 100644 a a a conflict.ts",
+      "? untracked.ts",
+      "! ignored.log",
+      "",
+    ].join("\0");
+
+    expect(parseGitStatusPorcelainV2(input)).toEqual({
+      head: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      branch: "task",
+      upstream: "origin/task",
+      ahead: 2,
+      behind: 1,
+      staged: 3,
+      modified: 3,
+      untracked: 1,
+      conflicted: 1,
+      ignored: 1,
+    });
+  });
+
+  it("handles detached and unborn heads", () => {
+    expect(
+      parseGitStatusPorcelainV2(
+        ["# branch.oid (initial)", "# branch.head (detached)", ""].join("\0"),
+      ),
+    ).toEqual({
+      ahead: 0,
+      behind: 0,
+      staged: 0,
+      modified: 0,
+      untracked: 0,
+      conflicted: 0,
+      ignored: 0,
+    });
+  });
+
+  it("fails closed on unknown records", () => {
+    expect(() => parseGitStatusPorcelainV2("future record\0")).toThrow(
+      "unknown porcelain v2 record",
+    );
+  });
+});

--- a/test/adapters/provider-reachability.test.ts
+++ b/test/adapters/provider-reachability.test.ts
@@ -1,0 +1,150 @@
+import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ProviderAuditAdapter } from "../../src/adapters/provider-adapter.js";
+import { PROVIDER_SPECS } from "../../src/adapters/provider-specs.js";
+import type { AuditContext } from "../../src/contracts/adapter.js";
+import { ReachabilityIndex } from "../../src/core/reachability.js";
+
+async function fixtureContext(): Promise<AuditContext> {
+  return {
+    home: await mkdtemp(join(tmpdir(), "agentrinse-reachability-")),
+    now: new Date("2026-07-24T00:00:00.000Z"),
+    auditId: "audit-reachability",
+  };
+}
+
+describe("provider reachability metadata", () => {
+  it("links Codex workspaces without reading transcript files", async () => {
+    const context = await fixtureContext();
+    const root = join(context.home, ".codex");
+    const active = join(context.home, "src", "active");
+    const recent = join(context.home, "src", "recent");
+    const managed = join(root, "worktrees", "repo", "task");
+    await mkdir(join(root, "sessions"), { recursive: true });
+    await mkdir(managed, { recursive: true });
+    await writeFile(join(root, "sessions", "secret.jsonl"), "never emit this transcript");
+    await writeFile(
+      join(root, ".codex-global-state.json"),
+      JSON.stringify({
+        "active-workspace-roots": [active],
+        "electron-saved-workspace-roots": [],
+        "thread-workspace-root-hints": { "private-thread-id": recent },
+      }),
+    );
+    const reachability = new ReachabilityIndex();
+    const adapter = new ProviderAuditAdapter(PROVIDER_SPECS.codex, {
+      root,
+      measureBytes: false,
+      maxEntries: 100,
+      reachability,
+    });
+
+    const probe = await adapter.probe(context);
+    const collection = await adapter.collect(context, probe);
+    const roots = [
+      ...reachability.rootsFor(active, context.now.toISOString()),
+      ...reachability.rootsFor(recent, context.now.toISOString()),
+      ...reachability.rootsFor(managed, context.now.toISOString()),
+    ];
+
+    expect(collection.diagnostics).toEqual([]);
+    expect(roots.map((root) => root.code)).toEqual([
+      "active-session",
+      "recent-session",
+      "provider-managed-worktree",
+    ]);
+    expect(JSON.stringify(roots)).not.toContain("private-thread-id");
+    expect(JSON.stringify(roots)).not.toContain("never emit this transcript");
+  });
+
+  it("links Claude project keys without reading session bodies", async () => {
+    const context = await fixtureContext();
+    const root = join(context.home, ".claude");
+    const project = join(context.home, "src", "project");
+    await mkdir(join(root, "projects", "encoded-project"), { recursive: true });
+    await writeFile(
+      join(root, "projects", "encoded-project", "secret.jsonl"),
+      "never emit this transcript",
+    );
+    await writeFile(
+      join(context.home, ".claude.json"),
+      JSON.stringify({
+        projects: {
+          [project]: {
+            lastSessionId: "private-session-id",
+          },
+        },
+      }),
+    );
+    const reachability = new ReachabilityIndex();
+    const adapter = new ProviderAuditAdapter(PROVIDER_SPECS.claude, {
+      root,
+      measureBytes: false,
+      maxEntries: 100,
+      reachability,
+    });
+
+    const probe = await adapter.probe(context);
+    const collection = await adapter.collect(context, probe);
+    const roots = reachability.rootsFor(project, context.now.toISOString());
+
+    expect(collection.diagnostics).toEqual([]);
+    expect(roots.map((root) => root.code)).toEqual(["recent-session"]);
+    expect(JSON.stringify(roots)).not.toContain("private-session-id");
+    expect(JSON.stringify(roots)).not.toContain("never emit this transcript");
+  });
+
+  it("fails closed when supported provider metadata is malformed", async () => {
+    const context = await fixtureContext();
+    const root = join(context.home, ".codex");
+    await mkdir(root);
+    await writeFile(join(root, ".codex-global-state.json"), "{broken");
+    const reachability = new ReachabilityIndex();
+    const adapter = new ProviderAuditAdapter(PROVIDER_SPECS.codex, {
+      root,
+      measureBytes: false,
+      maxEntries: 100,
+      reachability,
+    });
+
+    const probe = await adapter.probe(context);
+    const collection = await adapter.collect(context, probe);
+    const roots = reachability.rootsFor(
+      join(context.home, "any-worktree"),
+      context.now.toISOString(),
+    );
+
+    expect(collection.diagnostics.map((item) => item.code)).toContain(
+      "CODEX_WORKSPACE_METADATA_INVALID",
+    );
+    expect(roots.map((root) => root.code)).toContain("unknown-provider-state");
+  });
+
+  it("fails closed when a provider root cannot be inspected", async () => {
+    const context = await fixtureContext();
+    const root = join(context.home, ".claude");
+    const target = await mkdtemp(join(tmpdir(), "agentrinse-claude-target-"));
+    await symlink(target, root);
+    const reachability = new ReachabilityIndex();
+    const adapter = new ProviderAuditAdapter(PROVIDER_SPECS.claude, {
+      root,
+      measureBytes: false,
+      maxEntries: 100,
+      reachability,
+    });
+
+    const probe = await adapter.probe(context);
+    await adapter.collect(context, probe);
+
+    expect(probe.status).toBe("degraded");
+    expect(
+      reachability
+        .rootsFor(join(context.home, "any-worktree"), context.now.toISOString())
+        .map((root) => root.code),
+    ).toContain("unknown-provider-state");
+  });
+});

--- a/test/adapters/runtime-adapter.test.ts
+++ b/test/adapters/runtime-adapter.test.ts
@@ -1,0 +1,96 @@
+import { chmod, mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { RuntimeAuditAdapter } from "../../src/adapters/runtime/adapter.js";
+import type { AuditContext } from "../../src/contracts/adapter.js";
+
+async function fixtureContext(): Promise<AuditContext> {
+  return {
+    home: await mkdtemp(join(tmpdir(), "agentrinse-runtime-")),
+    now: new Date("2026-07-24T00:00:00.000Z"),
+    auditId: "audit-runtime",
+  };
+}
+
+describe("RuntimeAuditAdapter", () => {
+  it("inventories the documented Claude native version layout", async () => {
+    const context = await fixtureContext();
+    const bin = join(context.home, ".local", "bin");
+    const versions = join(context.home, ".local", "share", "claude", "versions");
+    const oldVersion = join(versions, "2.1.200");
+    const activeVersion = join(versions, "2.1.201");
+    await mkdir(bin, { recursive: true });
+    await mkdir(versions, { recursive: true });
+    await writeFile(oldVersion, "old");
+    await writeFile(activeVersion, "active");
+    await chmod(oldVersion, 0o700);
+    await chmod(activeVersion, 0o700);
+    await symlink(activeVersion, join(bin, "claude"));
+    const adapter = new RuntimeAuditAdapter({
+      environment: { PATH: bin },
+      platform: "linux",
+      runVersion: async () => {
+        throw new Error("native Claude versions do not need execution");
+      },
+    });
+
+    const probe = await adapter.probe(context);
+    const collection = await adapter.collect(context, probe);
+    const findings = await Promise.all(
+      collection.resources.map((resource) => adapter.classify(context, resource)),
+    );
+
+    expect(probe.status).toBe("available");
+    expect(collection.resources).toHaveLength(2);
+    expect(collection.resources.map((resource) => resource.facts.version)).toEqual([
+      "2.1.200",
+      "2.1.201",
+    ]);
+    expect(collection.resources.map((resource) => resource.facts.selected)).toEqual([false, true]);
+    expect(findings.every((finding) => finding.state === "protected")).toBe(true);
+    expect(findings.every((finding) => finding.candidateActions.length === 0)).toBe(true);
+  });
+
+  it("reports a generic selected executable without guessing its installer", async () => {
+    const context = await fixtureContext();
+    const bin = join(context.home, "bin");
+    const executable = join(bin, "codex");
+    await mkdir(bin);
+    await writeFile(executable, "#!/bin/sh\n");
+    await chmod(executable, 0o700);
+    const adapter = new RuntimeAuditAdapter({
+      environment: { PATH: bin },
+      platform: "linux",
+      runVersion: async () => "codex-cli 0.143.0\n",
+    });
+
+    const probe = await adapter.probe(context);
+    const collection = await adapter.collect(context, probe);
+
+    expect(collection.resources).toHaveLength(1);
+    expect(collection.resources[0]?.facts).toMatchObject({
+      tool: "codex",
+      selected: true,
+      version: "codex-cli 0.143.0",
+      installManager: "unknown",
+      reportOnly: true,
+    });
+    expect(collection.diagnostics).toEqual([]);
+  });
+
+  it("reports an absent isolated PATH without diagnostics", async () => {
+    const context = await fixtureContext();
+    const adapter = new RuntimeAuditAdapter({
+      environment: { PATH: join(context.home, "missing") },
+      platform: "linux",
+    });
+
+    const probe = await adapter.probe(context);
+
+    expect(probe.status).toBe("absent");
+    expect(probe.diagnostics).toEqual([]);
+  });
+});

--- a/test/adapters/runtime-adapter.test.ts
+++ b/test/adapters/runtime-adapter.test.ts
@@ -30,7 +30,7 @@ describe("RuntimeAuditAdapter", () => {
     await chmod(activeVersion, 0o700);
     await symlink(activeVersion, join(bin, "claude"));
     const adapter = new RuntimeAuditAdapter({
-      environment: { PATH: bin },
+      environment: { PATH: join(context.home, "missing-bin") },
       platform: "linux",
       runVersion: async () => {
         throw new Error("native Claude versions do not need execution");

--- a/test/adapters/runtime-adapter.test.ts
+++ b/test/adapters/runtime-adapter.test.ts
@@ -1,6 +1,6 @@
 import { chmod, mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -79,6 +79,34 @@ describe("RuntimeAuditAdapter", () => {
       reportOnly: true,
     });
     expect(collection.diagnostics).toEqual([]);
+  });
+
+  it("skips non-executable Unix PATH entries", async () => {
+    const context = await fixtureContext();
+    const shadowBin = join(context.home, "shadow-bin");
+    const selectedBin = join(context.home, "selected-bin");
+    const shadow = join(shadowBin, "codex");
+    const selected = join(selectedBin, "codex");
+    await mkdir(shadowBin);
+    await mkdir(selectedBin);
+    await writeFile(shadow, "#!/bin/sh\n");
+    await writeFile(selected, "#!/bin/sh\n");
+    await chmod(shadow, 0o600);
+    await chmod(selected, 0o700);
+    const adapter = new RuntimeAuditAdapter({
+      environment: { PATH: `${shadowBin}${delimiter}${selectedBin}` },
+      platform: "linux",
+      runVersion: async (executable) => {
+        expect(executable).toBe(selected);
+        return "codex-cli 0.143.0\n";
+      },
+    });
+
+    const probe = await adapter.probe(context);
+    const collection = await adapter.collect(context, probe);
+
+    expect(collection.resources).toHaveLength(1);
+    expect(collection.resources[0]?.facts.launcherPath).toBe(selected);
   });
 
   it("reports an absent isolated PATH without diagnostics", async () => {

--- a/test/commands/clean.test.ts
+++ b/test/commands/clean.test.ts
@@ -6,7 +6,11 @@ import { promisify } from "node:util";
 
 import { describe, expect, it } from "vitest";
 
-import { cleanCommandExitCode, executeCleanCommand } from "../../src/commands/clean.js";
+import {
+  cleanCommandExitCode,
+  cleanCommandStatus,
+  executeCleanCommand,
+} from "../../src/commands/clean.js";
 import { DEFAULT_CONFIG } from "../../src/config/defaults.js";
 import { commandEnvelopeSchema } from "../../src/contracts/output.js";
 import { writeJsonAtomic } from "../../src/state/json-file.js";
@@ -74,6 +78,9 @@ describe("clean closeout profile", () => {
   it("returns a nonzero automation status for degraded safety evidence", () => {
     expect(cleanCommandExitCode({ status: "degraded" })).toBe(1);
     expect(cleanCommandExitCode({ status: "ok" })).toBeUndefined();
+    expect(cleanCommandStatus({ probes: [], diagnostics: [] }, { status: "interrupted" })).toBe(
+      "failed",
+    );
   });
 
   it("scopes a compact dry run to one repository and protects the current worktree", async () => {

--- a/test/commands/clean.test.ts
+++ b/test/commands/clean.test.ts
@@ -1,0 +1,171 @@
+import { execFile } from "node:child_process";
+import { access, mkdir, mkdtemp, readFile, realpath, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import { describe, expect, it } from "vitest";
+
+import { executeCleanCommand } from "../../src/commands/clean.js";
+import { DEFAULT_CONFIG } from "../../src/config/defaults.js";
+import { commandEnvelopeSchema } from "../../src/contracts/output.js";
+import { writeJsonAtomic } from "../../src/state/json-file.js";
+
+const execFileAsync = promisify(execFile);
+const NOW = new Date("2026-07-24T12:00:00.000Z");
+
+async function run(command: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
+  const result = await execFileAsync(command, args, { encoding: "utf8" });
+  return { stdout: result.stdout, stderr: result.stderr };
+}
+
+async function gitFixture(): Promise<{
+  home: string;
+  main: string;
+  linked: string;
+  configPath: string;
+  stateDir: string;
+}> {
+  const home = await realpath(await mkdtemp(join(tmpdir(), "agentrinse-clean-")));
+  const main = join(home, "repo");
+  const linked = join(home, "task");
+  const configPath = join(home, "config.json");
+  const stateDir = join(home, "state");
+  await run("git", ["init", "-b", "main", main]);
+  await writeFile(join(main, "README.md"), "fixture\n");
+  await run("git", ["-C", main, "add", "README.md"]);
+  await run("git", [
+    "-C",
+    main,
+    "-c",
+    "user.name=AgentRinse",
+    "-c",
+    "user.email=fixture@example.invalid",
+    "commit",
+    "-m",
+    "fixture",
+  ]);
+  await run("git", ["-C", main, "worktree", "add", "-b", "task", linked]);
+  return { home, main, linked, configPath, stateDir };
+}
+
+function fixtureConfig(projects: { root: string; names: ["node_modules"] }[]) {
+  return {
+    ...structuredClone(DEFAULT_CONFIG),
+    adapters: {
+      ...structuredClone(DEFAULT_CONFIG.adapters),
+      codex: { enabled: false },
+      claude: { enabled: false },
+    },
+    audit: {
+      maxEntries: 100,
+      measureBytes: true,
+    },
+    artifacts: {
+      projects,
+      minAgeMinutes: 0,
+      minBytes: 0,
+      processCheck: "required" as const,
+    },
+  };
+}
+
+describe("clean closeout profile", () => {
+  it("scopes a compact dry run to one repository and protects the current worktree", async () => {
+    const value = await gitFixture();
+    const currentArtifact = join(value.linked, "node_modules");
+    const unrelated = join(value.home, "unrelated");
+    await mkdir(currentArtifact);
+    await mkdir(join(unrelated, "node_modules"), { recursive: true });
+    await writeFile(join(currentArtifact, "cache.bin"), "current");
+    await writeFile(join(unrelated, "node_modules", "cache.bin"), "unrelated");
+    await writeJsonAtomic(
+      value.configPath,
+      fixtureConfig([
+        { root: value.linked, names: ["node_modules"] },
+        { root: unrelated, names: ["node_modules"] },
+      ]),
+    );
+
+    const result = await executeCleanCommand({
+      home: value.home,
+      config: value.configPath,
+      stateDir: value.stateDir,
+      profile: "closeout",
+      cwd: value.linked,
+      apply: false,
+      yes: false,
+      json: true,
+      dependencies: {
+        platform: "darwin",
+        now: () => NOW,
+        runCommand: async (command, args) =>
+          command === "mo" ? { stdout: "Mole fixture\n", stderr: "" } : run(command, args),
+      },
+    });
+    const envelope = commandEnvelopeSchema.parse(JSON.parse(result.output));
+    const artifactFindings = result.audit.findings.filter(
+      (finding) => finding.resource.kind === "build-artifact",
+    );
+
+    expect(result.summary.repositoryRoot).toBe(value.main);
+    expect(result.summary.currentWorktree).toBe(value.linked);
+    expect(result.summary.worktrees).toBe(2);
+    expect(result.summary.protectedWorktrees).toBe(2);
+    expect(result.summary.eligibleActions).toBe(0);
+    expect(result.summary.mole).toEqual({
+      status: "available",
+      suggestions: ["mo purge --dry-run", "mo clean --dry-run"],
+    });
+    expect(artifactFindings).toHaveLength(1);
+    expect(artifactFindings[0]?.state).toBe("protected");
+    expect(artifactFindings[0]?.roots.map((root) => root.code)).toContain("current-worktree");
+    expect(result.audit.probes.map((probe) => probe.adapter)).not.toContain("cursor");
+    expect(envelope.command).toBe("clean");
+    await Promise.all([
+      access(result.summary.auditPath),
+      access(result.summary.planPath),
+      access(result.summary.configPath),
+    ]);
+    const scopedConfig = JSON.parse(await readFile(result.summary.configPath, "utf8"));
+    expect(scopedConfig.artifacts.projects).toEqual([
+      { root: value.linked, names: ["node_modules"] },
+    ]);
+  });
+
+  it("applies only an existing safe artifact action from a fresh closeout plan", async () => {
+    const value = await gitFixture();
+    const artifact = join(value.main, "node_modules");
+    const artifactFile = join(artifact, "cache.bin");
+    await mkdir(artifact);
+    await writeFile(artifactFile, "remove");
+    await utimes(artifactFile, new Date(0), new Date(0));
+    await utimes(artifact, new Date(0), new Date(0));
+    await writeJsonAtomic(
+      value.configPath,
+      fixtureConfig([{ root: value.main, names: ["node_modules"] }]),
+    );
+
+    const result = await executeCleanCommand({
+      home: value.home,
+      config: value.configPath,
+      stateDir: value.stateDir,
+      profile: "closeout",
+      cwd: value.linked,
+      apply: true,
+      yes: true,
+      json: false,
+      dependencies: {
+        platform: "linux",
+        now: () => NOW,
+        runCommand: run,
+      },
+    });
+
+    expect(result.plan.actions).toHaveLength(1);
+    expect(result.run?.status).toBe("completed");
+    expect(result.run?.actions[0]?.status).toBe("applied");
+    await expect(access(artifact)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(join(value.main, "README.md"), "utf8")).resolves.toBe("fixture\n");
+  });
+});

--- a/test/commands/clean.test.ts
+++ b/test/commands/clean.test.ts
@@ -6,7 +6,7 @@ import { promisify } from "node:util";
 
 import { describe, expect, it } from "vitest";
 
-import { executeCleanCommand } from "../../src/commands/clean.js";
+import { cleanCommandExitCode, executeCleanCommand } from "../../src/commands/clean.js";
 import { DEFAULT_CONFIG } from "../../src/config/defaults.js";
 import { commandEnvelopeSchema } from "../../src/contracts/output.js";
 import { writeJsonAtomic } from "../../src/state/json-file.js";
@@ -71,6 +71,11 @@ function fixtureConfig(projects: { root: string; names: ["node_modules"] }[]) {
 }
 
 describe("clean closeout profile", () => {
+  it("returns a nonzero automation status for degraded safety evidence", () => {
+    expect(cleanCommandExitCode({ status: "degraded" })).toBe(1);
+    expect(cleanCommandExitCode({ status: "ok" })).toBeUndefined();
+  });
+
   it("scopes a compact dry run to one repository and protects the current worktree", async () => {
     const value = await gitFixture();
     const currentArtifact = join(value.linked, "node_modules");
@@ -122,6 +127,7 @@ describe("clean closeout profile", () => {
     expect(artifactFindings[0]?.roots.map((root) => root.code)).toContain("current-worktree");
     expect(result.audit.probes.map((probe) => probe.adapter)).not.toContain("cursor");
     expect(envelope.command).toBe("clean");
+    expect(result.status).toBe("ok");
     await Promise.all([
       access(result.summary.auditPath),
       access(result.summary.planPath),
@@ -131,6 +137,39 @@ describe("clean closeout profile", () => {
     expect(scopedConfig.artifacts.projects).toEqual([
       { root: value.linked, names: ["node_modules"] },
     ]);
+  });
+
+  it("marks incomplete provider reachability as degraded", async () => {
+    const value = await gitFixture();
+    const codexRoot = join(value.home, ".codex");
+    await mkdir(codexRoot);
+    const config = fixtureConfig([]);
+    config.adapters.codex = { enabled: true };
+    await writeJsonAtomic(value.configPath, config);
+
+    const result = await executeCleanCommand({
+      home: value.home,
+      config: value.configPath,
+      stateDir: value.stateDir,
+      profile: "closeout",
+      cwd: value.linked,
+      apply: false,
+      yes: false,
+      json: true,
+      dependencies: {
+        platform: "linux",
+        now: () => NOW,
+        runCommand: run,
+      },
+    });
+    const envelope = commandEnvelopeSchema.parse(JSON.parse(result.output));
+
+    expect(result.status).toBe("degraded");
+    expect(cleanCommandExitCode(result)).toBe(1);
+    expect(envelope.status).toBe("degraded");
+    expect(result.audit.diagnostics.map((item) => item.code)).toContain(
+      "CODEX_WORKSPACE_METADATA_MISSING",
+    );
   });
 
   it("applies only an existing safe artifact action from a fresh closeout plan", async () => {

--- a/test/commands/completion.test.ts
+++ b/test/commands/completion.test.ts
@@ -12,6 +12,7 @@ describe("completion command", () => {
 
     expect(output).toContain(marker);
     expect(output).toContain("audit");
+    expect(output).toContain("clean");
     expect(output).toContain("doctor");
     expect(output).toContain("recover");
     expect(output).toContain("resource");

--- a/test/config/load.test.ts
+++ b/test/config/load.test.ts
@@ -63,6 +63,11 @@ describe("loadConfig", () => {
           ],
           minBytes: 1,
         },
+        pins: [
+          { path: "/tmp/project" },
+          { resourceId: "git:git-worktree:fixture" },
+          { gitRef: "refs/heads/release", expiresAt: "2026-08-01T00:00:00.000Z" },
+        ],
       }),
     );
 
@@ -81,6 +86,11 @@ describe("loadConfig", () => {
     ]);
     expect(config.artifacts.minAgeMinutes).toBe(24 * 60);
     expect(config.artifacts.minBytes).toBe(1);
+    expect(config.pins).toEqual([
+      { path: "/tmp/project" },
+      { resourceId: "git:git-worktree:fixture" },
+      { gitRef: "refs/heads/release", expiresAt: "2026-08-01T00:00:00.000Z" },
+    ]);
   });
 
   it("rejects relative artifact roots", async () => {
@@ -149,5 +159,19 @@ describe("loadConfig", () => {
     await expect(loadConfig(path)).rejects.toThrow(
       /artifact project roots must be unique|artifact cleanup targets must not overlap/,
     );
+  });
+
+  it("rejects ambiguous, relative, and malformed pins", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agentrinse-config-"));
+    const path = join(root, "config.json");
+    await writeFile(
+      path,
+      JSON.stringify({
+        schemaVersion: 1,
+        pins: [{ path: "./project" }, { path: "/tmp/project", resourceId: "resource" }],
+      }),
+    );
+
+    await expect(loadConfig(path)).rejects.toThrow();
   });
 });

--- a/test/config/load.test.ts
+++ b/test/config/load.test.ts
@@ -174,4 +174,28 @@ describe("loadConfig", () => {
 
     await expect(loadConfig(path)).rejects.toThrow();
   });
+
+  it.each([
+    "refs/tags/",
+    "refs/heads/foo bar",
+    "refs/heads/foo..bar",
+    "refs/heads/foo.lock",
+    "refs/heads/.hidden",
+    "refs/heads/foo@{bar",
+    "refs/heads/foo.",
+    "refs/heads/foo//bar",
+    "refs/heads/foo~1",
+  ])("rejects invalid Git pin ref %s", async (gitRef) => {
+    const root = await mkdtemp(join(tmpdir(), "agentrinse-config-"));
+    const path = join(root, "config.json");
+    await writeFile(
+      path,
+      JSON.stringify({
+        schemaVersion: 1,
+        pins: [{ gitRef }],
+      }),
+    );
+
+    await expect(loadConfig(path)).rejects.toThrow("pin Git ref is invalid");
+  });
 });

--- a/test/core/audit.test.ts
+++ b/test/core/audit.test.ts
@@ -56,6 +56,13 @@ describe("runAudit", () => {
     expect(createAuditAdapters(config).map((adapter) => adapter.id)).toContain("docker");
   });
 
+  it("adds runtime inventory only when explicitly enabled", () => {
+    const config = structuredClone(DEFAULT_CONFIG);
+    config.adapters.runtime = { enabled: true };
+
+    expect(createAuditAdapters(config).map((adapter) => adapter.id)).toContain("runtime");
+  });
+
   it("adds artifacts only when explicit projects are configured", () => {
     const config = structuredClone(DEFAULT_CONFIG);
     config.artifacts.projects = [

--- a/test/core/audit.test.ts
+++ b/test/core/audit.test.ts
@@ -49,6 +49,23 @@ describe("runAudit", () => {
     expect(createAuditAdapters(config).map((adapter) => adapter.id)).toContain("git");
   });
 
+  it("resolves Git roots before classifying mutable artifacts", () => {
+    const config = structuredClone(DEFAULT_CONFIG);
+    config.adapters.git = {
+      enabled: true,
+      root: "/tmp/agentrinse-git-fixture",
+    };
+    config.artifacts.projects = [
+      {
+        root: "/tmp/agentrinse-git-fixture",
+        names: ["node_modules"],
+      },
+    ];
+
+    const adapters = createAuditAdapters(config).map((adapter) => adapter.id);
+    expect(adapters.indexOf("git")).toBeLessThan(adapters.indexOf("artifacts"));
+  });
+
   it("adds Docker only when explicitly enabled", () => {
     const config = structuredClone(DEFAULT_CONFIG);
     config.adapters.docker = { enabled: true };

--- a/test/core/reachability.test.ts
+++ b/test/core/reachability.test.ts
@@ -116,4 +116,44 @@ describe("ReachabilityIndex", () => {
     expect(roots.every((item) => item.code === "user-pin")).toBe(true);
     expect(JSON.stringify(roots)).not.toContain("expiresAt");
   });
+
+  it("binds exact Git ref pins to nested resources in their worktree", () => {
+    const index = new ReachabilityIndex();
+    index.addGitRef("refs/tags/v0.2.0", {
+      code: "user-pin",
+      source: "config",
+      detail: "User configuration pins this resource.",
+    });
+
+    index.bindGitRefsToPath("/tmp/repo/task", ["refs/tags/v0.2.0"], "2026-07-24T00:00:00.000Z");
+
+    expect(index.rootsFor("/tmp/repo/task/node_modules", "2026-07-24T00:00:00.000Z")).toEqual([
+      {
+        code: "user-pin",
+        source: "config",
+        observedAt: "2026-07-24T00:00:00.000Z",
+        detail: "User configuration pins this resource.",
+      },
+    ]);
+  });
+
+  it("fails closed when Git ref pin resolution is incomplete", () => {
+    const index = new ReachabilityIndex();
+    index.addGitRef("refs/heads/task", {
+      code: "user-pin",
+      source: "config",
+      detail: "User configuration pins this resource.",
+    });
+
+    index.bindGitRefsToPath("/tmp/repo/task", [], "2026-07-24T00:00:00.000Z", false);
+
+    expect(index.rootsFor("/tmp/repo/task/dist", "2026-07-24T00:00:00.000Z")).toEqual([
+      {
+        code: "user-pin",
+        source: "config",
+        observedAt: "2026-07-24T00:00:00.000Z",
+        detail: "A configured Git ref pin could not be ruled out for this worktree.",
+      },
+    ]);
+  });
 });

--- a/test/core/reachability.test.ts
+++ b/test/core/reachability.test.ts
@@ -19,6 +19,18 @@ describe("ReachabilityIndex", () => {
       detail: "Codex links a thread to this path.",
       evidenceRef: "codex:thread",
     });
+    index.add({
+      code: "provider-managed-worktree",
+      source: "codex",
+      path: "/tmp/repo",
+      scope: "subtree",
+      detail: "Codex owns this managed worktree.",
+    });
+    index.addGlobal({
+      code: "unknown-provider-state",
+      source: "claude",
+      detail: "Claude metadata could not be proven.",
+    });
 
     expect(index.rootsFor("/tmp/repo/worktree", "2026-07-24T00:00:00.000Z")).toEqual([
       {
@@ -29,14 +41,33 @@ describe("ReachabilityIndex", () => {
         evidenceRef: "codex:thread",
       },
       {
+        code: "provider-managed-worktree",
+        source: "codex",
+        observedAt: "2026-07-24T00:00:00.000Z",
+        detail: "Codex owns this managed worktree.",
+      },
+      {
         code: "recent-session",
         source: "claude",
         observedAt: "2026-07-24T00:00:00.000Z",
         detail: "Claude remembers this project.",
         evidenceRef: "claude:project",
       },
+      {
+        code: "unknown-provider-state",
+        source: "claude",
+        observedAt: "2026-07-24T00:00:00.000Z",
+        detail: "Claude metadata could not be proven.",
+      },
     ]);
-    expect(index.rootsFor("/tmp/repo/other", "2026-07-24T00:00:00.000Z")).toEqual([]);
+    expect(index.rootsFor("/tmp/other", "2026-07-24T00:00:00.000Z")).toEqual([
+      {
+        code: "unknown-provider-state",
+        source: "claude",
+        observedAt: "2026-07-24T00:00:00.000Z",
+        detail: "Claude metadata could not be proven.",
+      },
+    ]);
   });
 
   it("deduplicates identical evidence", () => {

--- a/test/core/reachability.test.ts
+++ b/test/core/reachability.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { ReachabilityIndex } from "../../src/core/reachability.js";
+
+describe("ReachabilityIndex", () => {
+  it("adds roots monotonically and explains matching worktrees deterministically", () => {
+    const index = new ReachabilityIndex();
+    index.add({
+      code: "recent-session",
+      source: "claude",
+      path: "/tmp/repo/worktree",
+      detail: "Claude remembers this project.",
+      evidenceRef: "claude:project",
+    });
+    index.add({
+      code: "active-session",
+      source: "codex",
+      path: "/tmp/repo/worktree/src",
+      detail: "Codex links a thread to this path.",
+      evidenceRef: "codex:thread",
+    });
+
+    expect(index.rootsFor("/tmp/repo/worktree", "2026-07-24T00:00:00.000Z")).toEqual([
+      {
+        code: "active-session",
+        source: "codex",
+        observedAt: "2026-07-24T00:00:00.000Z",
+        detail: "Codex links a thread to this path.",
+        evidenceRef: "codex:thread",
+      },
+      {
+        code: "recent-session",
+        source: "claude",
+        observedAt: "2026-07-24T00:00:00.000Z",
+        detail: "Claude remembers this project.",
+        evidenceRef: "claude:project",
+      },
+    ]);
+    expect(index.rootsFor("/tmp/repo/other", "2026-07-24T00:00:00.000Z")).toEqual([]);
+  });
+
+  it("deduplicates identical evidence", () => {
+    const index = new ReachabilityIndex();
+    const root = {
+      code: "active-session",
+      source: "codex",
+      path: "/tmp/repo",
+      detail: "active",
+    };
+    index.add(root);
+    index.add(root);
+
+    expect(index.size()).toBe(1);
+  });
+});

--- a/test/core/reachability.test.ts
+++ b/test/core/reachability.test.ts
@@ -83,4 +83,37 @@ describe("ReachabilityIndex", () => {
 
     expect(index.size()).toBe(1);
   });
+
+  it("matches resource and Git ref pins while ignoring expired pins", () => {
+    const index = new ReachabilityIndex();
+    const root = {
+      code: "user-pin",
+      source: "config",
+      detail: "User configuration pins this resource.",
+    };
+    index.addResource("git:git-worktree:fixture", root);
+    index.addGitRef("refs/heads/task", root);
+    index.add({
+      ...root,
+      path: "/tmp/repo/task",
+      expiresAt: "2026-07-23T00:00:00.000Z",
+    });
+
+    const roots = index.rootsForResource(
+      {
+        id: "git:git-worktree:fixture",
+        adapter: "git",
+        kind: "git-worktree",
+        canonicalKey: "git:git-worktree:/tmp/repo/task",
+        displayName: "Linked worktree",
+        path: "/tmp/repo/task",
+      },
+      { branch: "task" },
+      "2026-07-24T00:00:00.000Z",
+    );
+
+    expect(roots).toHaveLength(2);
+    expect(roots.every((item) => item.code === "user-pin")).toBe(true);
+    expect(JSON.stringify(roots)).not.toContain("expiresAt");
+  });
 });


### PR DESCRIPTION
## Summary

- add structured Git worktree status, reachability, live-process, provider workspace, and explicit pin protection
- add repository-scoped `clean --profile closeout` with persisted audit/plan/config and optional safe artifact apply
- add opt-in report-only agent runtime inventory, including Claude native versions
- prepare the public package and docs for `0.2.0`

## Safety boundary

- **Resource owners:** Git owns worktree/ref state; Codex and Claude own workspace metadata; runtime installers own installed executables; configured project roots own rebuildable artifacts.
- **Discovery evidence:** Git porcelain v2 and worktree porcelain, local refs, exact tags, process cwd/fd ownership, metadata-only provider workspace roots, explicit config pins, PATH/native launcher inspection.
- **Protection roots:** main/current worktree, dirty or in-progress Git state, unpushed/unreachable commits, live processes, provider-managed/recent/active workspaces, exact resource/path/ref pins, and unresolved ref-pin state.
- **Risk class:** only existing explicit rebuildable artifact removal remains `safe`; Git worktrees, provider state, runtimes, Docker, branches, stashes, and volumes remain report-only.
- **Revalidation:** artifact actions retain exact path, project-root, device, inode, mtime, fingerprint, process, mount, age, and size checks before apply.
- **Recovery:** artifact apply keeps the existing same-parent tombstone, run journal, and recovery behavior. This release adds no new mutating action.

## Verification

- `oxfmt --check .`
- `oxlint src test`
- `tsc -p tsconfig.json --noEmit`
- `vitest run` (43 files, 229 tests)
- build and 6 generated schema checks
- package manifest check and `publint`
- `npm pack --dry-run`
- source synthetic smoke
- installed-tarball synthetic smoke
- structured autoreview clean after accepted fixes