### PR TITLE
feat(contract): add agent cache resource kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The project follows semantic versioning after its first supported release.
 
 ### Added
 
+- `agent-cache` resource identity for provider-owned disposable cache artifacts
 - recoverable `provider.file-quarantine` execution, undo, purge, run-journal,
   manifest, and JSON Schema contracts for exact provider-owned regular files
 - streamed content identity, provider-process and descriptor refusal,

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -760,15 +760,18 @@ Resource IDs must be deterministic across unchanged audits.
 export type ResourceKind =
   | "git-worktree"
   | "build-artifact"
-  | "agent-session"
+  | "agent-home"
+  | "agent-session-store"
   | "agent-log-store"
+  | "agent-cache"
+  | "agent-database"
+  | "agent-snapshot-store"
   | "agent-runtime"
   | "docker-container"
   | "docker-image"
   | "docker-network"
   | "docker-volume"
-  | "docker-build-cache"
-  | "external-cleaner";
+  | "docker-build-cache";
 
 export type ResourceRef = {
   id: string;

--- a/schemas/audit.schema.json
+++ b/schemas/audit.schema.json
@@ -127,6 +127,7 @@
                   "agent-home",
                   "agent-session-store",
                   "agent-log-store",
+                  "agent-cache",
                   "agent-database",
                   "agent-snapshot-store",
                   "agent-runtime",

--- a/src/contracts/resource.ts
+++ b/src/contracts/resource.ts
@@ -6,6 +6,7 @@ export const resourceKindSchema = z.enum([
   "agent-home",
   "agent-session-store",
   "agent-log-store",
+  "agent-cache",
   "agent-database",
   "agent-snapshot-store",
   "agent-runtime",

--- a/test/contracts/finding.test.ts
+++ b/test/contracts/finding.test.ts
@@ -41,4 +41,27 @@ describe("findingSchema", () => {
 
     expect(schema.properties.findings.items.required).not.toContain("candidateActions");
   });
+
+  it("accepts provider-owned cache resources", () => {
+    const finding = findingSchema.parse({
+      schemaVersion: 1,
+      findingId: "finding-cache-1",
+      auditId: "audit-1",
+      observedAt: "2026-07-27T00:00:00.000Z",
+      resource: {
+        id: "resource-cache-1",
+        adapter: "claude",
+        kind: "agent-cache",
+        canonicalKey: "claude:cache:changelog",
+        displayName: "Claude changelog cache",
+      },
+      state: "protected",
+      confidence: "certain",
+      roots: [],
+      facts: {},
+      warnings: [],
+    });
+
+    expect(finding.resource.kind).toBe("agent-cache");
+  });
 });


### PR DESCRIPTION
## Summary

- add `agent-cache` to the canonical resource identity contract
- publish the kind in the audit JSON Schema
- align the product specification with the executable resource-kind union

## Safety boundary

This PR adds identity only. It does not discover, plan, mutate, quarantine, or purge any provider cache. Provider-specific owner contracts and apply-time revalidation remain required before a cache can become actionable.

## Contract evidence

- owner: provider-specific adapters
- protection roots: unchanged; no filesystem paths are added
- risk class: none; no action is emitted
- revalidation: unchanged; future provider policies must authorize exact paths
- recovery: unchanged; future mutations use recoverable provider-file quarantine

## Verification

- 59 test files / 422 tests passed
- format, lint, and TypeScript checks passed
- all 9 generated JSON Schemas verified
- package manifest, publint, and `npm pack --dry-run` passed
- autoreview: clean

Part of #16.