### PR TITLE
fix(provider): share Claude root authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,9 @@ The project follows semantic versioning after its first supported release.
 
 ### Fixed
 
-- Claude discovery now honors an absolute `CLAUDE_CONFIG_DIR` when no explicit
-  adapter root is configured and fails closed on relative values
+- Claude discovery and provider-file authorization now share explicit root,
+  absolute `CLAUDE_CONFIG_DIR`, and `$HOME/.claude` precedence and fail closed
+  on relative environment values
 
 ### Safety
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,7 +102,8 @@ are enabled for read-only inventory by default. Each accepts an optional
 `root`. Claude resolves its root from the explicit adapter `root`, then an
 absolute `$CLAUDE_CONFIG_DIR`, then `$HOME/.claude`. A relative
 `$CLAUDE_CONFIG_DIR` degrades the Claude adapter rather than auditing the wrong
-directory. Missing default roots mean the provider is absent, not broken.
+directory. The same resolution is repeated before any provider-file action is
+authorized. Missing default roots mean the provider is absent, not broken.
 Codex can propose offline database maintenance only with
 `audit --allow-offline-vacuum`; the flag is intentionally not persisted in
 configuration. A

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -1270,7 +1270,8 @@ Avoid a large product-specific environment-variable surface.
 
 Claude root precedence is the explicit adapter root, an absolute
 `$CLAUDE_CONFIG_DIR`, then `$HOME/.claude`. A relative
-`$CLAUDE_CONFIG_DIR` is invalid and degrades only the Claude adapter.
+`$CLAUDE_CONFIG_DIR` is invalid and degrades only the Claude adapter. Discovery
+and mutation authorization use the same resolver.
 
 `$COPILOT_HOME` falls back to `$HOME/.copilot`.
 

--- a/src/adapters/provider-adapter.ts
+++ b/src/adapters/provider-adapter.ts
@@ -1,5 +1,5 @@
 import { lstat } from "node:fs/promises";
-import { isAbsolute, join, resolve } from "node:path";
+import { join, resolve } from "node:path";
 
 import type { AuditAdapter, AuditContext, CollectionResult } from "../contracts/adapter.js";
 import type { Diagnostic } from "../contracts/diagnostic.js";
@@ -19,6 +19,7 @@ import {
   type CodexDatabaseInspection,
 } from "./codex-database.js";
 import { collectProviderReachability } from "./provider-reachability.js";
