### PR TITLE
feat(claude): quarantine stale changelog cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The project follows semantic versioning after its first supported release.
   command lines, with fail-closed incomplete process evidence
 - recoverable quarantine for direct Claude `debug/*.txt` files older than 30
   days, with a seven-day undo window before purge
+- recoverable quarantine for the exact Claude `cache/changelog.md` file after
+  30 days, without matching neighboring or undocumented cache files
 
 ### Fixed
 
@@ -40,8 +42,9 @@ The project follows semantic versioning after its first supported release.
   path contract for disposable log or cache files
 - directories, symlinks, sessions, transcripts, databases, credentials,
   configuration, and ambiguous recovery state remain outside this boundary
-- Claude cleanup excludes JSONL, nested paths, recent logs, active Claude
-  processes, open descriptors, and incomplete directory enumeration
+- Claude cleanup excludes JSONL, nested paths, recent files, undocumented
+  caches, active Claude processes, open descriptors, and incomplete directory
+  enumeration
 
 ## [0.4.0] - 2026-07-25
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ optional external handoff for broader macOS and project debris.
 
 Codex sessions and every other provider store remain report-only. `0.4.0`
 adds one narrow exception: explicit offline compaction for the exact current
-Codex `state_5`, `logs_2`, `goals_1`, and `memories_1` SQLite contracts.
-Docker remains audit-only.
+Codex `state_5`, `logs_2`, `goals_1`, and `memories_1` SQLite contracts. Claude
+cleanup is limited to exact old debug text files and its rebuildable changelog
+cache. Docker remains audit-only.
 
 ## agent integrations
 
@@ -54,27 +55,27 @@ provider state is report-only unless the table below says otherwise.
 agentrinse never erases transcripts, sessions, credentials, configuration, or
 logical memory records.
 
