### PR TITLE
fix(claude): honor configured data root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ The project follows semantic versioning after its first supported release.
 - provider liveness detection for native, helper, interpreted, and wrapped
   command lines, with fail-closed incomplete process evidence
 
+### Fixed
+
+- Claude discovery now honors an absolute `CLAUDE_CONFIG_DIR` when no explicit
+  adapter root is configured and fails closed on relative values
+
 ### Safety
 
 - no provider adapter emits the new action until a provider-specific owner

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,8 +99,11 @@ protects the unresolved scope instead of allowing an artifact action.
 
 Codex, Claude Code, Cursor, GitHub Copilot CLI, Zed, OpenCode, and Grok Build
 are enabled for read-only inventory by default. Each accepts an optional
-`root`. Missing default roots mean the provider is absent, not broken. Codex
-can propose offline database maintenance only with
+`root`. Claude resolves its root from the explicit adapter `root`, then an
+absolute `$CLAUDE_CONFIG_DIR`, then `$HOME/.claude`. A relative
+`$CLAUDE_CONFIG_DIR` degrades the Claude adapter rather than auditing the wrong
+directory. Missing default roots mean the provider is absent, not broken.
+Codex can propose offline database maintenance only with
 `audit --allow-offline-vacuum`; the flag is intentionally not persisted in
 configuration. A
 missing explicit root is a doctor warning.

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -1268,7 +1268,9 @@ Avoid a large product-specific environment-variable surface.
 
 `$CODEX_HOME` falls back to `$HOME/.codex`.
 
-`$CLAUDE_CONFIG_DIR` falls back to `$HOME/.claude`.
+Claude root precedence is the explicit adapter root, an absolute
+`$CLAUDE_CONFIG_DIR`, then `$HOME/.claude`. A relative
+`$CLAUDE_CONFIG_DIR` is invalid and degrades only the Claude adapter.
 
 `$COPILOT_HOME` falls back to `$HOME/.copilot`.
 

--- a/src/adapters/provider-adapter.ts
+++ b/src/adapters/provider-adapter.ts
@@ -1,5 +1,5 @@
 import { lstat } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 
 import type { AuditAdapter, AuditContext, CollectionResult } from "../contracts/adapter.js";
 import type { Diagnostic } from "../contracts/diagnostic.js";
