### PR TITLE
feat(claude): quarantine old debug logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The project follows semantic versioning after its first supported release.
   JSON Schema branches that bind every action adapter to its target provider
 - provider liveness detection for native, helper, interpreted, and wrapped
   command lines, with fail-closed incomplete process evidence
+- recoverable quarantine for direct Claude `debug/*.txt` files older than 30
+  days, with a seven-day undo window before purge
 
 ### Fixed
 
@@ -37,6 +39,8 @@ The project follows semantic versioning after its first supported release.
   path contract for disposable log or cache files
 - directories, symlinks, sessions, transcripts, databases, credentials,
   configuration, and ambiguous recovery state remain outside this boundary
+- Claude cleanup excludes JSONL, nested paths, recent logs, active Claude
+  processes, open descriptors, and incomplete directory enumeration
 
 ## [0.4.0] - 2026-07-25
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ logical memory records.
 | Logo                                                                        | Client                                                        | Mode                   | What it protects                                                    |
 | --------------------------------------------------------------------------- | ------------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------- |
 | <img width="48px" src="docs/client-openai.jpg" alt="OpenAI Codex" />        | [OpenAI Codex](https://github.com/openai/codex)               | audit + offline vacuum | sessions, workspace roots, reachability, and supported SQLite state |
-| <img width="48px" src="docs/client-claude.jpg" alt="Claude Code" />         | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | audit-only             | sessions, workspace roots, and reachability                         |
+| <img width="48px" src="docs/client-claude.jpg" alt="Claude Code" />         | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | audit + log quarantine | sessions, workspace roots, reachability, and old debug logs         |
 | <img width="48px" src="docs/client-cursor.jpg" alt="Cursor" />              | [Cursor](https://cursor.com/docs)                             | audit-only             | local agent state and workspace references                          |
 | <img width="48px" src="docs/client-copilot.png" alt="GitHub Copilot CLI" /> | [GitHub Copilot CLI](https://github.com/github/copilot-cli)   | audit-only             | local session and configuration state                               |
 | <img width="48px" src="docs/client-zed.svg" alt="Zed" />                    | [Zed](https://zed.dev/docs/ai/overview)                       | audit-only             | local agent state                                                   |
@@ -66,14 +66,15 @@ logical memory records.
 
 ## cleanup surfaces
 
-| Icon                                                                 | Surface                              | Mode               | What it understands                                                     |
-| -------------------------------------------------------------------- | ------------------------------------ | ------------------ | ----------------------------------------------------------------------- |
-| 🌿                                                                   | Git worktrees                        | audit + quarantine | linked worktrees, refs, dirtiness, locks, processes, and provider roots |
-| 🧹                                                                   | Build artifacts                      | safe-clean         | exact configured rebuildable directories                                |
-| 🗜️                                                                   | Codex SQLite state                   | experimental       | schema versions, free pages, sidecars, owner processes, and rollback    |
-| ⚡                                                                   | Agent runtimes                       | audit-only, opt-in | installed agent executables and versions                                |
-| <img width="48px" src="docs/client-docker-agent.svg" alt="Docker" /> | [Docker](https://docs.docker.com/)   | audit-only, opt-in | images and containers                                                   |
-| 🕳️                                                                   | [Mole](https://github.com/tw93/Mole) | suggestions only   | external dry-run cleanup opportunities on macOS                         |
+| Icon                                                                 | Surface                              | Mode               | What it understands                                                      |
+| -------------------------------------------------------------------- | ------------------------------------ | ------------------ | ------------------------------------------------------------------------ |
+| 🌿                                                                   | Git worktrees                        | audit + quarantine | linked worktrees, refs, dirtiness, locks, processes, and provider roots  |
+| 🧹                                                                   | Build artifacts                      | safe-clean         | exact configured rebuildable directories                                 |
+| 🗜️                                                                   | Codex SQLite state                   | experimental       | schema versions, free pages, sidecars, owner processes, and rollback     |
+| <img width="48px" src="docs/client-claude.jpg" alt="Claude Code" />  | Claude debug logs                    | recoverable        | direct old text logs, exact identity, provider liveness, undo, and purge |
+| ⚡                                                                   | Agent runtimes                       | audit-only, opt-in | installed agent executables and versions                                 |
+| <img width="48px" src="docs/client-docker-agent.svg" alt="Docker" /> | [Docker](https://docs.docker.com/)   | audit-only, opt-in | images and containers                                                    |
+| 🕳️                                                                   | [Mole](https://github.com/tw93/Mole) | suggestions only   | external dry-run cleanup opportunities on macOS                          |
 
 ## install
 

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -1,14 +1,14 @@
 # Adapter Matrix
 
-Provider and Docker adapters are read-only except for one versioned Codex
-maintenance action. Artifact cleanup is scoped to explicitly configured
-rebuildable directories. The Git adapter can emit one recoverable
-whole-worktree action when every safety gate is proven.
+Provider and Docker adapters are read-only except for versioned Codex database
+maintenance and exact Claude debug-log quarantine. Artifact cleanup is scoped
+to explicitly configured rebuildable directories. The Git adapter can emit one
+recoverable whole-worktree action when every safety gate is proven.
 
 | Adapter        | Current capability                                        | Protected state |
 | -------------- | --------------------------------------------------------- | --------------- |
 | Codex          | sessions, worktrees, four SQLite DBs, offline compaction  | conditional     |
-| Claude         | project sessions, debug logs, managed worktrees           | all             |
+| Claude         | sessions, worktrees, recoverable old debug-log quarantine | conditional     |
 | Cursor         | workspace state, global state, logs                       | all             |
 | GitHub Copilot | CLI sessions and logs                                     | all             |
 | Zed            | user-data root                                            | all             |
@@ -53,7 +53,15 @@ descriptors.
 
 ### Claude
 
-Native retention and orphaned-worktree behavior stays provider-owned.
+Transcripts, prompt history, checkpoint files, task state, settings,
+credentials, plugins, caches, and native orphaned-worktree cleanup stay
+provider-owned.
+
+Direct regular files matching `debug/*.txt` may produce
+`provider.file-quarantine` after 30 days. The action is `recoverable`, excluded
+by the default `safe` ceiling, retains the exact file for seven days, and
+requires Claude to be stopped with no open descriptor. JSONL and nested paths
+never match this policy.
 
 ### Cursor
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,12 +98,13 @@ protects the unresolved scope instead of allowing an artifact action.
 ## Provider Adapters
 
 Codex, Claude Code, Cursor, GitHub Copilot CLI, Zed, OpenCode, and Grok Build
-are enabled for read-only inventory by default. Each accepts an optional
-`root`. Claude resolves its root from the explicit adapter `root`, then an
-absolute `$CLAUDE_CONFIG_DIR`, then `$HOME/.claude`. A relative
-`$CLAUDE_CONFIG_DIR` degrades the Claude adapter rather than auditing the wrong
-directory. The same resolution is repeated before any provider-file action is
-authorized. Missing default roots mean the provider is absent, not broken.
+are enabled for inventory by default. Each accepts an optional `root`. Claude
+resolves its root from the explicit adapter `root`, then an absolute
+`$CLAUDE_CONFIG_DIR`, then `$HOME/.claude`. A relative `$CLAUDE_CONFIG_DIR`
+degrades the Claude adapter rather than auditing the wrong directory. The same
+resolution is repeated before any provider-file action is authorized. Claude
+debug-log quarantine requires `plan --max-risk recoverable` and matching apply
+authorization. Missing default roots mean the provider is absent, not broken.
 Codex can propose offline database maintenance only with
 `audit --allow-offline-vacuum`; the flag is intentionally not persisted in
 configuration. A

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -1883,6 +1883,7 @@ AgentRinse owns:
 - Claude session-to-worktree roots
 - Git safety analysis
 - artifact trimming
+- recoverable quarantine for exact old Claude debug logs
 - explanation of native retention behavior
 
 ### Discovery
@@ -1895,6 +1896,7 @@ Detect:
 - user-created `--worktree` locations when discoverable
 - live Claude processes
 - configured `cleanupPeriodDays`
+- direct regular `debug/*.txt` files old enough for the AgentRinse policy
 
 ### Session handling
 
@@ -1909,6 +1911,19 @@ AgentRinse must distinguish:
 - unknown metadata due to unsupported formats
 
 Provider settings parsing failures protect affected resources.
+
+### Debug log handling
+
+Direct regular files matching `debug/*.txt` are the only Claude-owned mutation
+surface in this phase. A file must be at least 30 days old and completely
+identified before it can emit `provider.file-quarantine`. The action is
+`recoverable`, retains the file for seven days, and revalidates the configured
+Claude root, exact content identity, stopped provider processes, and open
+descriptors before its atomic move.
+
+Directories, nested debug paths, JSONL, transcripts, prompt history,
+checkpoint state, tasks, settings, credentials, plugins, and caches do not
+match this policy.
 
 ### Native cleanup interaction
 
@@ -3549,6 +3564,7 @@ decision-log entry. They must not be smuggled in as adapter fixes.
 - [x] worktree undo
 - [x] offline Codex database compaction
 - [x] exact provider-file quarantine, undo, purge, and recovery foundation
+- [x] recoverable Claude debug-log quarantine
 
 ### Documentation and release
 

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -73,6 +73,11 @@ Directories, sessions, transcripts, databases, credentials, configuration,
 plugins, and caches without an explicit file-level owner contract are not
 accepted.
 
+The first registered owner contract is Claude `debug/*.txt`: one direct
+regular file, at least 30 days old, retained in quarantine for seven days.
+JSONL, nested paths, recent files, incomplete directory enumeration, active
+Claude processes, and open descriptors remain protected.
+
 ## Recoverable Codex Database Boundary
 
 `database.vacuum` is `experimental` and excluded by every lower risk ceiling.

--- a/src/adapters/claude-debug.ts
+++ b/src/adapters/claude-debug.ts
@@ -1,0 +1,118 @@
+import type { Dirent } from "node:fs";
+import { lstat, readdir } from "node:fs/promises";
+import { basename, join } from "node:path";
+
+import type { AuditContext, CollectionResult } from "../contracts/adapter.js";
+import type { ResourceSnapshot } from "../contracts/resource.js";
+import { sha256 } from "../core/digest.js";
+import { inspectProviderFile } from "../core/provider-file-identity.js";
+import {
+  CLAUDE_DEBUG_LOG_MIN_AGE_MINUTES,
+  CLAUDE_DEBUG_LOG_POLICY_ID,
+  isClaudeDebugLogRelativePath,
+} from "../core/provider-file-policy.js";
+
+function isMissing(error: unknown): boolean {
+  return (
+    error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}
+
+export async function collectClaudeDebugLogs(
+  context: AuditContext,
+  ownerRoot: string,
+  maxEntries: number,
+): Promise<CollectionResult> {
+  const debugRoot = join(ownerRoot, "debug");
+  const diagnostics: CollectionResult["diagnostics"] = [];
+  let entries: Dirent<string>[];
+
+  try {
+    const rootStats = await lstat(debugRoot);
+    if (rootStats.isSymbolicLink() || !rootStats.isDirectory()) {
+      return { resources: [], diagnostics };
+    }
+    entries = await readdir(debugRoot, { withFileTypes: true });
+  } catch (error) {
+    if (isMissing(error)) {
+      return { resources: [], diagnostics };
+    }
+    return {
+      resources: [],
+      diagnostics: [
+        {
+          severity: "warning",
+          code: "CLAUDE_DEBUG_ENUMERATION_FAILED",
+          message: error instanceof Error ? error.message : String(error),
+          adapter: "claude",
+        },
+      ],
+    };
+  }
+
+  if (entries.length > maxEntries) {
+    return {
+      resources: [],
+      diagnostics: [
+        {
+          severity: "warning",
+          code: "CLAUDE_DEBUG_ENUMERATION_TRUNCATED",
+          message: `Claude debug cleanup requires at most ${maxEntries} direct entries`,
+          adapter: "claude",
+        },
+      ],
+    };
+  }
+
+  const cutoffMs = context.now.getTime() - CLAUDE_DEBUG_LOG_MIN_AGE_MINUTES * 60_000;
+  const resources: ResourceSnapshot[] = [];
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    context.signal?.throwIfAborted();
+    const path = join(debugRoot, entry.name);
+    const relativePath = join("debug", entry.name);
+    if (!isClaudeDebugLogRelativePath(relativePath)) {
+      continue;
+    }
+
+    try {
+      const stats = await lstat(path);
+      if (!stats.isFile() || stats.isSymbolicLink() || stats.mtimeMs > cutoffMs) {
+        continue;
+      }
+      const identity = await inspectProviderFile(path, ownerRoot, "claude");
+      const canonicalKey = `claude:debug-log:${identity.path}`;
+      resources.push({
+        resource: {
+          id: `claude:agent-log-store:${sha256(canonicalKey)}`,
+          adapter: "claude",
+          kind: "agent-log-store",
+          canonicalKey,
+          displayName: `Claude debug log ${basename(identity.path)}`,
+          path: identity.path,
+        },
+        observedAt: context.now.toISOString(),
+        exists: true,
+        measuredBytes: identity.measuredBytes,
+        facts: {
+          reportOnly: false,
+          maintenanceAction: "provider.file-quarantine",
+          policyId: CLAUDE_DEBUG_LOG_POLICY_ID,
+          minAgeMinutes: CLAUDE_DEBUG_LOG_MIN_AGE_MINUTES,
+          providerFileIdentity: identity,
+        },
+      });
+    } catch (error) {
+      if (isMissing(error)) {
+        continue;
+      }
+      diagnostics.push({
+        severity: "warning",
+        code: "CLAUDE_DEBUG_FILE_INSPECTION_FAILED",
+        message: error instanceof Error ? error.message : String(error),
+        adapter: "claude",
+      });
+    }
+  }
+
+  return { resources, diagnostics };
+}

--- a/src/adapters/provider-adapter.ts
+++ b/src/adapters/provider-adapter.ts
@@ -6,9 +6,20 @@ import type { Diagnostic } from "../contracts/diagnostic.js";
 import type { Finding } from "../contracts/finding.js";
 import type { AdapterProbe } from "../contracts/report.js";
 import type { ResourceSnapshot } from "../contracts/resource.js";
-import { databaseIdentitySchema, type DatabaseVacuumAction } from "../contracts/action.js";
+import {
+  databaseIdentitySchema,
+  providerFileIdentitySchema,
+  type DatabaseVacuumAction,
+  type ProviderFileQuarantineAction,
+} from "../contracts/action.js";
 import { sha256 } from "../core/digest.js";
 import { measurePath } from "../core/measure.js";
+import {
+  CLAUDE_DEBUG_LOG_MIN_AGE_MINUTES,
+  CLAUDE_DEBUG_LOG_POLICY_ID,
+  CLAUDE_DEBUG_LOG_QUARANTINE_TTL_MINUTES,
+  isClaudeDebugLogRelativePath,
+} from "../core/provider-file-policy.js";
 import type { ReachabilityIndex } from "../core/reachability.js";
 import {
   codexDatabaseContractMatches,
@@ -18,9 +29,15 @@ import {
   type CodexDatabaseDependencies,
   type CodexDatabaseInspection,
 } from "./codex-database.js";
+import { collectClaudeDebugLogs } from "./claude-debug.js";
 import { collectProviderReachability } from "./provider-reachability.js";
 import { resolveProviderRoot } from "./provider-root.js";
 import type { ProviderSpec } from "./provider-specs.js";
+
+type ClaudeProviderFileQuarantineAction = Extract<
+  ProviderFileQuarantineAction,
+  { adapter: "claude" }
+>;
 
 export type ProviderAdapterOptions = {
   root?: string;
@@ -283,11 +300,86 @@ export class ProviderAuditAdapter implements AuditAdapter {
       }
     }
 
+    if (this.spec.id === "claude") {
+      const debugLogs = await collectClaudeDebugLogs(context, probe.root, this.options.maxEntries);
+      resources.push(...debugLogs.resources);
+      diagnostics.push(...debugLogs.diagnostics);
+    }
+
     return { resources, diagnostics };
   }
 
   async classify(context: AuditContext, resource: ResourceSnapshot): Promise<Finding> {
     const observedAt = context.now.toISOString();
+    const providerFileIdentity = providerFileIdentitySchema.safeParse(
+      resource.facts.providerFileIdentity,
+    );
+    if (
+      this.spec.id === "claude" &&
+      providerFileIdentity.success &&
+      providerFileIdentity.data.provider === "claude" &&
+      resource.facts.policyId === CLAUDE_DEBUG_LOG_POLICY_ID &&
+      isClaudeDebugLogRelativePath(providerFileIdentity.data.relativePath)
+    ) {
+      const claudeIdentity = {
+        ...providerFileIdentity.data,
+        provider: "claude" as const,
+      };
+      const oldEnough =
+        context.now.getTime() - claudeIdentity.mtimeMs >= CLAUDE_DEBUG_LOG_MIN_AGE_MINUTES * 60_000;
+      const candidateActions: ClaudeProviderFileQuarantineAction[] = oldEnough
+        ? [
+            {
+              actionId: `provider.file-quarantine:${sha256(
+                `${CLAUDE_DEBUG_LOG_POLICY_ID}:${claudeIdentity.fingerprint}`,
+              )}`,
+              type: "provider.file-quarantine",
+              adapter: "claude",
+              resourceId: resource.resource.id,
+              policyId: CLAUDE_DEBUG_LOG_POLICY_ID,
+              risk: "recoverable",
+              description: "Quarantine a Claude debug log older than 30 days",
+              expectedReclaimBytes: 0,
+              pendingQuarantineBytes: claudeIdentity.measuredBytes,
+              quarantineTtlMinutes: CLAUDE_DEBUG_LOG_QUARANTINE_TTL_MINUTES,
+              target: claudeIdentity,
+            },
+          ]
+        : [];
+      return {
+        schemaVersion: 1,
+        findingId: `${resource.resource.id}:${sha256(context.auditId)}`,
+        auditId: context.auditId,
+        observedAt,
+        resource: resource.resource,
+        state: oldEnough ? "eligible" : "protected",
+        confidence: "certain",
+        roots: [
+          {
+            code: "claude-debug-log-owner-contract",
+            source: this.id,
+            observedAt,
+            detail:
+              "Claude documents direct debug logs as disposable application data with no user-facing loss.",
+          },
+          ...(oldEnough
+            ? []
+            : [
+                {
+                  code: "provider-file-too-recent",
+                  source: this.id,
+                  observedAt,
+                  detail: "The debug log is newer than the 30-day cleanup threshold.",
+                },
+              ]),
+        ],
+        facts: resource.facts,
+        candidateActions,
+        measuredBytes: claudeIdentity.measuredBytes,
+        estimatedReclaimBytes: 0,
+        warnings: [],
+      };
+    }
     const databaseIdentity = databaseIdentitySchema.safeParse(resource.facts.databaseIdentity);
     if (this.spec.id === "codex" && databaseIdentity.success) {
       const estimatedReclaimBytes =

--- a/src/core/apply.ts
+++ b/src/core/apply.ts
@@ -195,7 +195,7 @@ export async function applyCleanupPlan(options: ApplyCleanupPlanOptions): Promis
               : await options.dependencies.revalidateWorktree(action, plan.home, config)
             : action.type === "provider.file-quarantine"
               ? options.dependencies?.revalidateProviderFile === undefined
-                ? await revalidateProviderFileQuarantine(action, plan.home, config)
+                ? await revalidateProviderFileQuarantine(action, plan.home, config, { clock })
                 : await options.dependencies.revalidateProviderFile(action)
               : options.dependencies?.revalidateDatabase === undefined
                 ? await revalidateDatabaseVacuum(action, plan.home, config)
@@ -406,7 +406,14 @@ export async function applyCleanupPlan(options: ApplyCleanupPlanOptions): Promis
             dependencies: {
               clock,
               authorizeTarget: (selectedAction) =>
-                authorizeProviderFileAction(selectedAction, plan.home, config),
+                authorizeProviderFileAction(
+                  selectedAction,
+                  plan.home,
+                  config,
+                  process.platform,
+                  process.env,
+                  clock(),
+                ),
               authorization: {
                 expiresAtMs: Date.parse(plan.expiresAt),
                 now: clock,

--- a/src/core/provider-file-policy.ts
+++ b/src/core/provider-file-policy.ts
@@ -10,6 +10,7 @@ export type ProviderFilePolicy = {
   id: string;
   provider: ProviderMutationId;
   matchesRelativePath(relativePath: string): boolean;
+  validateAction(action: ProviderFileQuarantineAction, now: Date): string | undefined;
 };
 
 export const CLAUDE_DEBUG_LOG_POLICY_ID = "claude.debug-log";
@@ -31,6 +32,18 @@ export const PROVIDER_FILE_POLICIES: readonly ProviderFilePolicy[] = [
     id: CLAUDE_DEBUG_LOG_POLICY_ID,
     provider: "claude",
     matchesRelativePath: isClaudeDebugLogRelativePath,
+    validateAction(action, now) {
+      if (action.pendingQuarantineBytes !== action.target.measuredBytes) {
+        return "pending quarantine bytes must match the exact file identity";
+      }
+      if (action.quarantineTtlMinutes < CLAUDE_DEBUG_LOG_QUARANTINE_TTL_MINUTES) {
+        return "Claude debug logs require at least seven days of recoverable quarantine";
+      }
+      if (now.getTime() - action.target.mtimeMs < CLAUDE_DEBUG_LOG_MIN_AGE_MINUTES * 60_000) {
+        return "Claude debug logs must be at least 30 days old";
+      }
+      return undefined;
+    },
   },
 ];
 
@@ -40,6 +53,7 @@ export async function authorizeProviderFileAction(
   config: AgentRinseConfig,
   platform: NodeJS.Platform = process.platform,
   environment: NodeJS.ProcessEnv = process.env,
+  now: Date = new Date(),
 ): Promise<void> {
   const explicitRoot = config.adapters[action.adapter]?.root;
   const configuredRoot = resolveProviderRoot(PROVIDER_SPECS[action.adapter], resolve(home), {
@@ -57,6 +71,12 @@ export async function authorizeProviderFileAction(
   if (policy === undefined || !policy.matchesRelativePath(action.target.relativePath)) {
     throw new Error(
       `provider-file target is not approved by policy ${action.adapter}:${action.policyId}`,
+    );
+  }
+  const refusal = policy.validateAction(action, now);
+  if (refusal !== undefined) {
+    throw new Error(
+      `provider-file action violates policy ${action.adapter}:${action.policyId}: ${refusal}`,
     );
   }
 }

--- a/src/core/provider-file-policy.ts
+++ b/src/core/provider-file-policy.ts
@@ -12,9 +12,27 @@ export type ProviderFilePolicy = {
   matchesRelativePath(relativePath: string): boolean;
 };
 
-// Provider PRs add narrowly documented file contracts here. An empty registry
-// deliberately makes the shared executor unusable on its own.
-export const PROVIDER_FILE_POLICIES: readonly ProviderFilePolicy[] = [];
+export const CLAUDE_DEBUG_LOG_POLICY_ID = "claude.debug-log";
+export const CLAUDE_DEBUG_LOG_MIN_AGE_MINUTES = 30 * 24 * 60;
+export const CLAUDE_DEBUG_LOG_QUARANTINE_TTL_MINUTES = 7 * 24 * 60;
+
+export function isClaudeDebugLogRelativePath(relativePath: string): boolean {
+  const components = relativePath.split(/[\\/]/u);
+  return (
+    components.length === 2 &&
+    components[0] === "debug" &&
+    components[1] !== undefined &&
+    components[1].endsWith(".txt")
+  );
+}
+
+export const PROVIDER_FILE_POLICIES: readonly ProviderFilePolicy[] = [
+  {
+    id: CLAUDE_DEBUG_LOG_POLICY_ID,
+    provider: "claude",
+    matchesRelativePath: isClaudeDebugLogRelativePath,
+  },
+];
 
 export async function authorizeProviderFileAction(
   action: ProviderFileQuarantineAction,

--- a/src/core/provider-file-revalidation.ts
+++ b/src/core/provider-file-revalidation.ts
@@ -11,6 +11,7 @@ export type ProviderFileRevalidationResult =
   | { status: "stale"; diagnostic: Diagnostic };
 
 export type ProviderFileRevalidationDependencies = {
+  clock?: () => Date;
   authorizeTarget?: (action: ProviderFileQuarantineAction) => Promise<void>;
   allowedHandlePids?: ReadonlySet<number>;
   inspectProcesses?: (
@@ -47,7 +48,14 @@ export async function revalidateProviderFileQuarantine(
       dependencies.authorizeTarget ??
       (home !== undefined && config !== undefined
         ? (selectedAction: ProviderFileQuarantineAction) =>
-            authorizeProviderFileAction(selectedAction, home, config)
+            authorizeProviderFileAction(
+              selectedAction,
+              home,
+              config,
+              process.platform,
+              process.env,
+              (dependencies.clock ?? (() => new Date()))(),
+            )
         : undefined);
     if (authorizeTarget === undefined) {
       throw new Error("provider-file execution requires an approved provider policy");

--- a/test/adapters/claude-debug.test.ts
+++ b/test/adapters/claude-debug.test.ts
@@ -1,0 +1,133 @@
+import { mkdir, mkdtemp, realpath, symlink, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ProviderAuditAdapter } from "../../src/adapters/provider-adapter.js";
+import { PROVIDER_SPECS } from "../../src/adapters/provider-specs.js";
+import type { AuditContext } from "../../src/contracts/adapter.js";
+import {
+  CLAUDE_DEBUG_LOG_POLICY_ID,
+  isClaudeDebugLogRelativePath,
+} from "../../src/core/provider-file-policy.js";
+
+const NOW = new Date("2026-07-25T00:00:00.000Z");
+
+async function fixtureContext(): Promise<AuditContext> {
+  return {
+    home: await mkdtemp(join(tmpdir(), "agentrinse-claude-debug-")),
+    now: NOW,
+    auditId: "audit-claude-debug",
+  };
+}
+
+async function writeDatedFile(path: string, value: string, date: Date): Promise<void> {
+  await writeFile(path, value);
+  await utimes(path, date, date);
+}
+
+describe("Claude debug cleanup", () => {
+  it("proposes recoverable quarantine only for direct old debug text files", async () => {
+    const context = await fixtureContext();
+    const root = join(context.home, ".claude");
+    const debug = join(root, "debug");
+    await mkdir(debug, { recursive: true });
+    await writeDatedFile(
+      join(debug, "old-session.txt"),
+      "synthetic old debug output\n",
+      new Date("2026-06-01T00:00:00.000Z"),
+    );
+    await writeDatedFile(
+      join(debug, "recent-session.txt"),
+      "synthetic recent debug output\n",
+      new Date("2026-07-20T00:00:00.000Z"),
+    );
+    await writeDatedFile(
+      join(debug, "transcript.jsonl"),
+      '{"synthetic":"transcript"}\n',
+      new Date("2026-06-01T00:00:00.000Z"),
+    );
+    const adapter = new ProviderAuditAdapter(PROVIDER_SPECS.claude, {
+      environment: {},
+      measureBytes: true,
+      maxEntries: 100,
+    });
+
+    const probe = await adapter.probe(context);
+    const collection = await adapter.collect(context, probe);
+    const exactLogs = collection.resources.filter(
+      (resource) => resource.facts.policyId === CLAUDE_DEBUG_LOG_POLICY_ID,
+    );
+    const finding = await adapter.classify(context, exactLogs[0]!);
+
+    expect(exactLogs).toHaveLength(1);
+    expect(exactLogs[0]?.resource.path).toBe(await realpath(join(debug, "old-session.txt")));
+    expect(finding).toMatchObject({
+      state: "eligible",
+      confidence: "certain",
+      candidateActions: [
+        {
+          type: "provider.file-quarantine",
+          adapter: "claude",
+          policyId: CLAUDE_DEBUG_LOG_POLICY_ID,
+          risk: "recoverable",
+          expectedReclaimBytes: 0,
+          quarantineTtlMinutes: 7 * 24 * 60,
+        },
+      ],
+    });
+  });
+
+  it("fails closed when the debug directory exceeds the entry budget", async () => {
+    const context = await fixtureContext();
+    const debug = join(context.home, ".claude", "debug");
+    await mkdir(debug, { recursive: true });
+    await writeFile(join(debug, "one.txt"), "one");
+    await writeFile(join(debug, "two.txt"), "two");
+    const adapter = new ProviderAuditAdapter(PROVIDER_SPECS.claude, {
+      environment: {},
+      measureBytes: false,
+      maxEntries: 1,
+    });
+
+    const probe = await adapter.probe(context);
+    const collection = await adapter.collect(context, probe);
+
+    expect(collection.resources.some((resource) => resource.facts.policyId !== undefined)).toBe(
+      false,
+    );
+    expect(collection.diagnostics).toContainEqual(
+      expect.objectContaining({ code: "CLAUDE_DEBUG_ENUMERATION_TRUNCATED" }),
+    );
+  });
+
+  it("does not follow a symlinked debug directory", async () => {
+    const context = await fixtureContext();
+    const root = join(context.home, ".claude");
+    const target = await mkdtemp(join(tmpdir(), "agentrinse-claude-debug-target-"));
+    await mkdir(root);
+    await writeFile(join(target, "old-session.txt"), "outside");
+    await symlink(target, join(root, "debug"));
+    const adapter = new ProviderAuditAdapter(PROVIDER_SPECS.claude, {
+      environment: {},
+      measureBytes: false,
+      maxEntries: 100,
+    });
+
+    const probe = await adapter.probe(context);
+    const collection = await adapter.collect(context, probe);
+
+    expect(collection.resources.some((resource) => resource.facts.policyId !== undefined)).toBe(
+      false,
+    );
+  });
+
+  it("matches only one direct Claude debug text file", () => {
+    expect(isClaudeDebugLogRelativePath("debug/session.txt")).toBe(true);
+    expect(isClaudeDebugLogRelativePath("debug\\session.txt")).toBe(true);
+    expect(isClaudeDebugLogRelativePath("debug/session.jsonl")).toBe(false);
+    expect(isClaudeDebugLogRelativePath("debug/nested/session.txt")).toBe(false);
+    expect(isClaudeDebugLogRelativePath("projects/session.txt")).toBe(false);
+  });
+});

--- a/test/core/provider-file-policy.test.ts
+++ b/test/core/provider-file-policy.test.ts
@@ -1,0 +1,67 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_CONFIG } from "../../src/config/defaults.js";
+import type { ProviderFileQuarantineAction } from "../../src/contracts/action.js";
+import { inspectProviderFile } from "../../src/core/provider-file-identity.js";
+import {
+  authorizeProviderFileAction,
+  CLAUDE_DEBUG_LOG_POLICY_ID,
+} from "../../src/core/provider-file-policy.js";
+
+async function actionFor(
+  ownerRoot: string,
+  relativePath: string,
+): Promise<Extract<ProviderFileQuarantineAction, { adapter: "claude" }>> {
+  const path = join(ownerRoot, relativePath);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, "synthetic provider data\n");
+  const target = await inspectProviderFile(path, ownerRoot, "claude");
+  return {
+    actionId: "provider.file-quarantine:policy-test",
+    type: "provider.file-quarantine",
+    adapter: "claude",
+    resourceId: "claude:agent-log-store:policy-test",
+    policyId: CLAUDE_DEBUG_LOG_POLICY_ID,
+    risk: "recoverable",
+    description: "quarantine a synthetic Claude debug log",
+    expectedReclaimBytes: 0,
+    pendingQuarantineBytes: target.measuredBytes,
+    quarantineTtlMinutes: 60,
+    target,
+  };
+}
+
+describe("provider file policy", () => {
+  it("authorizes an exact Claude debug text file under CLAUDE_CONFIG_DIR", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-policy-home-"));
+    const ownerRoot = join(home, "claude-data");
+    const action = await actionFor(ownerRoot, "debug/session.txt");
+
+    await expect(
+      authorizeProviderFileAction(action, home, DEFAULT_CONFIG, "darwin", {
+        CLAUDE_CONFIG_DIR: ownerRoot,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it.each(["debug/session.jsonl", "debug/nested/session.txt", "projects/session.txt"])(
+    "rejects the non-policy path %s",
+    async (relativePath) => {
+      const home = await mkdtemp(join(tmpdir(), "agentrinse-policy-home-"));
+      const ownerRoot = join(home, "claude-data");
+      const action = await actionFor(ownerRoot, relativePath);
+
+      await expect(
+        authorizeProviderFileAction(action, home, DEFAULT_CONFIG, "darwin", {
+          CLAUDE_CONFIG_DIR: ownerRoot,
+        }),
+      ).rejects.toThrow(
+        `provider-file target is not approved by policy claude:${CLAUDE_DEBUG_LOG_POLICY_ID}`,
+      );
+    },
+  );
+});

--- a/test/core/provider-file-policy.test.ts
+++ b/test/core/provider-file-policy.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -15,10 +15,12 @@ import {
 async function actionFor(
   ownerRoot: string,
   relativePath: string,
+  mtime = new Date("2026-06-01T00:00:00.000Z"),
 ): Promise<Extract<ProviderFileQuarantineAction, { adapter: "claude" }>> {
   const path = join(ownerRoot, relativePath);
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, "synthetic provider data\n");
+  await utimes(path, mtime, mtime);
   const target = await inspectProviderFile(path, ownerRoot, "claude");
   return {
     actionId: "provider.file-quarantine:policy-test",
@@ -30,7 +32,7 @@ async function actionFor(
     description: "quarantine a synthetic Claude debug log",
     expectedReclaimBytes: 0,
     pendingQuarantineBytes: target.measuredBytes,
-    quarantineTtlMinutes: 60,
+    quarantineTtlMinutes: 7 * 24 * 60,
     target,
   };
 }
@@ -42,9 +44,16 @@ describe("provider file policy", () => {
     const action = await actionFor(ownerRoot, "debug/session.txt");
 
     await expect(
-      authorizeProviderFileAction(action, home, DEFAULT_CONFIG, "darwin", {
-        CLAUDE_CONFIG_DIR: ownerRoot,
-      }),
+      authorizeProviderFileAction(
+        action,
+        home,
+        DEFAULT_CONFIG,
+        "darwin",
+        {
+          CLAUDE_CONFIG_DIR: ownerRoot,
+        },
+        new Date("2026-07-25T00:00:00.000Z"),
+      ),
     ).resolves.toBeUndefined();
   });
 
@@ -56,12 +65,57 @@ describe("provider file policy", () => {
       const action = await actionFor(ownerRoot, relativePath);
 
       await expect(
-        authorizeProviderFileAction(action, home, DEFAULT_CONFIG, "darwin", {
-          CLAUDE_CONFIG_DIR: ownerRoot,
-        }),
+        authorizeProviderFileAction(
+          action,
+          home,
+          DEFAULT_CONFIG,
+          "darwin",
+          {
+            CLAUDE_CONFIG_DIR: ownerRoot,
+          },
+          new Date("2026-07-25T00:00:00.000Z"),
+        ),
       ).rejects.toThrow(
         `provider-file target is not approved by policy claude:${CLAUDE_DEBUG_LOG_POLICY_ID}`,
       );
     },
   );
+
+  it("rejects recent logs and shortened recovery windows at authorization", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-policy-home-"));
+    const ownerRoot = join(home, "claude-data");
+    const recent = await actionFor(
+      ownerRoot,
+      "debug/recent.txt",
+      new Date("2026-07-20T00:00:00.000Z"),
+    );
+
+    await expect(
+      authorizeProviderFileAction(
+        recent,
+        home,
+        DEFAULT_CONFIG,
+        "darwin",
+        {
+          CLAUDE_CONFIG_DIR: ownerRoot,
+        },
+        new Date("2026-07-25T00:00:00.000Z"),
+      ),
+    ).rejects.toThrow("Claude debug logs must be at least 30 days old");
+
+    const old = await actionFor(ownerRoot, "debug/old.txt");
+    old.quarantineTtlMinutes = 60;
+    await expect(
+      authorizeProviderFileAction(
+        old,
+        home,
+        DEFAULT_CONFIG,
+        "darwin",
+        {
+          CLAUDE_CONFIG_DIR: ownerRoot,
+        },
+        new Date("2026-07-25T00:00:00.000Z"),
+      ),
+    ).rejects.toThrow("at least seven days");
+  });
 });


### PR DESCRIPTION
## Summary

- inventory direct Claude `debug/*.txt` files as exact provider-owned resources
- propose recoverable quarantine only after 30 days
- retain quarantined logs for at least seven days before purge
- keep transcripts, JSONL, nested paths, caches, settings, credentials, and plugins protected

Part of #16.

## Safety boundary

- resource owner: Claude Code
- evidence: Claude documents `debug/` as per-session debug logs and states deleting debug data has no user-facing loss
- protection roots: explicit Claude root / `CLAUDE_CONFIG_DIR` / `$HOME/.claude`, plus exact direct-file policy
- risk class: `recoverable`; excluded by the default `safe` ceiling
- revalidation: root, relative path, 30-day age, exact bytes, seven-day minimum TTL, full identity, Claude liveness, and open descriptors
- recovery: existing provider-file undo, purge, journal, and crash reconciliation

## Verification

- full format, lint, and TypeScript checks
- `./node_modules/.bin/vitest run` (59 files, 421 tests)
- schema, manifest, publint, and package dry-run gate
- autoreview cycle 1: found apply-time age/TTL gap; fixed
- autoreview cycle 2: clean, no accepted/actionable findings