-| Logo                                                                        | Client                                                        | Mode                   | What it protects                                                    |
-| --------------------------------------------------------------------------- | ------------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------- |
-| <img width="48px" src="docs/client-openai.jpg" alt="OpenAI Codex" />        | [OpenAI Codex](https://github.com/openai/codex)               | audit + offline vacuum | sessions, workspace roots, reachability, and supported SQLite state |
-| <img width="48px" src="docs/client-claude.jpg" alt="Claude Code" />         | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | audit + log quarantine | sessions, workspace roots, reachability, and old debug logs         |
-| <img width="48px" src="docs/client-cursor.jpg" alt="Cursor" />              | [Cursor](https://cursor.com/docs)                             | audit-only             | local agent state and workspace references                          |
-| <img width="48px" src="docs/client-copilot.png" alt="GitHub Copilot CLI" /> | [GitHub Copilot CLI](https://github.com/github/copilot-cli)   | audit-only             | local session and configuration state                               |
-| <img width="48px" src="docs/client-zed.svg" alt="Zed" />                    | [Zed](https://zed.dev/docs/ai/overview)                       | audit-only             | local agent state                                                   |
-| <img width="48px" src="docs/client-opencode.png" alt="OpenCode" />          | [OpenCode](https://opencode.ai/)                              | audit-only             | local agent state                                                   |
-| <img width="48px" src="docs/client-grok-build.svg" alt="Grok Build" />      | [Grok Build](https://docs.x.ai/build/overview)                | audit-only             | local agent state                                                   |
+| Logo                                                                        | Client                                                      | Mode                    | What it protects                                                    |
+| --------------------------------------------------------------------------- | ----------------------------------------------------------- | ----------------------- | ------------------------------------------------------------------- |
+| <img width="48px" src="docs/client-openai.jpg" alt="OpenAI Codex" />        | [OpenAI Codex](https://github.com/openai/codex)             | audit + offline vacuum  | sessions, workspace roots, reachability, and supported SQLite state |
+| <img width="48px" src="docs/client-claude.jpg" alt="Claude Code" />         | [Claude Code](https://code.claude.com/docs/en/overview)     | audit + file quarantine | sessions, roots, reachability, old debug logs, and changelog cache  |
+| <img width="48px" src="docs/client-cursor.jpg" alt="Cursor" />              | [Cursor](https://cursor.com/docs)                           | audit-only              | local agent state and workspace references                          |
+| <img width="48px" src="docs/client-copilot.png" alt="GitHub Copilot CLI" /> | [GitHub Copilot CLI](https://github.com/github/copilot-cli) | audit-only              | local session and configuration state                               |
+| <img width="48px" src="docs/client-zed.svg" alt="Zed" />                    | [Zed](https://zed.dev/docs/ai/overview)                     | audit-only              | local agent state                                                   |
+| <img width="48px" src="docs/client-opencode.png" alt="OpenCode" />          | [OpenCode](https://opencode.ai/)                            | audit-only              | local agent state                                                   |
+| <img width="48px" src="docs/client-grok-build.svg" alt="Grok Build" />      | [Grok Build](https://docs.x.ai/build/overview)              | audit-only              | local agent state                                                   |
 
 ## cleanup surfaces
 
-| Icon                                                                 | Surface                              | Mode               | What it understands                                                      |
-| -------------------------------------------------------------------- | ------------------------------------ | ------------------ | ------------------------------------------------------------------------ |
-| 🌿                                                                   | Git worktrees                        | audit + quarantine | linked worktrees, refs, dirtiness, locks, processes, and provider roots  |
-| 🧹                                                                   | Build artifacts                      | safe-clean         | exact configured rebuildable directories                                 |
-| 🗜️                                                                   | Codex SQLite state                   | experimental       | schema versions, free pages, sidecars, owner processes, and rollback     |
-| <img width="48px" src="docs/client-claude.jpg" alt="Claude Code" />  | Claude debug logs                    | recoverable        | direct old text logs, exact identity, provider liveness, undo, and purge |
-| ⚡                                                                   | Agent runtimes                       | audit-only, opt-in | installed agent executables and versions                                 |
-| <img width="48px" src="docs/client-docker-agent.svg" alt="Docker" /> | [Docker](https://docs.docker.com/)   | audit-only, opt-in | images and containers                                                    |
-| 🕳️                                                                   | [Mole](https://github.com/tw93/Mole) | suggestions only   | external dry-run cleanup opportunities on macOS                          |
+| Icon                                                                 | Surface                              | Mode               | What it understands                                                     |
+| -------------------------------------------------------------------- | ------------------------------------ | ------------------ | ----------------------------------------------------------------------- |
+| 🌿                                                                   | Git worktrees                        | audit + quarantine | linked worktrees, refs, dirtiness, locks, processes, and provider roots |
+| 🧹                                                                   | Build artifacts                      | safe-clean         | exact configured rebuildable directories                                |
+| 🗜️                                                                   | Codex SQLite state                   | experimental       | schema versions, free pages, sidecars, owner processes, and rollback    |
+| <img width="48px" src="docs/client-claude.jpg" alt="Claude Code" />  | Claude logs and changelog cache      | recoverable        | exact old files, provider liveness, seven-day undo, and explicit purge  |
+| ⚡                                                                   | Agent runtimes                       | audit-only, opt-in | installed agent executables and versions                                |
+| <img width="48px" src="docs/client-docker-agent.svg" alt="Docker" /> | [Docker](https://docs.docker.com/)   | audit-only, opt-in | images and containers                                                   |
+| 🕳️                                                                   | [Mole](https://github.com/tw93/Mole) | suggestions only   | external dry-run cleanup opportunities on macOS                         |
 
 ## install
 

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -54,14 +54,21 @@ descriptors.
 ### Claude
 
 Transcripts, prompt history, checkpoint files, task state, settings,
-credentials, plugins, caches, and native orphaned-worktree cleanup stay
-provider-owned.
+credentials, plugins, undocumented caches, and native orphaned-worktree
+cleanup stay provider-owned.
 
 Direct regular files matching `debug/*.txt` may produce
 `provider.file-quarantine` after 30 days. The action is `recoverable`, excluded
 by the default `safe` ceiling, retains the exact file for seven days, and
 requires Claude to be stopped with no open descriptor. JSONL and nested paths
 never match this policy.
+
+The exact regular file `cache/changelog.md` may use the same recoverable
+quarantine boundary after 30 days. [Claude's application-data
+reference](https://code.claude.com/docs/en/claude-directory) documents it as a
+release-notes cache that is refreshed in the background. AgentRinse does not
+enumerate or mutate neighboring cache files, `paste-cache`, `image-cache`,
+`remote-settings.json`, or `policy-limits.json`.
 
 ### Cursor
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -1887,6 +1887,7 @@ AgentRinse owns:
 - Git safety analysis
 - artifact trimming
 - recoverable quarantine for exact old Claude debug logs
+- recoverable quarantine for the exact stale Claude changelog cache
 - explanation of native retention behavior
 
 ### Discovery
@@ -1900,6 +1901,8 @@ Detect:
 - live Claude processes
 - configured `cleanupPeriodDays`
 - direct regular `debug/*.txt` files old enough for the AgentRinse policy
+- the exact regular `cache/changelog.md` file when it exceeds the AgentRinse
+  age policy
 
 ### Session handling
 
@@ -1917,16 +1920,30 @@ Provider settings parsing failures protect affected resources.
 
 ### Debug log handling
 
-Direct regular files matching `debug/*.txt` are the only Claude-owned mutation
-surface in this phase. A file must be at least 30 days old and completely
-identified before it can emit `provider.file-quarantine`. The action is
-`recoverable`, retains the file for seven days, and revalidates the configured
-Claude root, exact content identity, stopped provider processes, and open
-descriptors before its atomic move.
+Direct regular files matching `debug/*.txt` are one Claude-owned mutation
+surface. A file must be at least 30 days old and completely identified before
+it can emit `provider.file-quarantine`. The action is `recoverable`, retains
+the file for seven days, and revalidates the configured Claude root, exact
+content identity, stopped provider processes, and open descriptors before its
+atomic move.
 
 Directories, nested debug paths, JSONL, transcripts, prompt history,
 checkpoint state, tasks, settings, credentials, plugins, and caches do not
-match this policy.
+match this debug-log policy.
+
+### Changelog cache handling
+
+The exact regular file `cache/changelog.md` may emit a separate
+`claude.changelog-cache` policy action after 30 days. [Claude's
+application-data
+reference](https://code.claude.com/docs/en/claude-directory) documents this
+release-notes cache as rebuildable and refreshed in the background. The action
+uses the same seven-day recoverable quarantine, configured-root, complete
+identity, stopped-provider, and open-descriptor checks as debug logs.
+
+No directory or wildcard cache policy exists. Neighboring cache files,
+`paste-cache`, `image-cache`, `remote-settings.json`, `policy-limits.json`,
+and undocumented cache paths remain protected.
 
 ### Native cleanup interaction
 
@@ -3568,6 +3585,7 @@ decision-log entry. They must not be smuggled in as adapter fixes.
 - [x] offline Codex database compaction
 - [x] exact provider-file quarantine, undo, purge, and recovery foundation
 - [x] recoverable Claude debug-log quarantine
+- [x] recoverable Claude changelog-cache quarantine
 
 ### Documentation and release
 

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -73,10 +73,15 @@ Directories, sessions, transcripts, databases, credentials, configuration,
 plugins, and caches without an explicit file-level owner contract are not
 accepted.
 
-The first registered owner contract is Claude `debug/*.txt`: one direct
-regular file, at least 30 days old, retained in quarantine for seven days.
-JSONL, nested paths, recent files, incomplete directory enumeration, active
-Claude processes, and open descriptors remain protected.
+The registered Claude owner contracts are:
+
+- `debug/*.txt`: one direct regular debug file
+- `cache/changelog.md`: the exact rebuildable changelog cache
+
+Both require a minimum age of 30 days and seven days of recoverable
+quarantine. JSONL, nested paths, neighboring or undocumented cache files,
+recent files, incomplete directory enumeration, active Claude processes, and
+open descriptors remain protected.
 
 ## Recoverable Codex Database Boundary
 

--- a/src/adapters/claude-cache.ts
+++ b/src/adapters/claude-cache.ts
@@ -1,0 +1,80 @@
+import { lstat } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { AuditContext, CollectionResult } from "../contracts/adapter.js";
+import { sha256 } from "../core/digest.js";
+import { inspectProviderFile } from "../core/provider-file-identity.js";
+import {
+  CLAUDE_CHANGELOG_CACHE_MIN_AGE_MINUTES,
+  CLAUDE_CHANGELOG_CACHE_POLICY_ID,
+} from "../core/provider-file-policy.js";
+
+function isMissing(error: unknown): boolean {
+  return (
+    error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}
+
+export async function collectClaudeChangelogCache(
+  context: AuditContext,
+  ownerRoot: string,
+): Promise<CollectionResult> {
+  const cacheRoot = join(ownerRoot, "cache");
+  const path = join(cacheRoot, "changelog.md");
+
+  try {
+    const cacheStats = await lstat(cacheRoot);
+    if (cacheStats.isSymbolicLink() || !cacheStats.isDirectory()) {
+      return { resources: [], diagnostics: [] };
+    }
+
+    const stats = await lstat(path);
+    const cutoffMs = context.now.getTime() - CLAUDE_CHANGELOG_CACHE_MIN_AGE_MINUTES * 60_000;
+    if (!stats.isFile() || stats.isSymbolicLink() || stats.mtimeMs > cutoffMs) {
+      return { resources: [], diagnostics: [] };
+    }
+
+    const identity = await inspectProviderFile(path, ownerRoot, "claude");
+    const canonicalKey = `claude:changelog-cache:${identity.path}`;
+    return {
+      resources: [
+        {
+          resource: {
+            id: `claude:agent-cache:${sha256(canonicalKey)}`,
+            adapter: "claude",
+            kind: "agent-cache",
+            canonicalKey,
+            displayName: "Claude changelog cache",
+            path: identity.path,
+          },
+          observedAt: context.now.toISOString(),
+          exists: true,
+          measuredBytes: identity.measuredBytes,
+          facts: {
+            reportOnly: false,
+            maintenanceAction: "provider.file-quarantine",
+            policyId: CLAUDE_CHANGELOG_CACHE_POLICY_ID,
+            minAgeMinutes: CLAUDE_CHANGELOG_CACHE_MIN_AGE_MINUTES,
+            providerFileIdentity: identity,
+          },
+        },
+      ],
+      diagnostics: [],
+    };
+  } catch (error) {
+    if (isMissing(error)) {
+      return { resources: [], diagnostics: [] };
+    }
+    return {
+      resources: [],
+      diagnostics: [
+        {
+          severity: "warning",
+          code: "CLAUDE_CHANGELOG_CACHE_INSPECTION_FAILED",
+          message: error instanceof Error ? error.message : String(error),
+          adapter: "claude",
+        },
+      ],
+    };
+  }
+}

--- a/src/adapters/provider-adapter.ts
+++ b/src/adapters/provider-adapter.ts
@@ -15,9 +15,13 @@ import {
 import { sha256 } from "../core/digest.js";
 import { measurePath } from "../core/measure.js";
 import {
+  CLAUDE_CHANGELOG_CACHE_MIN_AGE_MINUTES,
+  CLAUDE_CHANGELOG_CACHE_POLICY_ID,
+  CLAUDE_CHANGELOG_CACHE_QUARANTINE_TTL_MINUTES,
   CLAUDE_DEBUG_LOG_MIN_AGE_MINUTES,
   CLAUDE_DEBUG_LOG_POLICY_ID,
   CLAUDE_DEBUG_LOG_QUARANTINE_TTL_MINUTES,
+  isClaudeChangelogCacheRelativePath,
   isClaudeDebugLogRelativePath,
 } from "../core/provider-file-policy.js";
 import type { ReachabilityIndex } from "../core/reachability.js";
@@ -29,6 +33,7 @@ import {
   type CodexDatabaseDependencies,
   type CodexDatabaseInspection,
 } from "./codex-database.js";
+import { collectClaudeChangelogCache } from "./claude-cache.js";
 import { collectClaudeDebugLogs } from "./claude-debug.js";
 import { collectProviderReachability } from "./provider-reachability.js";
 import { resolveProviderRoot } from "./provider-root.js";
@@ -38,6 +43,42 @@ type ClaudeProviderFileQuarantineAction = Extract<
   ProviderFileQuarantineAction,
   { adapter: "claude" }
 >;
+
+type ClaudeProviderFileContract = {
+  policyId: string;
+  minAgeMinutes: number;
+  quarantineTtlMinutes: number;
+  matchesRelativePath(relativePath: string): boolean;
+  description: string;
+  rootCode: string;
+  rootDetail: string;
+  tooRecentDetail: string;
+};
+
+const CLAUDE_PROVIDER_FILE_CONTRACTS: readonly ClaudeProviderFileContract[] = [
+  {
+    policyId: CLAUDE_DEBUG_LOG_POLICY_ID,
+    minAgeMinutes: CLAUDE_DEBUG_LOG_MIN_AGE_MINUTES,
+    quarantineTtlMinutes: CLAUDE_DEBUG_LOG_QUARANTINE_TTL_MINUTES,
+    matchesRelativePath: isClaudeDebugLogRelativePath,
+    description: "Quarantine a Claude debug log older than 30 days",
+    rootCode: "claude-debug-log-owner-contract",
+    rootDetail:
+      "Claude documents direct debug logs as disposable application data with no user-facing loss.",
+    tooRecentDetail: "The debug log is newer than the 30-day cleanup threshold.",
+  },
+  {
+    policyId: CLAUDE_CHANGELOG_CACHE_POLICY_ID,
+    minAgeMinutes: CLAUDE_CHANGELOG_CACHE_MIN_AGE_MINUTES,
+    quarantineTtlMinutes: CLAUDE_CHANGELOG_CACHE_QUARANTINE_TTL_MINUTES,
+    matchesRelativePath: isClaudeChangelogCacheRelativePath,
+    description: "Quarantine the Claude changelog cache after 30 days",
+    rootCode: "claude-changelog-cache-owner-contract",
+    rootDetail:
+      "Claude documents cache/changelog.md as a rebuildable release-notes cache refreshed in the background.",
+    tooRecentDetail: "The changelog cache is newer than the 30-day cleanup threshold.",
+  },
+];
 
 export type ProviderAdapterOptions = {
   root?: string;
@@ -302,8 +343,11 @@ export class ProviderAuditAdapter implements AuditAdapter {
 
     if (this.spec.id === "claude") {
       const debugLogs = await collectClaudeDebugLogs(context, probe.root, this.options.maxEntries);
+      const changelogCache = await collectClaudeChangelogCache(context, probe.root);
       resources.push(...debugLogs.resources);
+      resources.push(...changelogCache.resources);
       diagnostics.push(...debugLogs.diagnostics);
+      diagnostics.push(...changelogCache.diagnostics);
     }
 
     return { resources, diagnostics };
@@ -314,34 +358,43 @@ export class ProviderAuditAdapter implements AuditAdapter {
     const providerFileIdentity = providerFileIdentitySchema.safeParse(
       resource.facts.providerFileIdentity,
     );
+    const claudeProviderFileContract =
+      typeof resource.facts.policyId === "string"
+        ? CLAUDE_PROVIDER_FILE_CONTRACTS.find(
+            (contract) =>
+              contract.policyId === resource.facts.policyId &&
+              providerFileIdentity.success &&
+              contract.matchesRelativePath(providerFileIdentity.data.relativePath),
+          )
+        : undefined;
     if (
       this.spec.id === "claude" &&
       providerFileIdentity.success &&
       providerFileIdentity.data.provider === "claude" &&
-      resource.facts.policyId === CLAUDE_DEBUG_LOG_POLICY_ID &&
-      isClaudeDebugLogRelativePath(providerFileIdentity.data.relativePath)
+      claudeProviderFileContract !== undefined
     ) {
       const claudeIdentity = {
         ...providerFileIdentity.data,
         provider: "claude" as const,
       };
       const oldEnough =
-        context.now.getTime() - claudeIdentity.mtimeMs >= CLAUDE_DEBUG_LOG_MIN_AGE_MINUTES * 60_000;
+        context.now.getTime() - claudeIdentity.mtimeMs >=
+        claudeProviderFileContract.minAgeMinutes * 60_000;
       const candidateActions: ClaudeProviderFileQuarantineAction[] = oldEnough
         ? [
             {
               actionId: `provider.file-quarantine:${sha256(
-                `${CLAUDE_DEBUG_LOG_POLICY_ID}:${claudeIdentity.fingerprint}`,
+                `${claudeProviderFileContract.policyId}:${claudeIdentity.fingerprint}`,
               )}`,
               type: "provider.file-quarantine",
               adapter: "claude",
               resourceId: resource.resource.id,
-              policyId: CLAUDE_DEBUG_LOG_POLICY_ID,
+              policyId: claudeProviderFileContract.policyId,
               risk: "recoverable",
-              description: "Quarantine a Claude debug log older than 30 days",
+              description: claudeProviderFileContract.description,
               expectedReclaimBytes: 0,
               pendingQuarantineBytes: claudeIdentity.measuredBytes,
-              quarantineTtlMinutes: CLAUDE_DEBUG_LOG_QUARANTINE_TTL_MINUTES,
+              quarantineTtlMinutes: claudeProviderFileContract.quarantineTtlMinutes,
               target: claudeIdentity,
             },
           ]
@@ -356,11 +409,10 @@ export class ProviderAuditAdapter implements AuditAdapter {
         confidence: "certain",
         roots: [
           {
-            code: "claude-debug-log-owner-contract",
+            code: claudeProviderFileContract.rootCode,
             source: this.id,
             observedAt,
-            detail:
-              "Claude documents direct debug logs as disposable application data with no user-facing loss.",
+            detail: claudeProviderFileContract.rootDetail,
           },
           ...(oldEnough
             ? []
@@ -369,7 +421,7 @@ export class ProviderAuditAdapter implements AuditAdapter {
                   code: "provider-file-too-recent",
                   source: this.id,
                   observedAt,
-                  detail: "The debug log is newer than the 30-day cleanup threshold.",
+                  detail: claudeProviderFileContract.tooRecentDetail,
                 },
               ]),
         ],

--- a/src/core/provider-file-policy.ts
+++ b/src/core/provider-file-policy.ts
@@ -16,6 +16,9 @@ export type ProviderFilePolicy = {
 export const CLAUDE_DEBUG_LOG_POLICY_ID = "claude.debug-log";
 export const CLAUDE_DEBUG_LOG_MIN_AGE_MINUTES = 30 * 24 * 60;
 export const CLAUDE_DEBUG_LOG_QUARANTINE_TTL_MINUTES = 7 * 24 * 60;
+export const CLAUDE_CHANGELOG_CACHE_POLICY_ID = "claude.changelog-cache";
+export const CLAUDE_CHANGELOG_CACHE_MIN_AGE_MINUTES = 30 * 24 * 60;
+export const CLAUDE_CHANGELOG_CACHE_QUARANTINE_TTL_MINUTES = 7 * 24 * 60;
 
 export function isClaudeDebugLogRelativePath(relativePath: string): boolean {
   const components = relativePath.split(/[\\/]/u);
@@ -27,22 +30,57 @@ export function isClaudeDebugLogRelativePath(relativePath: string): boolean {
   );
 }
 
+export function isClaudeChangelogCacheRelativePath(relativePath: string): boolean {
+  const components = relativePath.split(/[\\/]/u);
+  return components.length === 2 && components[0] === "cache" && components[1] === "changelog.md";
+}
+
+function validateAgeAndRecoveryWindow(
+  action: ProviderFileQuarantineAction,
+  now: Date,
+  label: string,
+  minimumAgeMinutes: number,
+  minimumTtlMinutes: number,
+): string | undefined {
+  if (action.pendingQuarantineBytes !== action.target.measuredBytes) {
+    return "pending quarantine bytes must match the exact file identity";
+  }
+  if (action.quarantineTtlMinutes < minimumTtlMinutes) {
+    return `${label} require at least seven days of recoverable quarantine`;
+  }
+  if (now.getTime() - action.target.mtimeMs < minimumAgeMinutes * 60_000) {
+    return `${label} must be at least 30 days old`;
+  }
+  return undefined;
+}
+
 export const PROVIDER_FILE_POLICIES: readonly ProviderFilePolicy[] = [
   {
     id: CLAUDE_DEBUG_LOG_POLICY_ID,
     provider: "claude",
     matchesRelativePath: isClaudeDebugLogRelativePath,
     validateAction(action, now) {
-      if (action.pendingQuarantineBytes !== action.target.measuredBytes) {
-        return "pending quarantine bytes must match the exact file identity";
-      }
-      if (action.quarantineTtlMinutes < CLAUDE_DEBUG_LOG_QUARANTINE_TTL_MINUTES) {
-        return "Claude debug logs require at least seven days of recoverable quarantine";
-      }
-      if (now.getTime() - action.target.mtimeMs < CLAUDE_DEBUG_LOG_MIN_AGE_MINUTES * 60_000) {
-        return "Claude debug logs must be at least 30 days old";
-      }
-      return undefined;
+      return validateAgeAndRecoveryWindow(
+        action,
+        now,
+        "Claude debug logs",
+        CLAUDE_DEBUG_LOG_MIN_AGE_MINUTES,
+        CLAUDE_DEBUG_LOG_QUARANTINE_TTL_MINUTES,
+      );
+    },
+  },
+  {
+    id: CLAUDE_CHANGELOG_CACHE_POLICY_ID,
+    provider: "claude",
+    matchesRelativePath: isClaudeChangelogCacheRelativePath,
+    validateAction(action, now) {
+      return validateAgeAndRecoveryWindow(
+        action,
+        now,
+        "Claude changelog caches",
+        CLAUDE_CHANGELOG_CACHE_MIN_AGE_MINUTES,
+        CLAUDE_CHANGELOG_CACHE_QUARANTINE_TTL_MINUTES,
+      );
     },
   },
 ];

--- a/src/core/provider-file-policy.ts
+++ b/src/core/provider-file-policy.ts
@@ -1,5 +1,5 @@
 import { realpath } from "node:fs/promises";
-import { resolve } from "node:path";
+import { resolve, sep } from "node:path";
 
 import { resolveProviderRoot } from "../adapters/provider-root.js";
 import { PROVIDER_SPECS } from "../adapters/provider-specs.js";
@@ -21,7 +21,7 @@ export const CLAUDE_CHANGELOG_CACHE_MIN_AGE_MINUTES = 30 * 24 * 60;
 export const CLAUDE_CHANGELOG_CACHE_QUARANTINE_TTL_MINUTES = 7 * 24 * 60;
 
 export function isClaudeDebugLogRelativePath(relativePath: string): boolean {
-  const components = relativePath.split(/[\\/]/u);
+  const components = relativePath.split(sep);
   return (
     components.length === 2 &&
     components[0] === "debug" &&
@@ -31,7 +31,7 @@ export function isClaudeDebugLogRelativePath(relativePath: string): boolean {
 }
 
 export function isClaudeChangelogCacheRelativePath(relativePath: string): boolean {
-  const components = relativePath.split(/[\\/]/u);
+  const components = relativePath.split(sep);
   return components.length === 2 && components[0] === "cache" && components[1] === "changelog.md";
 }
 

--- a/test/adapters/claude-cache.test.ts
+++ b/test/adapters/claude-cache.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, realpath, symlink, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -146,10 +146,12 @@ describe("Claude changelog cache cleanup", () => {
   });
 
   it("matches only the exact Claude changelog cache path", () => {
-    expect(isClaudeChangelogCacheRelativePath("cache/changelog.md")).toBe(true);
-    expect(isClaudeChangelogCacheRelativePath("cache\\changelog.md")).toBe(true);
+    expect(isClaudeChangelogCacheRelativePath(`cache${sep}changelog.md`)).toBe(true);
     expect(isClaudeChangelogCacheRelativePath("cache/my-closed-issues.json")).toBe(false);
     expect(isClaudeChangelogCacheRelativePath("cache/nested/changelog.md")).toBe(false);
     expect(isClaudeChangelogCacheRelativePath("changelog.md")).toBe(false);
+    if (sep === "/") {
+      expect(isClaudeChangelogCacheRelativePath("cache\\changelog.md")).toBe(false);
+    }
   });
 });

--- a/test/adapters/claude-cache.test.ts
+++ b/test/adapters/claude-cache.test.ts
@@ -1,0 +1,155 @@
+import { mkdir, mkdtemp, realpath, symlink, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ProviderAuditAdapter } from "../../src/adapters/provider-adapter.js";
+import { PROVIDER_SPECS } from "../../src/adapters/provider-specs.js";
+import type { AuditContext } from "../../src/contracts/adapter.js";
+import {
+  CLAUDE_CHANGELOG_CACHE_POLICY_ID,
+  isClaudeChangelogCacheRelativePath,
+} from "../../src/core/provider-file-policy.js";
+
+const NOW = new Date("2026-07-27T00:00:00.000Z");
+
+async function fixtureContext(): Promise<AuditContext> {
+  return {
+    home: await mkdtemp(join(tmpdir(), "agentrinse-claude-cache-")),
+    now: NOW,
+    auditId: "audit-claude-cache",
+  };
+}
+
+async function writeDatedFile(path: string, value: string, date: Date): Promise<void> {
+  await writeFile(path, value);
+  await utimes(path, date, date);
+}
+
+function adapter(): ProviderAuditAdapter {
+  return new ProviderAuditAdapter(PROVIDER_SPECS.claude, {
+    environment: {},
+    measureBytes: true,
+    maxEntries: 100,
+  });
+}
+
+describe("Claude changelog cache cleanup", () => {
+  it("proposes recoverable quarantine only for the exact old changelog cache", async () => {
+    const context = await fixtureContext();
+    const cache = join(context.home, ".claude", "cache");
+    await mkdir(cache, { recursive: true });
+    await writeDatedFile(
+      join(cache, "changelog.md"),
+      "synthetic release notes cache\n",
+      new Date("2026-06-01T00:00:00.000Z"),
+    );
+    await writeDatedFile(
+      join(cache, "my-closed-issues.json"),
+      '{"synthetic":"undocumented-neighbor"}\n',
+      new Date("2026-06-01T00:00:00.000Z"),
+    );
+    const claude = adapter();
+
+    const probe = await claude.probe(context);
+    const collection = await claude.collect(context, probe);
+    const exactCaches = collection.resources.filter(
+      (resource) => resource.facts.policyId === CLAUDE_CHANGELOG_CACHE_POLICY_ID,
+    );
+    const finding = await claude.classify(context, exactCaches[0]!);
+
+    expect(exactCaches).toHaveLength(1);
+    expect(exactCaches[0]).toMatchObject({
+      resource: {
+        kind: "agent-cache",
+        displayName: "Claude changelog cache",
+        path: await realpath(join(cache, "changelog.md")),
+      },
+    });
+    expect(
+      collection.resources.some((resource) =>
+        resource.resource.path?.endsWith("my-closed-issues.json"),
+      ),
+    ).toBe(false);
+    expect(finding).toMatchObject({
+      state: "eligible",
+      confidence: "certain",
+      roots: [{ code: "claude-changelog-cache-owner-contract" }],
+      candidateActions: [
+        {
+          type: "provider.file-quarantine",
+          adapter: "claude",
+          policyId: CLAUDE_CHANGELOG_CACHE_POLICY_ID,
+          risk: "recoverable",
+          expectedReclaimBytes: 0,
+          quarantineTtlMinutes: 7 * 24 * 60,
+        },
+      ],
+    });
+  });
+
+  it("does not collect a recent changelog cache", async () => {
+    const context = await fixtureContext();
+    const cache = join(context.home, ".claude", "cache");
+    await mkdir(cache, { recursive: true });
+    await writeDatedFile(
+      join(cache, "changelog.md"),
+      "synthetic recent release notes cache\n",
+      new Date("2026-07-20T00:00:00.000Z"),
+    );
+    const claude = adapter();
+
+    const probe = await claude.probe(context);
+    const collection = await claude.collect(context, probe);
+
+    expect(
+      collection.resources.some(
+        (resource) => resource.facts.policyId === CLAUDE_CHANGELOG_CACHE_POLICY_ID,
+      ),
+    ).toBe(false);
+  });
+
+  it("does not follow a symlinked cache directory or changelog file", async () => {
+    const directoryContext = await fixtureContext();
+    const root = join(directoryContext.home, ".claude");
+    const target = await mkdtemp(join(tmpdir(), "agentrinse-claude-cache-target-"));
+    await mkdir(root);
+    await writeFile(join(target, "changelog.md"), "outside");
+    await symlink(target, join(root, "cache"));
+    const claude = adapter();
+
+    const directoryProbe = await claude.probe(directoryContext);
+    const directoryCollection = await claude.collect(directoryContext, directoryProbe);
+
+    expect(
+      directoryCollection.resources.some(
+        (resource) => resource.facts.policyId === CLAUDE_CHANGELOG_CACHE_POLICY_ID,
+      ),
+    ).toBe(false);
+
+    const fileContext = await fixtureContext();
+    const cache = join(fileContext.home, ".claude", "cache");
+    const outside = join(fileContext.home, "outside.md");
+    await mkdir(cache, { recursive: true });
+    await writeFile(outside, "outside");
+    await symlink(outside, join(cache, "changelog.md"));
+
+    const fileProbe = await claude.probe(fileContext);
+    const fileCollection = await claude.collect(fileContext, fileProbe);
+
+    expect(
+      fileCollection.resources.some(
+        (resource) => resource.facts.policyId === CLAUDE_CHANGELOG_CACHE_POLICY_ID,
+      ),
+    ).toBe(false);
+  });
+
+  it("matches only the exact Claude changelog cache path", () => {
+    expect(isClaudeChangelogCacheRelativePath("cache/changelog.md")).toBe(true);
+    expect(isClaudeChangelogCacheRelativePath("cache\\changelog.md")).toBe(true);
+    expect(isClaudeChangelogCacheRelativePath("cache/my-closed-issues.json")).toBe(false);
+    expect(isClaudeChangelogCacheRelativePath("cache/nested/changelog.md")).toBe(false);
+    expect(isClaudeChangelogCacheRelativePath("changelog.md")).toBe(false);
+  });
+});

--- a/test/adapters/claude-debug.test.ts
+++ b/test/adapters/claude-debug.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, realpath, symlink, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -124,10 +124,12 @@ describe("Claude debug cleanup", () => {
   });
 
   it("matches only one direct Claude debug text file", () => {
-    expect(isClaudeDebugLogRelativePath("debug/session.txt")).toBe(true);
-    expect(isClaudeDebugLogRelativePath("debug\\session.txt")).toBe(true);
+    expect(isClaudeDebugLogRelativePath(`debug${sep}session.txt`)).toBe(true);
     expect(isClaudeDebugLogRelativePath("debug/session.jsonl")).toBe(false);
     expect(isClaudeDebugLogRelativePath("debug/nested/session.txt")).toBe(false);
     expect(isClaudeDebugLogRelativePath("projects/session.txt")).toBe(false);
+    if (sep === "/") {
+      expect(isClaudeDebugLogRelativePath("debug\\session.txt")).toBe(false);
+    }
   });
 });

--- a/test/core/provider-file-policy.test.ts
+++ b/test/core/provider-file-policy.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, sep } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -96,6 +96,27 @@ describe("provider file policy", () => {
     },
   );
 
+  it.skipIf(sep !== "/")("rejects a root-level debug filename containing a backslash", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-policy-home-"));
+    const ownerRoot = join(home, "claude-data");
+    const action = await actionFor(ownerRoot, "debug\\session.txt");
+
+    await expect(
+      authorizeProviderFileAction(
+        action,
+        home,
+        DEFAULT_CONFIG,
+        "darwin",
+        {
+          CLAUDE_CONFIG_DIR: ownerRoot,
+        },
+        new Date("2026-07-25T00:00:00.000Z"),
+      ),
+    ).rejects.toThrow(
+      `provider-file target is not approved by policy claude:${CLAUDE_DEBUG_LOG_POLICY_ID}`,
+    );
+  });
+
   it("rejects recent logs and shortened recovery windows at authorization", async () => {
     const home = await mkdtemp(join(tmpdir(), "agentrinse-policy-home-"));
     const ownerRoot = join(home, "claude-data");
@@ -176,6 +197,27 @@ describe("provider file policy", () => {
       );
     },
   );
+
+  it.skipIf(sep !== "/")("rejects a root-level cache filename containing a backslash", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-policy-home-"));
+    const ownerRoot = join(home, "claude-data");
+    const action = await cacheActionFor(ownerRoot, "cache\\changelog.md");
+
+    await expect(
+      authorizeProviderFileAction(
+        action,
+        home,
+        DEFAULT_CONFIG,
+        "darwin",
+        {
+          CLAUDE_CONFIG_DIR: ownerRoot,
+        },
+        new Date("2026-07-27T00:00:00.000Z"),
+      ),
+    ).rejects.toThrow(
+      `provider-file target is not approved by policy claude:${CLAUDE_CHANGELOG_CACHE_POLICY_ID}`,
+    );
+  });
 
   it("rejects recent changelog caches and shortened recovery windows at authorization", async () => {
     const home = await mkdtemp(join(tmpdir(), "agentrinse-policy-home-"));

--- a/test/core/provider-file-policy.test.ts
+++ b/test/core/provider-file-policy.test.ts
@@ -9,6 +9,7 @@ import type { ProviderFileQuarantineAction } from "../../src/contracts/action.js
 import { inspectProviderFile } from "../../src/core/provider-file-identity.js";
 import {
   authorizeProviderFileAction,
+  CLAUDE_CHANGELOG_CACHE_POLICY_ID,
   CLAUDE_DEBUG_LOG_POLICY_ID,
 } from "../../src/core/provider-file-policy.js";
 
@@ -34,6 +35,20 @@ async function actionFor(
     pendingQuarantineBytes: target.measuredBytes,
     quarantineTtlMinutes: 7 * 24 * 60,
     target,
+  };
+}
+
+async function cacheActionFor(
+  ownerRoot: string,
+  relativePath: string,
+  mtime = new Date("2026-06-01T00:00:00.000Z"),
+): Promise<Extract<ProviderFileQuarantineAction, { adapter: "claude" }>> {
+  const action = await actionFor(ownerRoot, relativePath, mtime);
+  return {
+    ...action,
+    resourceId: "claude:agent-cache:policy-test",
+    policyId: CLAUDE_CHANGELOG_CACHE_POLICY_ID,
+    description: "quarantine a synthetic Claude changelog cache",
   };
 }
 
@@ -115,6 +130,87 @@ describe("provider file policy", () => {
           CLAUDE_CONFIG_DIR: ownerRoot,
         },
         new Date("2026-07-25T00:00:00.000Z"),
+      ),
+    ).rejects.toThrow("at least seven days");
+  });
+
+  it("authorizes only the exact old Claude changelog cache", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-policy-home-"));
+    const ownerRoot = join(home, "claude-data");
+    const action = await cacheActionFor(ownerRoot, "cache/changelog.md");
+
+    await expect(
+      authorizeProviderFileAction(
+        action,
+        home,
+        DEFAULT_CONFIG,
+        "darwin",
+        {
+          CLAUDE_CONFIG_DIR: ownerRoot,
+        },
+        new Date("2026-07-27T00:00:00.000Z"),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it.each(["cache/my-closed-issues.json", "cache/nested/changelog.md", "changelog.md"])(
+    "rejects the non-cache-policy path %s",
+    async (relativePath) => {
+      const home = await mkdtemp(join(tmpdir(), "agentrinse-policy-home-"));
+      const ownerRoot = join(home, "claude-data");
+      const action = await cacheActionFor(ownerRoot, relativePath);
+
+      await expect(
+        authorizeProviderFileAction(
+          action,
+          home,
+          DEFAULT_CONFIG,
+          "darwin",
+          {
+            CLAUDE_CONFIG_DIR: ownerRoot,
+          },
+          new Date("2026-07-27T00:00:00.000Z"),
+        ),
+      ).rejects.toThrow(
+        `provider-file target is not approved by policy claude:${CLAUDE_CHANGELOG_CACHE_POLICY_ID}`,
+      );
+    },
+  );
+
+  it("rejects recent changelog caches and shortened recovery windows at authorization", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-policy-home-"));
+    const ownerRoot = join(home, "claude-data");
+    const recent = await cacheActionFor(
+      ownerRoot,
+      "cache/changelog.md",
+      new Date("2026-07-20T00:00:00.000Z"),
+    );
+
+    await expect(
+      authorizeProviderFileAction(
+        recent,
+        home,
+        DEFAULT_CONFIG,
+        "darwin",
+        {
+          CLAUDE_CONFIG_DIR: ownerRoot,
+        },
+        new Date("2026-07-27T00:00:00.000Z"),
+      ),
+    ).rejects.toThrow("Claude changelog caches must be at least 30 days old");
+
+    const old = await cacheActionFor(ownerRoot, "cache/changelog.md");
+    old.quarantineTtlMinutes = 60;
+    await expect(
+      authorizeProviderFileAction(
+        old,
+        home,
+        DEFAULT_CONFIG,
+        "darwin",
+        {
+          CLAUDE_CONFIG_DIR: ownerRoot,
+        },
+        new Date("2026-07-27T00:00:00.000Z"),
       ),
     ).rejects.toThrow("at least seven days");
   });


### PR DESCRIPTION
## Summary

- discover only the exact Claude `cache/changelog.md` file after 30 days
- classify it as an `agent-cache` and emit recoverable `provider.file-quarantine`
- retain the file for seven days before explicit purge
- document the new boundary in the README, adapter guide, safety model, product spec, and changelog

## Owner evidence

Claude documents `cache/changelog.md` as a cached changelog used for release notes and refreshed in the background: https://code.claude.com/docs/en/claude-directory

## Safety boundary

- owner: Claude Code under the configured physical Claude root
- exact target: `cache/changelog.md`; no directory or wildcard cache policy
- protected neighbors: undocumented cache files, `paste-cache`, `image-cache`, `remote-settings.json`, and `policy-limits.json`
- protected state: transcripts, prompt history, checkpoints, tasks, settings, credentials, plugins, and databases
- risk: `recoverable`, excluded by the default `safe` ceiling
- revalidation: policy ID, native path components, exact content identity, age, byte count, configured root, stopped Claude processes, and no open descriptor
- recovery: seven-day descriptor-bound quarantine, undo, and explicit purge through the existing provider-file manifest

The branch also closes an existing separator ambiguity in the Claude debug policy: POSIX filenames containing a literal backslash can no longer masquerade as nested provider paths.

## Verification

- 60 test files / 433 tests passed
- format, lint, and TypeScript checks passed
- all 9 generated JSON Schemas verified
- package manifest, publint, and `npm pack --dry-run` passed
- autoreview found the separator issue; fixed in `a09fc56`; fresh autoreview is clean
- trufflehog: clean

Part of #16.