### PR TITLE
feat(claude): report native retention policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ The project follows semantic versioning after its first supported release.
   days, with a seven-day undo window before purge
 - recoverable quarantine for the exact Claude `cache/changelog.md` file after
   30 days, without matching neighboring or undocumented cache files
+- report-only Claude native retention findings for sessions, debug data,
+  managed worktrees, paste cache, and image cache, including the documented
+  default and any valid user `cleanupPeriodDays`
 
 ### Fixed
 
@@ -45,6 +48,9 @@ The project follows semantic versioning after its first supported release.
 - Claude cleanup excludes JSONL, nested paths, recent files, undocumented
   caches, active Claude processes, open descriptors, and incomplete directory
   enumeration
+- malformed, unreadable, changing, symlinked, oversized, and invalid Claude
+  settings make native retention uncertain instead of assuming the default or
+  emitting an action
 
 ## [0.4.0] - 2026-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,9 @@ The project follows semantic versioning after its first supported release.
 - Claude cleanup excludes JSONL, nested paths, recent files, undocumented
   caches, active Claude processes, open descriptors, and incomplete directory
   enumeration
-- malformed, unreadable, changing, symlinked, oversized, and invalid Claude
-  settings make native retention uncertain instead of assuming the default or
-  emitting an action
+- malformed, unreadable, changing, symlinked, oversized, invalid, and
+  whole-file-unverified Claude settings make native retention uncertain instead
+  of assuming the default or emitting an action
 
 ## [0.4.0] - 2026-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,9 @@ The project follows semantic versioning after its first supported release.
   days, with a seven-day undo window before purge
 - recoverable quarantine for the exact Claude `cache/changelog.md` file after
   30 days, without matching neighboring or undocumented cache files
-- report-only Claude native retention findings for sessions, debug data,
-  managed worktrees, paste cache, and image cache, including the documented
-  default and any valid user `cleanupPeriodDays`
+- report-only Claude native retention findings for sessions, debug data, paste
+  cache, and image cache, including the documented default and any valid user
+  `cleanupPeriodDays`
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ adds one narrow exception: explicit offline compaction for the exact current
 Codex `state_5`, `logs_2`, `goals_1`, and `memories_1` SQLite contracts. Claude
 cleanup is limited to exact old debug text files and its rebuildable changelog
 cache. AgentRinse also reports Claude's native retention policy for sessions,
-managed worktrees, debug data, paste cache, and image cache. Docker remains
-audit-only.
+debug data, paste cache, and image cache. Docker remains audit-only.
 
 ## agent integrations
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ Codex sessions and every other provider store remain report-only. `0.4.0`
 adds one narrow exception: explicit offline compaction for the exact current
 Codex `state_5`, `logs_2`, `goals_1`, and `memories_1` SQLite contracts. Claude
 cleanup is limited to exact old debug text files and its rebuildable changelog
-cache. Docker remains audit-only.
+cache. AgentRinse also reports Claude's native retention policy for sessions,
+managed worktrees, debug data, paste cache, and image cache. Docker remains
+audit-only.
 
 ## agent integrations
 
@@ -55,15 +57,15 @@ provider state is report-only unless the table below says otherwise.
 agentrinse never erases transcripts, sessions, credentials, configuration, or
 logical memory records.
 