+import { resolveProviderRoot } from "./provider-root.js";
 import type { ProviderSpec } from "./provider-specs.js";
 
 export type ProviderAdapterOptions = {
@@ -58,19 +59,7 @@ export class ProviderAuditAdapter implements AuditAdapter {
   }
 
   private root(context: AuditContext): string {
-    if (this.options.root !== undefined) {
-      return resolve(this.options.root);
-    }
-    if (this.spec.id === "claude") {
-      const configuredRoot = this.options.environment?.CLAUDE_CONFIG_DIR;
-      if (configuredRoot !== undefined && configuredRoot !== "") {
-        if (!isAbsolute(configuredRoot)) {
-          throw new Error("CLAUDE_CONFIG_DIR must be an absolute path");
-        }
-        return resolve(configuredRoot);
-      }
-    }
-    return resolve(this.spec.defaultRoot(context.home, this.options.platform ?? process.platform));
+    return resolveProviderRoot(this.spec, context.home, this.options);
   }
 
   async probe(context: AuditContext): Promise<AdapterProbe> {

--- a/src/adapters/provider-root.ts
+++ b/src/adapters/provider-root.ts
@@ -1,0 +1,29 @@
+import { isAbsolute, resolve } from "node:path";
+
+import type { ProviderSpec } from "./provider-specs.js";
+
+export type ProviderRootOptions = {
+  root?: string;
+  environment?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+};
+
+export function resolveProviderRoot(
+  spec: ProviderSpec,
+  home: string,
+  options: ProviderRootOptions = {},
+): string {
+  if (options.root !== undefined) {
+    return resolve(options.root);
+  }
+  if (spec.id === "claude") {
+    const configuredRoot = options.environment?.CLAUDE_CONFIG_DIR;
+    if (configuredRoot !== undefined && configuredRoot !== "") {
+      if (!isAbsolute(configuredRoot)) {
+        throw new Error("CLAUDE_CONFIG_DIR must be an absolute path");
+      }
+      return resolve(configuredRoot);
+    }
+  }
+  return resolve(spec.defaultRoot(resolve(home), options.platform ?? process.platform));
+}

--- a/src/core/provider-file-policy.ts
+++ b/src/core/provider-file-policy.ts
@@ -1,6 +1,7 @@
 import { realpath } from "node:fs/promises";
 import { resolve } from "node:path";
 
+import { resolveProviderRoot } from "../adapters/provider-root.js";
 import { PROVIDER_SPECS } from "../adapters/provider-specs.js";
 import type { AgentRinseConfig } from "../config/schema.js";
 import type { ProviderFileQuarantineAction, ProviderMutationId } from "../contracts/action.js";
@@ -20,11 +21,15 @@ export async function authorizeProviderFileAction(
   home: string,
   config: AgentRinseConfig,
   platform: NodeJS.Platform = process.platform,
+  environment: NodeJS.ProcessEnv = process.env,
 ): Promise<void> {
-  const configuredRoot =
-    config.adapters[action.adapter]?.root ??
-    PROVIDER_SPECS[action.adapter].defaultRoot(resolve(home), platform);
-  const physicalRoot = await realpath(resolve(configuredRoot));
+  const explicitRoot = config.adapters[action.adapter]?.root;
+  const configuredRoot = resolveProviderRoot(PROVIDER_SPECS[action.adapter], resolve(home), {
+    ...(explicitRoot === undefined ? {} : { root: explicitRoot }),
+    platform,
+    environment,
+  });
+  const physicalRoot = await realpath(configuredRoot);
   if (action.target.ownerRoot !== physicalRoot) {
     throw new Error(`provider-file target is outside the configured ${action.adapter} root`);
   }

--- a/test/adapters/provider-root.test.ts
+++ b/test/adapters/provider-root.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveProviderRoot } from "../../src/adapters/provider-root.js";
+import { PROVIDER_SPECS } from "../../src/adapters/provider-specs.js";
+
+describe("resolveProviderRoot", () => {
+  it("prefers an explicit root over the Claude environment", () => {
+    expect(
+      resolveProviderRoot(PROVIDER_SPECS.claude, "/fixture/home", {
+        root: "/fixture/configured-claude",
+        environment: { CLAUDE_CONFIG_DIR: "/fixture/environment-claude" },
+      }),
+    ).toBe("/fixture/configured-claude");
+  });
+
+  it("uses an absolute CLAUDE_CONFIG_DIR before the default", () => {
+    expect(
+      resolveProviderRoot(PROVIDER_SPECS.claude, "/fixture/home", {
+        environment: { CLAUDE_CONFIG_DIR: "/fixture/environment-claude" },
+      }),
+    ).toBe("/fixture/environment-claude");
+  });
+
+  it("falls back to the Claude directory under the audited home", () => {
+    expect(
+      resolveProviderRoot(PROVIDER_SPECS.claude, "/fixture/home", {
+        environment: {},
+      }),
+    ).toBe("/fixture/home/.claude");
+  });
+
+  it("rejects a relative CLAUDE_CONFIG_DIR", () => {
+    expect(() =>
+      resolveProviderRoot(PROVIDER_SPECS.claude, "/fixture/home", {
+        environment: { CLAUDE_CONFIG_DIR: "relative/claude" },
+      }),
+    ).toThrow("CLAUDE_CONFIG_DIR must be an absolute path");
+  });
+});


### PR DESCRIPTION
## Summary

- centralize provider root resolution
- use the same Claude root precedence for audit discovery and final provider-file authorization
- keep explicit AgentRinse config above `CLAUDE_CONFIG_DIR` and reject relative environment roots

Part of #16.

## Safety boundary

- resource owner: Claude Code
- evidence: Claude documents `CLAUDE_CONFIG_DIR` as the application-data relocation mechanism
- protection roots: mutation authorization now resolves the identical physical root used by discovery
- risk class: authorization-only; no provider policy is enabled by this PR
- revalidation: the shared resolver runs again before provider-file apply
- recovery: unchanged; no new action can yet be emitted

## Verification

- full format, lint, and TypeScript checks
- `./node_modules/.bin/vitest run` (57 files, 412 tests)
- schema, manifest, publint, and package dry-run gate
- autoreview: clean, no accepted/actionable findings