### PR TITLE
fix: enable audit state persistence on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,29 @@ jobs:
 
       - name: Smoke installed package
         run: pnpm smoke:package
+
+  windows-audit-state:
+    runs-on: windows-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check Windows build
+        run: pnpm typecheck
+
+      - name: Test private audit state
+        run: pnpm vitest run test/state/json-file.test.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ The project follows semantic versioning after its first supported release.
 
 ### Fixed
 
+- native Windows audit and plan commands can persist private state without
+  attempting unsupported directory-handle sync, while enforcing and verifying
+  explicit owner, `SYSTEM`, and Administrators ACLs
 - Claude discovery and provider-file authorization now share explicit root,
   absolute `CLAUDE_CONFIG_DIR`, and `$HOME/.claude` precedence and fail closed
   on relative environment values

--- a/src/state/json-file.ts
+++ b/src/state/json-file.ts
@@ -16,7 +16,7 @@ $identities = @($currentUser, $system, $administrators) | Group-Object Value | F
 $allowedSids = @($identities | ForEach-Object { $_.Value })
 $acl = $directory.GetAccessControl()
 $owner = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
-if (-not $owner.Equals($currentUser)) { throw "private state directory is not owned by the current user: $($directory.FullName)" }
+if (-not ($owner.Equals($currentUser) -or $owner.Equals($administrators))) { throw "private state directory is not owned by the current user or local Administrators: $($directory.FullName)" }
 $acl.SetAccessRuleProtection($true, $false)
 foreach ($rule in @($acl.Access)) { [void] $acl.RemoveAccessRuleAll($rule) }
 $inheritance = [System.Security.AccessControl.InheritanceFlags]::ObjectInherit -bor [System.Security.AccessControl.InheritanceFlags]::ContainerInherit