-| Logo                                                                        | Client                                                      | Mode                    | What it protects                                                    |
-| --------------------------------------------------------------------------- | ----------------------------------------------------------- | ----------------------- | ------------------------------------------------------------------- |
-| <img width="48px" src="docs/client-openai.jpg" alt="OpenAI Codex" />        | [OpenAI Codex](https://github.com/openai/codex)             | audit + offline vacuum  | sessions, workspace roots, reachability, and supported SQLite state |
-| <img width="48px" src="docs/client-claude.jpg" alt="Claude Code" />         | [Claude Code](https://code.claude.com/docs/en/overview)     | audit + file quarantine | sessions, roots, reachability, old debug logs, and changelog cache  |
-| <img width="48px" src="docs/client-cursor.jpg" alt="Cursor" />              | [Cursor](https://cursor.com/docs)                           | audit-only              | local agent state and workspace references                          |
-| <img width="48px" src="docs/client-copilot.png" alt="GitHub Copilot CLI" /> | [GitHub Copilot CLI](https://github.com/github/copilot-cli) | audit-only              | local session and configuration state                               |
-| <img width="48px" src="docs/client-zed.svg" alt="Zed" />                    | [Zed](https://zed.dev/docs/ai/overview)                     | audit-only              | local agent state                                                   |
-| <img width="48px" src="docs/client-opencode.png" alt="OpenCode" />          | [OpenCode](https://opencode.ai/)                            | audit-only              | local agent state                                                   |
-| <img width="48px" src="docs/client-grok-build.svg" alt="Grok Build" />      | [Grok Build](https://docs.x.ai/build/overview)              | audit-only              | local agent state                                                   |
+| Logo                                                                        | Client                                                      | Mode                   | What it protects                                                    |
+| --------------------------------------------------------------------------- | ----------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------- |
+| <img width="48px" src="docs/client-openai.jpg" alt="OpenAI Codex" />        | [OpenAI Codex](https://github.com/openai/codex)             | audit + offline vacuum | sessions, workspace roots, reachability, and supported SQLite state |
+| <img width="48px" src="docs/client-claude.jpg" alt="Claude Code" />         | [Claude Code](https://code.claude.com/docs/en/overview)     | retention + quarantine | sessions, caches, roots, native retention, and exact old files      |
+| <img width="48px" src="docs/client-cursor.jpg" alt="Cursor" />              | [Cursor](https://cursor.com/docs)                           | audit-only             | local agent state and workspace references                          |
+| <img width="48px" src="docs/client-copilot.png" alt="GitHub Copilot CLI" /> | [GitHub Copilot CLI](https://github.com/github/copilot-cli) | audit-only             | local session and configuration state                               |
+| <img width="48px" src="docs/client-zed.svg" alt="Zed" />                    | [Zed](https://zed.dev/docs/ai/overview)                     | audit-only             | local agent state                                                   |
+| <img width="48px" src="docs/client-opencode.png" alt="OpenCode" />          | [OpenCode](https://opencode.ai/)                            | audit-only             | local agent state                                                   |
+| <img width="48px" src="docs/client-grok-build.svg" alt="Grok Build" />      | [Grok Build](https://docs.x.ai/build/overview)              | audit-only             | local agent state                                                   |
 
 ## cleanup surfaces
 
@@ -72,6 +74,7 @@ logical memory records.
 | 🌿                                                                   | Git worktrees                        | audit + quarantine | linked worktrees, refs, dirtiness, locks, processes, and provider roots |
 | 🧹                                                                   | Build artifacts                      | safe-clean         | exact configured rebuildable directories                                |
 | 🗜️                                                                   | Codex SQLite state                   | experimental       | schema versions, free pages, sidecars, owner processes, and rollback    |
+| <img width="48px" src="docs/client-claude.jpg" alt="Claude Code" />  | Claude native retention              | report-only        | default or user retention, settings validity, and provider ownership    |
 | <img width="48px" src="docs/client-claude.jpg" alt="Claude Code" />  | Claude logs and changelog cache      | recoverable        | exact old files, provider liveness, seven-day undo, and explicit purge  |
 | ⚡                                                                   | Agent runtimes                       | audit-only, opt-in | installed agent executables and versions                                |
 | <img width="48px" src="docs/client-docker-agent.svg" alt="Docker" /> | [Docker](https://docs.docker.com/)   | audit-only, opt-in | images and containers                                                   |

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -59,14 +59,13 @@ credentials, plugins, undocumented caches, and native orphaned-worktree
 cleanup stay provider-owned.
 
 AgentRinse reports Claude's native startup retention for project sessions,
-debug data, managed worktrees, `paste-cache`, and `image-cache`. It reads only
-the direct user `settings.json`, with a 1 MiB limit and stable-file check. A
-valid user `cleanupPeriodDays` value is reported alongside Claude's documented
-30-day default, but never presented as globally effective because
-higher-precedence settings are not resolved. Missing settings preserve the
-documented default signal. Malformed, unreadable, changing, symlinked,
-oversized, or invalid settings make native cleanup uncertain and emit no
-action.
+debug data, `paste-cache`, and `image-cache`. It reads only the direct user
+`settings.json`, with a 1 MiB limit and stable-file check. A valid user
+`cleanupPeriodDays` value is reported alongside Claude's documented 30-day
+default, but never presented as globally effective because higher-precedence
+settings are not resolved. Missing settings preserve the documented default
+signal. Malformed, unreadable, changing, symlinked, oversized, or invalid
+settings make native cleanup uncertain and emit no action.
 
 Direct regular files matching `debug/*.txt` may produce
 `provider.file-quarantine` after 30 days. The action is `recoverable`, excluded

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -1,14 +1,15 @@
 # Adapter Matrix
 
 Provider and Docker adapters are read-only except for versioned Codex database
-maintenance and exact Claude debug-log quarantine. Artifact cleanup is scoped
-to explicitly configured rebuildable directories. The Git adapter can emit one
-recoverable whole-worktree action when every safety gate is proven.
+maintenance and exact Claude debug-log and changelog-cache quarantine. Artifact
+cleanup is scoped to explicitly configured rebuildable directories. The Git
+adapter can emit one recoverable whole-worktree action when every safety gate
+is proven.
 
 | Adapter        | Current capability                                        | Protected state |
 | -------------- | --------------------------------------------------------- | --------------- |
 | Codex          | sessions, worktrees, four SQLite DBs, offline compaction  | conditional     |
-| Claude         | sessions, worktrees, recoverable old debug-log quarantine | conditional     |
+| Claude         | sessions, caches, native retention, exact file quarantine | conditional     |
 | Cursor         | workspace state, global state, logs                       | all             |
 | GitHub Copilot | CLI sessions and logs                                     | all             |
 | Zed            | user-data root                                            | all             |
@@ -56,6 +57,16 @@ descriptors.
 Transcripts, prompt history, checkpoint files, task state, settings,
 credentials, plugins, undocumented caches, and native orphaned-worktree
 cleanup stay provider-owned.
+
+AgentRinse reports Claude's native startup retention for project sessions,
+debug data, managed worktrees, `paste-cache`, and `image-cache`. It reads only
+the direct user `settings.json`, with a 1 MiB limit and stable-file check. A
+valid user `cleanupPeriodDays` value is reported alongside Claude's documented
+30-day default, but never presented as globally effective because
+higher-precedence settings are not resolved. Missing settings preserve the
+documented default signal. Malformed, unreadable, changing, symlinked,
+oversized, or invalid settings make native cleanup uncertain and emit no
+action.
 
 Direct regular files matching `debug/*.txt` may produce
 `provider.file-quarantine` after 30 days. The action is `recoverable`, excluded

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -63,9 +63,11 @@ debug data, `paste-cache`, and `image-cache`. It reads only the direct user
 `settings.json`, with a 1 MiB limit and stable-file check. A valid user
 `cleanupPeriodDays` value is reported alongside Claude's documented 30-day
 default, but never presented as globally effective because higher-precedence
-settings are not resolved. Missing settings preserve the documented default
-signal. Malformed, unreadable, changing, symlinked, oversized, or invalid
-settings make native cleanup uncertain and emit no action.
+settings are not resolved. AgentRinse validates only empty or retention-only
+user settings objects; additional fields remain unverified rather than copying
+Claude's full settings schema. Missing settings preserve the documented default
+signal. Malformed, unreadable, changing, symlinked, oversized, invalid, or
+unverified settings make native cleanup uncertain and emit no action.
 
 Direct regular files matching `debug/*.txt` may produce
 `provider.file-quarantine` after 30 days. The action is `recoverable`, excluded

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -1957,9 +1957,11 @@ native cleanup expected
 The finding includes Claude's documented 30-day default and a valid user-level
 `cleanupPeriodDays` when present. It explicitly marks the effective value as
 unknown because higher-precedence settings are not resolved. The user settings
-read is limited to a stable direct regular file of at most 1 MiB.
-Malformed, unreadable, changing, symlinked, oversized, or invalid settings
-produce `native cleanup uncertain` instead of falling back to 30 days.
+read is limited to a stable direct regular file of at most 1 MiB. Only empty or
+retention-only objects are validated; additional fields preserve the observed
+cleanup period but leave whole-file validity unverified. Malformed, unreadable,
+changing, symlinked, oversized, invalid, or unverified settings produce
+`native cleanup uncertain` instead of falling back to 30 days.
 
 Native retention never emits an AgentRinse action. Exact debug-log and
 changelog-cache quarantine remain separate policies with their own apply-time

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -1947,15 +1947,23 @@ and undocumented cache paths remain protected.
 
 ### Native cleanup interaction
 
-If Claude is expected to remove an orphaned worktree under its configured
-retention policy, AgentRinse reports:
+AgentRinse inventories project sessions, debug data, managed worktrees,
+`paste-cache`, and `image-cache` as native-retention resources. Findings report:
 
 ```text
 native cleanup expected
 ```
 
-It may still propose safe artifact trimming. It should avoid racing the
-provider's startup cleanup and must revalidate path existence before action.
+The finding includes Claude's documented 30-day default and a valid user-level
+`cleanupPeriodDays` when present. It explicitly marks the effective value as
+unknown because higher-precedence settings are not resolved. The user settings
+read is limited to a stable direct regular file of at most 1 MiB.
+Malformed, unreadable, changing, symlinked, oversized, or invalid settings
+produce `native cleanup uncertain` instead of falling back to 30 days.
+
+Native retention never emits an AgentRinse action. Exact debug-log and
+changelog-cache quarantine remain separate policies with their own apply-time
+revalidation.
 
 ## Cursor Adapter
 
@@ -3586,6 +3594,7 @@ decision-log entry. They must not be smuggled in as adapter fixes.
 - [x] exact provider-file quarantine, undo, purge, and recovery foundation
 - [x] recoverable Claude debug-log quarantine
 - [x] recoverable Claude changelog-cache quarantine
+- [x] Claude native retention and cache inventory reporting
 
 ### Documentation and release
 
@@ -3627,14 +3636,16 @@ Verified on 2026-07-24:
 
 ## Reference Links
 
-Primary references current as of 2026-07-23:
+Primary references current as of 2026-07-27:
 
 - Codex worktrees:
   `https://developers.openai.com/codex/environments/git-worktrees`
 - Codex source:
   `https://github.com/openai/codex`
 - Claude Code settings:
-  `https://docs.anthropic.com/en/docs/claude-code/settings`
+  `https://code.claude.com/docs/en/settings`
+- Claude Code application data:
+  `https://code.claude.com/docs/en/claude-directory`
 - Cursor documentation:
   `https://cursor.com/docs`
 - GitHub Copilot CLI configuration directory:

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -1947,8 +1947,8 @@ and undocumented cache paths remain protected.
 
 ### Native cleanup interaction
 
-AgentRinse inventories project sessions, debug data, managed worktrees,
-`paste-cache`, and `image-cache` as native-retention resources. Findings report:
+AgentRinse inventories project sessions, debug data, `paste-cache`, and
+`image-cache` as native-retention resources. Findings report:
 
 ```text
 native cleanup expected

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -86,8 +86,8 @@ open descriptors remain protected.
 ## Native Provider Retention Reporting
 
 Claude native retention is report-only. AgentRinse inventories project
-sessions, debug data, managed worktrees, `paste-cache`, and `image-cache`, then
-reports Claude's documented `cleanupPeriodDays` startup sweep.
+sessions, debug data, `paste-cache`, and `image-cache`, then reports Claude's
+documented `cleanupPeriodDays` startup sweep.
 
 The user `settings.json` read is pinned to one direct regular file, capped at
 1 MiB, and checked for stable device, inode, mode, timestamps, and size before

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -93,10 +93,12 @@ The user `settings.json` read is pinned to one direct regular file, capped at
 1 MiB, and checked for stable device, inode, mode, timestamps, and size before
 and after reading. AgentRinse reports a valid user value but does not call it
 globally effective because higher-precedence settings are outside this
-inspection. Missing user settings retain the documented 30-day default signal.
-Malformed, unreadable, changing, symlinked, oversized, or invalid settings
-downgrade the finding to unknown confidence. AgentRinse does not substitute
-the default or emit a cleanup action in that state.
+inspection. Only empty or retention-only user settings objects are validated;
+additional fields preserve any observed cleanup period but make whole-file
+validity unverified. Missing user settings retain the documented 30-day default
+signal. Malformed, unreadable, changing, symlinked, oversized, invalid, or
+unverified settings downgrade the finding to unknown confidence. AgentRinse
+does not substitute the default or emit a cleanup action in that state.
 
 ## Recoverable Codex Database Boundary
 

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -83,6 +83,21 @@ quarantine. JSONL, nested paths, neighboring or undocumented cache files,
 recent files, incomplete directory enumeration, active Claude processes, and
 open descriptors remain protected.
 
+## Native Provider Retention Reporting
+
+Claude native retention is report-only. AgentRinse inventories project
+sessions, debug data, managed worktrees, `paste-cache`, and `image-cache`, then
+reports Claude's documented `cleanupPeriodDays` startup sweep.
+
+The user `settings.json` read is pinned to one direct regular file, capped at
+1 MiB, and checked for stable device, inode, mode, timestamps, and size before
+and after reading. AgentRinse reports a valid user value but does not call it
+globally effective because higher-precedence settings are outside this
+inspection. Missing user settings retain the documented 30-day default signal.
+Malformed, unreadable, changing, symlinked, oversized, or invalid settings
+downgrade the finding to unknown confidence. AgentRinse does not substitute
+the default or emit a cleanup action in that state.
+
 ## Recoverable Codex Database Boundary
 
 `database.vacuum` is `experimental` and excluded by every lower risk ceiling.

--- a/src/adapters/claude-retention.ts
+++ b/src/adapters/claude-retention.ts
@@ -1,0 +1,222 @@
+import { constants, type Stats } from "node:fs";
+import { lstat, open, type FileHandle } from "node:fs/promises";
+import { join } from "node:path";
+
+import { z } from "zod";
+
+import type { Diagnostic } from "../contracts/diagnostic.js";
+
+const MAX_SETTINGS_BYTES = 1024 * 1024;
+
+export const CLAUDE_NATIVE_RETENTION_DEFAULT_DAYS = 30;
+
+export const claudeNativeRetentionFactsSchema = z.object({
+  mechanism: z.literal("cleanupPeriodDays"),
+  documentedDefaultDays: z.literal(CLAUDE_NATIVE_RETENTION_DEFAULT_DAYS),
+  startupSweep: z.literal(true),
+  effectiveDaysKnown: z.literal(false),
+  userSettingsStatus: z.enum([
+    "missing",
+    "valid",
+    "invalid",
+    "changed",
+    "unreadable",
+    "unsupported",
+    "too-large",
+  ]),
+  userConfiguredDays: z.number().int().min(1).optional(),
+});
+
+export type ClaudeNativeRetentionFacts = z.infer<typeof claudeNativeRetentionFactsSchema>;
+
+type SettingsFileHandle = Pick<FileHandle, "close" | "readFile" | "stat">;
+
+export type ClaudeRetentionDependencies = {
+  lstat(path: string): Promise<Stats>;
+  open(path: string, flags: number): Promise<SettingsFileHandle>;
+};
+
+export type ClaudeRetentionInspection = {
+  facts: ClaudeNativeRetentionFacts;
+  diagnostics: Diagnostic[];
+};
+
+const DEFAULT_DEPENDENCIES: ClaudeRetentionDependencies = {
+  lstat,
+  open,
+};
+
+const NATIVE_RETENTION_PATHS = new Set([
+  "projects",
+  "debug",
+  "worktrees",
+  "paste-cache",
+  "image-cache",
+]);
+
+function isMissing(error: unknown): boolean {
+  return (
+    error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}
+
+function stableStats(before: Stats, after: Stats): boolean {
+  return (
+    before.dev === after.dev &&
+    before.ino === after.ino &&
+    before.mode === after.mode &&
+    before.mtimeMs === after.mtimeMs &&
+    before.ctimeMs === after.ctimeMs &&
+    before.size === after.size
+  );
+}
+
+function inspection(
+  userSettingsStatus: ClaudeNativeRetentionFacts["userSettingsStatus"],
+  diagnostics: Diagnostic[] = [],
+  userConfiguredDays?: number,
+): ClaudeRetentionInspection {
+  return {
+    facts: {
+      mechanism: "cleanupPeriodDays",
+      documentedDefaultDays: CLAUDE_NATIVE_RETENTION_DEFAULT_DAYS,
+      startupSweep: true,
+      effectiveDaysKnown: false,
+      userSettingsStatus,
+      ...(userConfiguredDays === undefined ? {} : { userConfiguredDays }),
+    },
+    diagnostics,
+  };
+}
+
+function warning(code: string, message: string): Diagnostic {
+  return {
+    severity: "warning",
+    code,
+    message,
+    adapter: "claude",
+  };
+}
+
+export function usesClaudeNativeRetention(relativePath: string): boolean {
+  return NATIVE_RETENTION_PATHS.has(relativePath);
+}
+
+export async function inspectClaudeNativeRetention(
+  ownerRoot: string,
+  platform: NodeJS.Platform = process.platform,
+  dependencies: ClaudeRetentionDependencies = DEFAULT_DEPENDENCIES,
+): Promise<ClaudeRetentionInspection> {
+  const settingsPath = join(ownerRoot, "settings.json");
+  let entryStats: Stats;
+  try {
+    entryStats = await dependencies.lstat(settingsPath);
+  } catch (error) {
+    if (isMissing(error)) {
+      return inspection("missing");
+    }
+    return inspection("unreadable", [
+      warning(
+        "CLAUDE_RETENTION_SETTINGS_UNREADABLE",
+        "Claude user settings could not be inspected; native retention is uncertain.",
+      ),
+    ]);
+  }
+
+  if (entryStats.isSymbolicLink() || !entryStats.isFile()) {
+    return inspection("unsupported", [
+      warning(
+        "CLAUDE_RETENTION_SETTINGS_UNSUPPORTED",
+        "Claude user settings are not a direct regular file; native retention is uncertain.",
+      ),
+    ]);
+  }
+  if (entryStats.size > MAX_SETTINGS_BYTES) {
+    return inspection("too-large", [
+      warning(
+        "CLAUDE_RETENTION_SETTINGS_TOO_LARGE",
+        "Claude user settings exceed the inspection limit; native retention is uncertain.",
+      ),
+    ]);
+  }
+
+  let handle: SettingsFileHandle;
+  try {
+    const flags =
+      platform === "win32" ? constants.O_RDONLY : constants.O_RDONLY | constants.O_NOFOLLOW;
+    handle = await dependencies.open(settingsPath, flags);
+  } catch {
+    return inspection("unreadable", [
+      warning(
+        "CLAUDE_RETENTION_SETTINGS_UNREADABLE",
+        "Claude user settings could not be opened safely; native retention is uncertain.",
+      ),
+    ]);
+  }
+
+  let contents: string;
+  try {
+    const before = await handle.stat();
+    if (!before.isFile() || !stableStats(entryStats, before) || before.size > MAX_SETTINGS_BYTES) {
+      return inspection("changed", [
+        warning(
+          "CLAUDE_RETENTION_SETTINGS_CHANGED",
+          "Claude user settings changed during inspection; native retention is uncertain.",
+        ),
+      ]);
+    }
+    contents = await handle.readFile({ encoding: "utf8" });
+    const after = await handle.stat();
+    if (!stableStats(before, after)) {
+      return inspection("changed", [
+        warning(
+          "CLAUDE_RETENTION_SETTINGS_CHANGED",
+          "Claude user settings changed during inspection; native retention is uncertain.",
+        ),
+      ]);
+    }
+  } catch {
+    return inspection("unreadable", [
+      warning(
+        "CLAUDE_RETENTION_SETTINGS_UNREADABLE",
+        "Claude user settings could not be read safely; native retention is uncertain.",
+      ),
+    ]);
+  } finally {
+    await handle.close().catch(() => undefined);
+  }
+
+  let value: unknown;
+  try {
+    value = JSON.parse(contents.replace(/^\uFEFF/u, ""));
+  } catch {
+    return inspection("invalid", [
+      warning(
+        "CLAUDE_RETENTION_SETTINGS_INVALID",
+        "Claude user settings are not valid JSON; Claude may pause its native retention sweep.",
+      ),
+    ]);
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return inspection("invalid", [
+      warning(
+        "CLAUDE_RETENTION_SETTINGS_INVALID",
+        "Claude user settings must be a JSON object; Claude may pause its native retention sweep.",
+      ),
+    ]);
+  }
+
+  const cleanupPeriodDays = (value as Record<string, unknown>).cleanupPeriodDays;
+  if (cleanupPeriodDays === undefined) {
+    return inspection("valid");
+  }
+  if (!Number.isInteger(cleanupPeriodDays) || (cleanupPeriodDays as number) < 1) {
+    return inspection("invalid", [
+      warning(
+        "CLAUDE_RETENTION_SETTINGS_INVALID",
+        "Claude cleanupPeriodDays must be an integer of at least 1; native retention is uncertain.",
+      ),
+    ]);
+  }
+  return inspection("valid", [], cleanupPeriodDays as number);
+}

--- a/src/adapters/claude-retention.ts
+++ b/src/adapters/claude-retention.ts
@@ -29,7 +29,7 @@ export const claudeNativeRetentionFactsSchema = z.object({
 
 export type ClaudeNativeRetentionFacts = z.infer<typeof claudeNativeRetentionFactsSchema>;
 
-type SettingsFileHandle = Pick<FileHandle, "close" | "readFile" | "stat">;
+type SettingsFileHandle = Pick<FileHandle, "close" | "read" | "stat">;
 
 export type ClaudeRetentionDependencies = {
   lstat(path: string): Promise<Stats>;
@@ -46,13 +46,7 @@ const DEFAULT_DEPENDENCIES: ClaudeRetentionDependencies = {
   open,
 };
 
-const NATIVE_RETENTION_PATHS = new Set([
-  "projects",
-  "debug",
-  "worktrees",
-  "paste-cache",
-  "image-cache",
-]);
+const NATIVE_RETENTION_PATHS = new Set(["projects", "debug", "paste-cache", "image-cache"]);
 
 function isMissing(error: unknown): boolean {
   return (
@@ -69,6 +63,27 @@ function stableStats(before: Stats, after: Stats): boolean {
     before.ctimeMs === after.ctimeMs &&
     before.size === after.size
   );
+}
+
+async function readBoundedSettings(
+  handle: SettingsFileHandle,
+): Promise<{ contents?: string; overflow: boolean }> {
+  const buffer = Buffer.allocUnsafe(MAX_SETTINGS_BYTES + 1);
+  let offset = 0;
+  while (offset < buffer.length) {
+    const result = await handle.read(buffer, offset, buffer.length - offset, offset);
+    if (result.bytesRead === 0) {
+      break;
+    }
+    offset += result.bytesRead;
+  }
+  if (offset > MAX_SETTINGS_BYTES) {
+    return { overflow: true };
+  }
+  return {
+    contents: buffer.subarray(0, offset).toString("utf8"),
+    overflow: false,
+  };
 }
 
 function inspection(
@@ -165,7 +180,7 @@ export async function inspectClaudeNativeRetention(
         ),
       ]);
     }
-    contents = await handle.readFile({ encoding: "utf8" });
+    const boundedRead = await readBoundedSettings(handle);
     const after = await handle.stat();
     if (!stableStats(before, after)) {
       return inspection("changed", [
@@ -175,6 +190,15 @@ export async function inspectClaudeNativeRetention(
         ),
       ]);
     }
+    if (boundedRead.overflow || boundedRead.contents === undefined) {
+      return inspection("too-large", [
+        warning(
+          "CLAUDE_RETENTION_SETTINGS_TOO_LARGE",
+          "Claude user settings exceed the inspection limit; native retention is uncertain.",
+        ),
+      ]);
+    }
+    contents = boundedRead.contents;
   } catch {
     return inspection("unreadable", [
       warning(

--- a/src/adapters/claude-retention.ts
+++ b/src/adapters/claude-retention.ts
@@ -23,6 +23,7 @@ export const claudeNativeRetentionFactsSchema = z.object({
     "unreadable",
     "unsupported",
     "too-large",
+    "unverified",
   ]),
   userConfiguredDays: z.number().int().min(1).optional(),
 });
@@ -230,11 +231,12 @@ export async function inspectClaudeNativeRetention(
     ]);
   }
 
-  const cleanupPeriodDays = (value as Record<string, unknown>).cleanupPeriodDays;
-  if (cleanupPeriodDays === undefined) {
-    return inspection("valid");
-  }
-  if (!Number.isInteger(cleanupPeriodDays) || (cleanupPeriodDays as number) < 1) {
+  const settings = value as Record<string, unknown>;
+  const cleanupPeriodDays = settings.cleanupPeriodDays;
+  if (
+    cleanupPeriodDays !== undefined &&
+    (!Number.isInteger(cleanupPeriodDays) || (cleanupPeriodDays as number) < 1)
+  ) {
     return inspection("invalid", [
       warning(
         "CLAUDE_RETENTION_SETTINGS_INVALID",
@@ -242,5 +244,19 @@ export async function inspectClaudeNativeRetention(
       ),
     ]);
   }
-  return inspection("valid", [], cleanupPeriodDays as number);
+  const userConfiguredDays =
+    cleanupPeriodDays === undefined ? undefined : (cleanupPeriodDays as number);
+  if (Object.keys(settings).some((key) => key !== "cleanupPeriodDays")) {
+    return inspection(
+      "unverified",
+      [
+        warning(
+          "CLAUDE_RETENTION_SETTINGS_UNVERIFIED",
+          "Claude user settings contain fields AgentRinse does not validate; native retention is uncertain.",
+        ),
+      ],
+      userConfiguredDays,
+    );
+  }
+  return inspection("valid", [], userConfiguredDays);
 }

--- a/src/adapters/provider-adapter.ts
+++ b/src/adapters/provider-adapter.ts
@@ -590,8 +590,8 @@ export class ProviderAuditAdapter implements AuditAdapter {
             detail: uncertain
               ? "Claude user settings could not be validated; Claude may pause native cleanup unless managed settings provide cleanupPeriodDays."
               : configuredDays === undefined
-                ? "Claude documents a 30-day startup retention sweep; managed and project overrides were not resolved."
-                : `Claude user settings declare a ${configuredDays}-day startup retention sweep; managed and project overrides were not resolved.`,
+                ? "Claude documents a 30-day startup retention sweep; higher-precedence settings were not resolved."
+                : `Claude user settings declare a ${configuredDays}-day startup retention sweep; higher-precedence settings were not resolved.`,
           },
           {
             code: "provider-owned-report-only",

--- a/src/adapters/provider-adapter.ts
+++ b/src/adapters/provider-adapter.ts
@@ -35,6 +35,11 @@ import {
 } from "./codex-database.js";
 import { collectClaudeChangelogCache } from "./claude-cache.js";
 import { collectClaudeDebugLogs } from "./claude-debug.js";
+import {
+  claudeNativeRetentionFactsSchema,
+  inspectClaudeNativeRetention,
+  usesClaudeNativeRetention,
+} from "./claude-retention.js";
 import { collectProviderReachability } from "./provider-reachability.js";
 import { resolveProviderRoot } from "./provider-root.js";
 import type { ProviderSpec } from "./provider-specs.js";
@@ -243,6 +248,13 @@ export class ProviderAuditAdapter implements AuditAdapter {
     if (this.options.inventoryResources === false) {
       return { resources: [], diagnostics };
     }
+    const claudeRetention =
+      this.spec.id === "claude"
+        ? await inspectClaudeNativeRetention(probe.root, this.options.platform ?? process.platform)
+        : undefined;
+    if (claudeRetention !== undefined) {
+      diagnostics.push(...claudeRetention.diagnostics);
+    }
 
     for (const candidate of this.spec.resources) {
       context.signal?.throwIfAborted();
@@ -310,6 +322,9 @@ export class ProviderAuditAdapter implements AuditAdapter {
             entries: measurement?.entries,
             symlinksSkipped: measurement?.symlinksSkipped,
             measurementTruncated: measurement?.truncated,
+            ...(claudeRetention !== undefined && usesClaudeNativeRetention(candidate.relativePath)
+              ? { nativeRetention: claudeRetention.facts }
+              : {}),
             ...(databaseInspection === undefined
               ? {}
               : {
@@ -357,6 +372,9 @@ export class ProviderAuditAdapter implements AuditAdapter {
     const observedAt = context.now.toISOString();
     const providerFileIdentity = providerFileIdentitySchema.safeParse(
       resource.facts.providerFileIdentity,
+    );
+    const claudeNativeRetention = claudeNativeRetentionFactsSchema.safeParse(
+      resource.facts.nativeRetention,
     );
     const claudeProviderFileContract =
       typeof resource.facts.policyId === "string"
@@ -546,6 +564,45 @@ export class ProviderAuditAdapter implements AuditAdapter {
         candidateActions,
         measuredBytes: databaseIdentity.data.measuredBytes,
         estimatedReclaimBytes,
+        warnings: [],
+      };
+    }
+    if (this.spec.id === "claude" && claudeNativeRetention.success) {
+      const uncertain = !["missing", "valid"].includes(
+        claudeNativeRetention.data.userSettingsStatus,
+      );
+      const configuredDays = claudeNativeRetention.data.userConfiguredDays;
+      return {
+        schemaVersion: 1,
+        findingId: `${resource.resource.id}:${sha256(context.auditId)}`,
+        auditId: context.auditId,
+        observedAt,
+        resource: resource.resource,
+        state: "protected",
+        confidence: uncertain ? "unknown" : "high",
+        roots: [
+          {
+            code: uncertain
+              ? "claude-native-retention-uncertain"
+              : "claude-native-retention-expected",
+            source: this.id,
+            observedAt,
+            detail: uncertain
+              ? "Claude user settings could not be validated; Claude may pause native cleanup unless managed settings provide cleanupPeriodDays."
+              : configuredDays === undefined
+                ? "Claude documents a 30-day startup retention sweep; managed and project overrides were not resolved."
+                : `Claude user settings declare a ${configuredDays}-day startup retention sweep; managed and project overrides were not resolved.`,
+          },
+          {
+            code: "provider-owned-report-only",
+            source: this.id,
+            observedAt,
+            detail: "Claude owns this retention sweep; AgentRinse does not mutate the resource.",
+          },
+        ],
+        facts: resource.facts,
+        candidateActions: [],
+        ...(resource.measuredBytes === undefined ? {} : { measuredBytes: resource.measuredBytes }),
         warnings: [],
       };
     }

--- a/src/adapters/provider-specs.ts
+++ b/src/adapters/provider-specs.ts
@@ -85,6 +85,16 @@ export const PROVIDER_SPECS: Record<ProviderAdapterId, ProviderSpec> = {
         displayName: "Claude managed worktrees",
         kind: "git-worktree",
       },
+      {
+        relativePath: "paste-cache",
+        displayName: "Claude paste cache",
+        kind: "agent-cache",
+      },
+      {
+        relativePath: "image-cache",
+        displayName: "Claude image cache",
+        kind: "agent-cache",
+      },
     ],
   },
   cursor: {

--- a/test/adapters/claude-retention.test.ts
+++ b/test/adapters/claude-retention.test.ts
@@ -47,10 +47,15 @@ describe("Claude native retention reporting", () => {
     );
     const finding = await claude.classify(context, sessions!);
 
-    expect(nativeResources).toHaveLength(5);
+    expect(nativeResources).toHaveLength(4);
     expect(
       nativeResources.filter((resource) => resource.resource.kind === "agent-cache"),
     ).toHaveLength(2);
+    expect(
+      nativeResources.some(
+        (resource) => resource.resource.displayName === "Claude managed worktrees",
+      ),
+    ).toBe(false);
     expect(sessions?.facts.nativeRetention).toEqual({
       mechanism: "cleanupPeriodDays",
       documentedDefaultDays: 30,
@@ -162,11 +167,21 @@ describe("Claude native retention reporting", () => {
     const before = await lstat(settingsPath);
     const after = await lstat(changedPath);
     const stat = vi.fn().mockResolvedValueOnce(before).mockResolvedValueOnce(after);
+    const payload = Buffer.from('{"cleanupPeriodDays":45}\n');
+    const read = vi.fn(
+      async (buffer: Buffer, offset: number, _length: number, position: number) => {
+        if (position > 0) {
+          return { bytesRead: 0, buffer };
+        }
+        payload.copy(buffer, offset);
+        return { bytesRead: payload.length, buffer };
+      },
+    );
     const dependencies = {
       lstat: async () => before,
       open: async () => ({
         stat,
-        readFile: async () => '{"cleanupPeriodDays":45}\n',
+        read,
         close: async () => undefined,
       }),
     } as unknown as ClaudeRetentionDependencies;
@@ -178,5 +193,37 @@ describe("Claude native retention reporting", () => {
       expect.objectContaining({ code: "CLAUDE_RETENTION_SETTINGS_CHANGED" }),
     );
     expect(stat).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds a growing settings read to one byte beyond the inspection limit", async () => {
+    const context = await fixtureContext();
+    const root = join(context.home, ".claude");
+    const settingsPath = join(root, "settings.json");
+    await mkdir(root);
+    await writeFile(settingsPath, "{}\n");
+    const stats = await lstat(settingsPath);
+    const read = vi.fn(
+      async (buffer: Buffer, _offset: number, length: number, _position: number) => ({
+        bytesRead: length,
+        buffer,
+      }),
+    );
+    const dependencies = {
+      lstat: async () => stats,
+      open: async () => ({
+        stat: async () => stats,
+        read,
+        close: async () => undefined,
+      }),
+    } as unknown as ClaudeRetentionDependencies;
+
+    const result = await inspectClaudeNativeRetention(root, "darwin", dependencies);
+
+    expect(result.facts.userSettingsStatus).toBe("too-large");
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ code: "CLAUDE_RETENTION_SETTINGS_TOO_LARGE" }),
+    );
+    expect(read).toHaveBeenCalledOnce();
+    expect(read.mock.calls[0]?.[2]).toBe(1024 * 1024 + 1);
   });
 });

--- a/test/adapters/claude-retention.test.ts
+++ b/test/adapters/claude-retention.test.ts
@@ -1,0 +1,182 @@
+import { lstat, mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { ProviderAuditAdapter } from "../../src/adapters/provider-adapter.js";
+import {
+  inspectClaudeNativeRetention,
+  type ClaudeRetentionDependencies,
+} from "../../src/adapters/claude-retention.js";
+import { PROVIDER_SPECS } from "../../src/adapters/provider-specs.js";
+import type { AuditContext } from "../../src/contracts/adapter.js";
+
+async function fixtureContext(): Promise<AuditContext> {
+  return {
+    home: await mkdtemp(join(tmpdir(), "agentrinse-claude-retention-")),
+    now: new Date("2026-07-27T00:00:00.000Z"),
+    auditId: "audit-claude-retention",
+  };
+}
+
+function adapter(): ProviderAuditAdapter {
+  return new ProviderAuditAdapter(PROVIDER_SPECS.claude, {
+    environment: {},
+    measureBytes: true,
+    maxEntries: 100,
+  });
+}
+
+describe("Claude native retention reporting", () => {
+  it("reports the documented default for native-cleaned resources without mutating them", async () => {
+    const context = await fixtureContext();
+    const root = join(context.home, ".claude");
+    for (const relativePath of ["projects", "debug", "worktrees", "paste-cache", "image-cache"]) {
+      await mkdir(join(root, relativePath), { recursive: true });
+    }
+    const claude = adapter();
+
+    const probe = await claude.probe(context);
+    const collection = await claude.collect(context, probe);
+    const nativeResources = collection.resources.filter(
+      (resource) => resource.facts.nativeRetention !== undefined,
+    );
+    const sessions = nativeResources.find(
+      (resource) => resource.resource.displayName === "Claude project sessions",
+    );
+    const finding = await claude.classify(context, sessions!);
+
+    expect(nativeResources).toHaveLength(5);
+    expect(
+      nativeResources.filter((resource) => resource.resource.kind === "agent-cache"),
+    ).toHaveLength(2);
+    expect(sessions?.facts.nativeRetention).toEqual({
+      mechanism: "cleanupPeriodDays",
+      documentedDefaultDays: 30,
+      startupSweep: true,
+      effectiveDaysKnown: false,
+      userSettingsStatus: "missing",
+    });
+    expect(finding).toMatchObject({
+      state: "protected",
+      confidence: "high",
+      roots: [{ code: "claude-native-retention-expected" }, { code: "provider-owned-report-only" }],
+      candidateActions: [],
+    });
+  });
+
+  it("reports a valid user cleanup period without claiming it is globally effective", async () => {
+    const context = await fixtureContext();
+    const root = join(context.home, ".claude");
+    await mkdir(join(root, "projects"), { recursive: true });
+    await writeFile(join(root, "settings.json"), '{"cleanupPeriodDays":45}\n');
+    const claude = adapter();
+
+    const probe = await claude.probe(context);
+    const collection = await claude.collect(context, probe);
+    const sessions = collection.resources.find(
+      (resource) => resource.resource.displayName === "Claude project sessions",
+    );
+    const finding = await claude.classify(context, sessions!);
+
+    expect(sessions?.facts.nativeRetention).toMatchObject({
+      userSettingsStatus: "valid",
+      userConfiguredDays: 45,
+      effectiveDaysKnown: false,
+    });
+    expect(finding.roots[0]).toMatchObject({
+      code: "claude-native-retention-expected",
+      detail:
+        "Claude user settings declare a 45-day startup retention sweep; managed and project overrides were not resolved.",
+    });
+    expect(finding.candidateActions).toEqual([]);
+  });
+
+  it.each([
+    ["malformed JSON", "{", "Claude user settings are not valid JSON"],
+    ["zero days", '{"cleanupPeriodDays":0}', "must be an integer of at least 1"],
+    ["fractional days", '{"cleanupPeriodDays":1.5}', "must be an integer of at least 1"],
+  ])("reports uncertain native cleanup for %s", async (_name, contents, message) => {
+    const context = await fixtureContext();
+    const root = join(context.home, ".claude");
+    await mkdir(join(root, "projects"), { recursive: true });
+    await writeFile(join(root, "settings.json"), contents);
+    const claude = adapter();
+
+    const probe = await claude.probe(context);
+    const collection = await claude.collect(context, probe);
+    const sessions = collection.resources.find(
+      (resource) => resource.resource.displayName === "Claude project sessions",
+    );
+    const finding = await claude.classify(context, sessions!);
+
+    expect(collection.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "CLAUDE_RETENTION_SETTINGS_INVALID",
+        message: expect.stringContaining(message),
+      }),
+    );
+    expect(sessions?.facts.nativeRetention).toMatchObject({
+      userSettingsStatus: "invalid",
+      effectiveDaysKnown: false,
+    });
+    expect(finding).toMatchObject({
+      state: "protected",
+      confidence: "unknown",
+      candidateActions: [],
+    });
+    expect(finding.roots.map((root) => root.code)).toEqual([
+      "claude-native-retention-uncertain",
+      "provider-owned-report-only",
+    ]);
+  });
+
+  it("does not follow a symlinked Claude settings file", async () => {
+    const context = await fixtureContext();
+    const root = join(context.home, ".claude");
+    const outside = join(context.home, "outside-settings.json");
+    await mkdir(root);
+    await writeFile(outside, '{"cleanupPeriodDays":1}\n');
+    await symlink(outside, join(root, "settings.json"));
+
+    const result = await inspectClaudeNativeRetention(root);
+
+    expect(result.facts).toMatchObject({
+      userSettingsStatus: "unsupported",
+      effectiveDaysKnown: false,
+    });
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ code: "CLAUDE_RETENTION_SETTINGS_UNSUPPORTED" }),
+    );
+  });
+
+  it("rejects settings that change while being read", async () => {
+    const context = await fixtureContext();
+    const root = join(context.home, ".claude");
+    const settingsPath = join(root, "settings.json");
+    const changedPath = join(root, "changed-settings.json");
+    await mkdir(root);
+    await writeFile(settingsPath, '{"cleanupPeriodDays":45}\n');
+    await writeFile(changedPath, '{"cleanupPeriodDays":120,"changed":true}\n');
+    const before = await lstat(settingsPath);
+    const after = await lstat(changedPath);
+    const stat = vi.fn().mockResolvedValueOnce(before).mockResolvedValueOnce(after);
+    const dependencies = {
+      lstat: async () => before,
+      open: async () => ({
+        stat,
+        readFile: async () => '{"cleanupPeriodDays":45}\n',
+        close: async () => undefined,
+      }),
+    } as unknown as ClaudeRetentionDependencies;
+
+    const result = await inspectClaudeNativeRetention(root, "darwin", dependencies);
+
+    expect(result.facts.userSettingsStatus).toBe("changed");
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ code: "CLAUDE_RETENTION_SETTINGS_CHANGED" }),
+    );
+    expect(stat).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/adapters/claude-retention.test.ts
+++ b/test/adapters/claude-retention.test.ts
@@ -137,6 +137,41 @@ describe("Claude native retention reporting", () => {
     ]);
   });
 
+  it("reports additional settings fields as unverified instead of validating the whole file", async () => {
+    const context = await fixtureContext();
+    const root = join(context.home, ".claude");
+    await mkdir(join(root, "projects"), { recursive: true });
+    await writeFile(join(root, "settings.json"), '{"cleanupPeriodDays":45,"permissions":1}\n');
+    const claude = adapter();
+
+    const probe = await claude.probe(context);
+    const collection = await claude.collect(context, probe);
+    const sessions = collection.resources.find(
+      (resource) => resource.resource.displayName === "Claude project sessions",
+    );
+    const finding = await claude.classify(context, sessions!);
+
+    expect(collection.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "CLAUDE_RETENTION_SETTINGS_UNVERIFIED",
+      }),
+    );
+    expect(sessions?.facts.nativeRetention).toMatchObject({
+      userSettingsStatus: "unverified",
+      userConfiguredDays: 45,
+      effectiveDaysKnown: false,
+    });
+    expect(finding).toMatchObject({
+      state: "protected",
+      confidence: "unknown",
+      roots: [
+        { code: "claude-native-retention-uncertain" },
+        { code: "provider-owned-report-only" },
+      ],
+      candidateActions: [],
+    });
+  });
+
   it("does not follow a symlinked Claude settings file", async () => {
     const context = await fixtureContext();
     const root = join(context.home, ".claude");

--- a/test/adapters/claude-retention.test.ts
+++ b/test/adapters/claude-retention.test.ts
@@ -88,7 +88,7 @@ describe("Claude native retention reporting", () => {
     expect(finding.roots[0]).toMatchObject({
       code: "claude-native-retention-expected",
       detail:
-        "Claude user settings declare a 45-day startup retention sweep; managed and project overrides were not resolved.",
+        "Claude user settings declare a 45-day startup retention sweep; higher-precedence settings were not resolved.",
     });
     expect(finding.candidateActions).toEqual([]);
   });


### PR DESCRIPTION
## Summary

- report Claude native startup retention for project sessions, debug data, paste cache, and image cache
- inventory `paste-cache` and `image-cache` without creating cleanup actions
- inspect only a bounded, stable, direct user `settings.json` and preserve higher-precedence uncertainty
- keep global managed-worktree inventory outside this repository-scoped retention claim

## Owner evidence

Claude documents `cleanupPeriodDays` with a 30-day default and startup cleanup for old application data. The application-data reference identifies project JSONL, debug data, paste cache, and image cache as Claude-owned data. AgentRinse reports that contract but does not replace Claude cleanup.

- https://code.claude.com/docs/en/settings
- https://code.claude.com/docs/en/claude-directory

## Safety boundary

- report-only; every finding has zero candidate actions
- no JSONL, transcript, credential, settings, or cache mutation
- reads at most 1 MiB plus one overflow byte from one direct regular settings file
- rejects symlinks and changed, unreadable, oversized, or malformed files
- reports additional settings fields as whole-file-unverified instead of cloning Claude's full settings schema
- reports observed user retention without claiming it is globally effective

## Verification

- 61 test files / 442 tests
- format, lint, typecheck, and build
- 9 generated schemas verified
- package manifest and publint
- `npm pack --dry-run` for `agentrinse@0.4.0`
- autoreview clean after fixing bounded-read, worktree-scope, and whole-settings-validity findings

Part of #16