@@ -23,6 +23,7 @@ import type { ProviderSpec } from "./provider-specs.js";
 
 export type ProviderAdapterOptions = {
   root?: string;
+  environment?: NodeJS.ProcessEnv;
   platform?: NodeJS.Platform;
   measureBytes: boolean;
   maxEntries: number;
@@ -57,14 +58,40 @@ export class ProviderAuditAdapter implements AuditAdapter {
   }
 
   private root(context: AuditContext): string {
-    return resolve(
-      this.options.root ??
-        this.spec.defaultRoot(context.home, this.options.platform ?? process.platform),
-    );
+    if (this.options.root !== undefined) {
+      return resolve(this.options.root);
+    }
+    if (this.spec.id === "claude") {
+      const configuredRoot = this.options.environment?.CLAUDE_CONFIG_DIR;
+      if (configuredRoot !== undefined && configuredRoot !== "") {
+        if (!isAbsolute(configuredRoot)) {
+          throw new Error("CLAUDE_CONFIG_DIR must be an absolute path");
+        }
+        return resolve(configuredRoot);
+      }
+    }
+    return resolve(this.spec.defaultRoot(context.home, this.options.platform ?? process.platform));
   }
 
   async probe(context: AuditContext): Promise<AdapterProbe> {
-    const root = this.root(context);
+    let root: string;
+    try {
+      root = this.root(context);
+    } catch (error) {
+      return {
+        adapter: this.id,
+        status: "degraded",
+        detail: `${this.spec.displayName} root configuration is invalid`,
+        diagnostics: [
+          {
+            severity: "warning",
+            code: "PROVIDER_ROOT_INVALID",
+            message: error instanceof Error ? error.message : String(error),
+            adapter: this.id,
+          },
+        ],
+      };
+    }
 
     try {
       const stats = await lstat(root);

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -62,6 +62,7 @@ export function createAuditAdapters(
         reachability,
         inventoryResources: options.providerInventory ?? true,
         allowOfflineVacuum: options.allowOfflineVacuum ?? false,
+        environment: options.environment ?? process.env,
       }),
   );
 

--- a/test/adapters/provider-adapter.test.ts
+++ b/test/adapters/provider-adapter.test.ts
@@ -93,6 +93,62 @@ describe("ProviderAuditAdapter", () => {
     expect(probe.diagnostics[0]?.code).toBe("PROVIDER_ROOT_SYMLINK");
   });
 
+  it("uses CLAUDE_CONFIG_DIR as the default Claude root", async () => {
+    const context = await fixtureContext();
+    const root = join(context.home, "claude-state");
+    await mkdir(join(root, "debug"), { recursive: true });
+    const adapter = new ProviderAuditAdapter(PROVIDER_SPECS.claude, {
+      environment: { CLAUDE_CONFIG_DIR: root },
+      measureBytes: true,
+      maxEntries: 100,
+    });
+
+    const probe = await adapter.probe(context);
+    const collection = await adapter.collect(context, probe);
+
+    expect(probe).toMatchObject({ status: "available", root });
+    expect(collection.resources[0]?.resource.path).toBe(join(root, "debug"));
+  });
+
+  it("fails closed for a relative CLAUDE_CONFIG_DIR", async () => {
+    const context = await fixtureContext();
+    const adapter = new ProviderAuditAdapter(PROVIDER_SPECS.claude, {
+      environment: { CLAUDE_CONFIG_DIR: "relative/claude-state" },
+      measureBytes: true,
+      maxEntries: 100,
+    });
+
+    const probe = await adapter.probe(context);
+
+    expect(probe).toMatchObject({
+      status: "degraded",
+      detail: "Claude Code root configuration is invalid",
+      diagnostics: [
+        {
+          code: "PROVIDER_ROOT_INVALID",
+          message: "CLAUDE_CONFIG_DIR must be an absolute path",
+        },
+      ],
+    });
+    expect((await adapter.collect(context, probe)).resources).toEqual([]);
+  });
+
+  it("prefers an explicit Claude root over CLAUDE_CONFIG_DIR", async () => {
+    const context = await fixtureContext();
+    const root = join(context.home, "configured-claude");
+    await mkdir(root);
+    const adapter = new ProviderAuditAdapter(PROVIDER_SPECS.claude, {
+      root,
+      environment: { CLAUDE_CONFIG_DIR: join(context.home, "environment-claude") },
+      measureBytes: true,
+      maxEntries: 100,
+    });
+
+    const probe = await adapter.probe(context);
+
+    expect(probe).toMatchObject({ status: "available", root });
+  });
+
   it("proposes an experimental offline vacuum only with explicit authorization", async () => {
     const context = await fixtureContext();
     const path = join(context.home, ".codex", "state_5.sqlite");


### PR DESCRIPTION
## Summary

- resolve Claude state from an explicit AgentRinse adapter root, then `CLAUDE_CONFIG_DIR`, then `$HOME/.claude`
- require the environment-provided root to be absolute and degrade only the Claude adapter when invalid
- document the precedence and fail-closed behavior

Part of #16.

## Safety boundary

- resource owner: Claude Code
- evidence: Claude documents `CLAUDE_CONFIG_DIR` as the application-data relocation mechanism
- protection roots: explicit AgentRinse configuration remains highest priority; relative environment paths are never resolved against the process working directory
- risk class: discovery-only; this PR adds no mutation
- revalidation/recovery: unchanged because no action is emitted

## Verification

- `./node_modules/.bin/oxfmt --check .`
- `./node_modules/.bin/oxlint src test`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `./node_modules/.bin/vitest run` (56 files, 408 tests)
- schema, manifest, publint, and `npm pack --dry-run` package gate
- autoreview: clean, no accepted/actionable findings