@@ -27,7 +27,7 @@ foreach ($sid in $identities) { $acl.AddAccessRule([System.Security.AccessContro
 $directory.SetAccessControl($acl)
 $verified = $directory.GetAccessControl()
 $verifiedOwner = $verified.GetOwner([System.Security.Principal.SecurityIdentifier])
-if (-not $verifiedOwner.Equals($currentUser)) { throw "private state directory is not owned by the current user after ACL update: $($directory.FullName)" }
+if (-not ($verifiedOwner.Equals($currentUser) -or $verifiedOwner.Equals($administrators))) { throw "private state directory has an unexpected owner after ACL update: $($directory.FullName)" }
 $rules = @($verified.Access)
 if ($rules.Count -ne $allowedSids.Count) { throw "private state directory has unexpected access rules after ACL update: $($directory.FullName)" }
 foreach ($rule in $rules) {

--- a/src/state/json-file.ts
+++ b/src/state/json-file.ts
@@ -12,7 +12,8 @@ $directory = [System.IO.DirectoryInfo]::new([Environment]::GetEnvironmentVariabl
 $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
 $system = [System.Security.Principal.SecurityIdentifier]::new('S-1-5-18')
 $administrators = [System.Security.Principal.SecurityIdentifier]::new('S-1-5-32-544')
-$allowedSids = @($currentUser.Value, $system.Value, $administrators.Value)
+$identities = @($currentUser, $system, $administrators) | Group-Object Value | ForEach-Object { $_.Group[0] }
+$allowedSids = @($identities | ForEach-Object { $_.Value })
 $acl = $directory.GetAccessControl()
 $owner = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
 if (-not $owner.Equals($currentUser)) { throw "private state directory is not owned by the current user: $($directory.FullName)" }
@@ -22,7 +23,7 @@ $inheritance = [System.Security.AccessControl.InheritanceFlags]::ObjectInherit -
 $propagation = [System.Security.AccessControl.PropagationFlags]::None
 $allow = [System.Security.AccessControl.AccessControlType]::Allow
 $full = [System.Security.AccessControl.FileSystemRights]::FullControl
-foreach ($sid in @($currentUser, $system, $administrators)) { $acl.AddAccessRule([System.Security.AccessControl.FileSystemAccessRule]::new($sid, $full, $inheritance, $propagation, $allow)) }
+foreach ($sid in $identities) { $acl.AddAccessRule([System.Security.AccessControl.FileSystemAccessRule]::new($sid, $full, $inheritance, $propagation, $allow)) }
 $directory.SetAccessControl($acl)
 $verified = $directory.GetAccessControl()
 $verifiedOwner = $verified.GetOwner([System.Security.Principal.SecurityIdentifier])

--- a/src/state/json-file.ts
+++ b/src/state/json-file.ts
@@ -1,12 +1,60 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { chmod, lstat, mkdir, open, readFile, rename, rm } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { dirname, join, win32 as windowsPath } from "node:path";
 import { randomUUID } from "node:crypto";
+
+const execFileAsync = promisify(execFile);
+const windowsPrivateDirectoryPathEnvironmentVariable = "AGENTRINSE_PRIVATE_DIRECTORY";
+
+const secureWindowsPrivateDirectoryCommand = `
+$directory = [System.IO.DirectoryInfo]::new([Environment]::GetEnvironmentVariable('${windowsPrivateDirectoryPathEnvironmentVariable}'))
+$currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+$system = [System.Security.Principal.SecurityIdentifier]::new('S-1-5-18')
+$administrators = [System.Security.Principal.SecurityIdentifier]::new('S-1-5-32-544')
+$allowedSids = @($currentUser.Value, $system.Value, $administrators.Value)
+$acl = $directory.GetAccessControl()
+$owner = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
+if (-not $owner.Equals($currentUser)) { throw "private state directory is not owned by the current user: $($directory.FullName)" }
+$acl.SetAccessRuleProtection($true, $false)
+foreach ($rule in @($acl.Access)) { [void] $acl.RemoveAccessRuleAll($rule) }
+$inheritance = [System.Security.AccessControl.InheritanceFlags]::ObjectInherit -bor [System.Security.AccessControl.InheritanceFlags]::ContainerInherit
+$propagation = [System.Security.AccessControl.PropagationFlags]::None
+$allow = [System.Security.AccessControl.AccessControlType]::Allow
+$full = [System.Security.AccessControl.FileSystemRights]::FullControl
+foreach ($sid in @($currentUser, $system, $administrators)) { $acl.AddAccessRule([System.Security.AccessControl.FileSystemAccessRule]::new($sid, $full, $inheritance, $propagation, $allow)) }
+$directory.SetAccessControl($acl)
+$verified = $directory.GetAccessControl()
+$verifiedOwner = $verified.GetOwner([System.Security.Principal.SecurityIdentifier])
+if (-not $verifiedOwner.Equals($currentUser)) { throw "private state directory is not owned by the current user after ACL update: $($directory.FullName)" }
+$rules = @($verified.Access)
+if ($rules.Count -ne $allowedSids.Count) { throw "private state directory has unexpected access rules after ACL update: $($directory.FullName)" }
+foreach ($rule in $rules) {
+  $sid = $rule.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier])
+  if ($rule.AccessControlType -ne $allow -or $allowedSids -notcontains $sid.Value -or $rule.FileSystemRights -ne $full -or $rule.InheritanceFlags -ne $inheritance -or $rule.PropagationFlags -ne $propagation -or $rule.IsInherited) { throw "private state directory ACL verification failed: $($directory.FullName)" }
+}
+`;
+
+export function windowsPowerShellExecutable(systemRoot = process.env.SystemRoot): string {
+  if (systemRoot === undefined || !windowsPath.isAbsolute(systemRoot)) {
+    throw new Error("Windows SystemRoot is unavailable or not absolute");
+  }
+  return windowsPath.join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+}
 
 export async function readJsonFile(path: string): Promise<unknown> {
   return JSON.parse(await readFile(path, "utf8")) as unknown;
 }
 
-export async function syncDirectory(path: string): Promise<void> {
+export async function syncDirectory(
+  path: string,
+  platform: NodeJS.Platform = process.platform,
+): Promise<void> {
+  // Windows does not support fsync on directory handles. State-file handles
+  // are still synced before rename, and mutation remains blocked on Windows.
+  if (platform === "win32") {
+    return;
+  }
   const handle = await open(path, "r");
   try {
     await handle.sync();
@@ -19,6 +67,21 @@ export type JsonWriteOptions = {
   privateDirectories?: string[];
 };
 
+async function secureWindowsPrivateDirectory(directory: string): Promise<void> {
+  await execFileAsync(
+    windowsPowerShellExecutable(),
+    ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", secureWindowsPrivateDirectoryCommand],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        [windowsPrivateDirectoryPathEnvironmentVariable]: directory,
+      },
+      windowsHide: true,
+    },
+  );
+}
+
 export async function ensurePrivateDirectory(directory: string): Promise<void> {
   await mkdir(directory, { recursive: true, mode: 0o700 });
   const stats = await lstat(directory);
@@ -28,6 +91,10 @@ export async function ensurePrivateDirectory(directory: string): Promise<void> {
   const uid = process.getuid?.();
   if (uid !== undefined && stats.uid !== uid) {
     throw new Error(`private state directory is not owned by the current user: ${directory}`);
+  }
+  if (process.platform === "win32") {
+    await secureWindowsPrivateDirectory(directory);
+    return;
   }
   await chmod(directory, 0o700);
 }

--- a/test/state/json-file.test.ts
+++ b/test/state/json-file.test.ts
@@ -1,12 +1,87 @@
+import { execFile } from "node:child_process";
 import { chmod, mkdtemp, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
 
 import { describe, expect, it } from "vitest";
 
-import { readJsonFile, writeJsonAtomic, writeJsonExclusive } from "../../src/state/json-file.js";
+import {
+  readJsonFile,
+  syncDirectory,
+  windowsPowerShellExecutable,
+  writeJsonAtomic,
+  writeJsonExclusive,
+} from "../../src/state/json-file.js";
+
+const execFileAsync = promisify(execFile);
+
+type WindowsAclRule = {
+  sid: string;
+  type: string;
+  rights: number;
+  inherited: boolean;
+};
+
+type WindowsAcl = {
+  currentUserSid: string;
+  ownerSid: string;
+  access: WindowsAclRule[];
+};
+
+const inspectWindowsAclCommand = `
+$directory = [System.IO.DirectoryInfo]::new([Environment]::GetEnvironmentVariable('AGENTRINSE_TEST_DIRECTORY'))
+$currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+$acl = $directory.GetAccessControl()
+[pscustomobject]@{
+  currentUserSid = $currentUser
+  ownerSid = $acl.GetOwner([System.Security.Principal.SecurityIdentifier]).Value
+  access = @($acl.Access | ForEach-Object {
+    [pscustomobject]@{
+      sid = $_.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier]).Value
+      type = $_.AccessControlType.ToString()
+      rights = [int]$_.FileSystemRights
+      inherited = $_.IsInherited
+    }
+  })
+} | ConvertTo-Json -Compress
+`;
+
+async function expectPosixMode(path: string, expected: number): Promise<void> {
+  if (process.platform !== "win32") {
+    expect((await stat(path)).mode & 0o777).toBe(expected);
+  }
+}
+
+async function inspectWindowsAcl(directory: string): Promise<WindowsAcl> {
+  const { stdout } = await execFileAsync(
+    "powershell.exe",
+    ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", inspectWindowsAclCommand],
+    {
+      encoding: "utf8",
+      env: { ...process.env, AGENTRINSE_TEST_DIRECTORY: directory },
+      windowsHide: true,
+    },
+  );
+  return JSON.parse(stdout) as WindowsAcl;
+}
 
 describe("atomic JSON files", () => {
+  it("resolves PowerShell from an absolute Windows system root", () => {
+    expect(windowsPowerShellExecutable("C:\\Windows")).toBe(
+      "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+    );
+    expect(() => windowsPowerShellExecutable("relative")).toThrow(
+      "Windows SystemRoot is unavailable or not absolute",
+    );
+  });
+
+  it("skips unsupported directory sync on Windows", async () => {
+    await expect(
+      syncDirectory(join(tmpdir(), "agentrinse-missing-directory"), "win32"),
+    ).resolves.toBeUndefined();
+  });
+
   it("writes a complete owner-only document", async () => {
     const root = await mkdtemp(join(tmpdir(), "agentrinse-state-"));
     const path = join(root, "plans", "plan.json");
@@ -14,8 +89,8 @@ describe("atomic JSON files", () => {
     await writeJsonAtomic(path, { planId: "plan-1" });
 
     expect(await readJsonFile(path)).toEqual({ planId: "plan-1" });
-    expect((await stat(path)).mode & 0o777).toBe(0o600);
-    expect((await stat(join(root, "plans"))).mode & 0o777).toBe(0o700);
+    await expectPosixMode(path, 0o600);
+    await expectPosixMode(join(root, "plans"), 0o700);
   });
 
   it("does not change permissions on an existing parent directory", async () => {
@@ -24,8 +99,8 @@ describe("atomic JSON files", () => {
 
     await writeJsonExclusive(join(root, "config.json"), { schemaVersion: 1 });
 
-    expect((await stat(root)).mode & 0o777).toBe(0o755);
-    expect((await stat(join(root, "config.json"))).mode & 0o777).toBe(0o600);
+    await expectPosixMode(root, 0o755);
+    await expectPosixMode(join(root, "config.json"), 0o600);
   });
 
   it("repairs and verifies AgentRinse-owned state directories", async () => {
@@ -41,7 +116,35 @@ describe("atomic JSON files", () => {
       },
     );
 
-    expect((await stat(root)).mode & 0o777).toBe(0o700);
-    expect((await stat(plans)).mode & 0o777).toBe(0o700);
+    await expectPosixMode(root, 0o700);
+    await expectPosixMode(plans, 0o700);
   });
+
+  it.runIf(process.platform === "win32")(
+    "removes inherited access from private state directories",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "agentrinse-private-state-windows-"));
+      const plans = join(root, "plans");
+
+      await writeJsonAtomic(
+        join(plans, "plan.json"),
+        { planId: "plan-1" },
+        { privateDirectories: [root, plans] },
+      );
+
+      for (const directory of [root, plans]) {
+        const acl = await inspectWindowsAcl(directory);
+        expect(acl.ownerSid).toBe(acl.currentUserSid);
+        expect(acl.access).toHaveLength(3);
+        expect(acl.access).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ sid: acl.currentUserSid, type: "Allow", rights: 2_032_127 }),
+            expect.objectContaining({ sid: "S-1-5-18", type: "Allow", rights: 2_032_127 }),
+            expect.objectContaining({ sid: "S-1-5-32-544", type: "Allow", rights: 2_032_127 }),
+          ]),
+        );
+        expect(acl.access.every((rule) => !rule.inherited)).toBe(true);
+      }
+    },
+  );
 });

--- a/test/state/json-file.test.ts
+++ b/test/state/json-file.test.ts
@@ -134,7 +134,7 @@ describe("atomic JSON files", () => {
 
       for (const directory of [root, plans]) {
         const acl = await inspectWindowsAcl(directory);
-        expect(acl.ownerSid).toBe(acl.currentUserSid);
+        expect([acl.currentUserSid, "S-1-5-32-544"]).toContain(acl.ownerSid);
         expect(acl.access).toHaveLength(3);
         expect(acl.access).toEqual(
           expect.arrayContaining([


### PR DESCRIPTION
## Summary

Enables the documented native-Windows audit-only path to persist its audit and plan evidence safely.

## Problem

`agentrinse clean --profile closeout --json` failed on native Windows with `EPERM: operation not permitted, fsync` after writing state, because Windows does not support `fsync` on a directory handle. The original POSIX permission handling also could not establish owner-only Windows ACLs for persisted audit state.

## Implementation

- Skip directory-handle `fsync` only on Windows; state-file handles are still synced before atomic rename.
- Secure every private state directory on Windows with an explicit ACL for the current user, `SYSTEM`, and local Administrators, then verify the owner, rules, inheritance, and full-control rights.
- Resolve PowerShell only from the absolute `SystemRoot\System32\WindowsPowerShell\v1.0` path so an untrusted checkout cannot shadow it with a local executable.
- Add portable path-resolution coverage and native-Windows ACL regression coverage.

## Validation

Native Windows host:

```text
pnpm vitest run test/state/json-file.test.ts  # 6 passed
pnpm format:check; pnpm lint; pnpm typecheck # passed
pnpm build                                   # passed
node dist/cli.js clean --profile closeout --home C:\Users\example --json # exit 0
```

The host audit persisted its records with exactly the current user, `SYSTEM`, and Administrators as non-inherited full-control ACL entries.

Linux Docker proof (source mounted read-only, copied into the disposable container workspace):

```text
pnpm vitest run test/state/json-file.test.ts  # 5 passed, 1 Windows-only test skipped
pnpm schemas:check
pnpm smoke
pnpm smoke:package
pnpm pack:check
```

All Docker commands passed.

`pnpm check` on the Windows host passed formatting, lint, and typecheck, then reported 116 pre-existing POSIX/path/atomic-rename/lock test failures. Those tests exercise unsupported mutation and Unix-only fixture behavior and are outside this audit-only patch; no repository-wide Windows test-suite claim is made.

## Codex review closeout

- `codex review --uncommitted`: clean after the final fix.
- `codex review --base origin/main`: clean after the final fix.
- One accepted P1 from the first base review (current-directory/PATH executable shadowing) was fixed by resolving PowerShell from an absolute SystemRoot path; focused proof and both review gates were rerun.

## Risk and rollout

Native Windows remains audit-only. If PowerShell is unavailable, `SystemRoot` is not absolute, or the state directory cannot be made and verified private, the command fails closed rather than writing audit data with a weak ACL.

## Maintainer closeout

- Rebased onto current main and added a native Windows audit-state CI job.
- Autoreview found and fixed duplicate SID handling for LocalSystem.
- GitHub Windows proof found and fixed the valid Administrators-group owner case used by elevated Windows accounts.
- Final autoreview: clean after the ownership correction.