### PR TITLE
fix(copilot): honor configured data root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ The project follows semantic versioning after its first supported release.
 - Claude discovery and provider-file authorization now share explicit root,
   absolute `CLAUDE_CONFIG_DIR`, and `$HOME/.claude` precedence and fail closed
   on relative environment values
+- Copilot discovery now honors explicit root, absolute `COPILOT_HOME`, and
+  `$HOME/.copilot` precedence and fails closed on relative environment values
 
 ### Safety
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,7 +101,9 @@ Codex, Claude Code, Cursor, GitHub Copilot CLI, Zed, OpenCode, and Grok Build
 are enabled for inventory by default. Each accepts an optional `root`. Claude
 resolves its root from the explicit adapter `root`, then an absolute
 `$CLAUDE_CONFIG_DIR`, then `$HOME/.claude`. A relative `$CLAUDE_CONFIG_DIR`
-degrades the Claude adapter rather than auditing the wrong directory. The same
+degrades the Claude adapter rather than auditing the wrong directory. Copilot
+uses the same explicit-root precedence with absolute `$COPILOT_HOME`, then
+`$HOME/.copilot`; a relative value degrades only the Copilot adapter. The same
 resolution is repeated before any provider-file action is authorized. Claude
 debug-log quarantine requires `plan --max-risk recoverable` and matching apply
 authorization. Missing default roots mean the provider is absent, not broken.

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -1276,7 +1276,9 @@ Claude root precedence is the explicit adapter root, an absolute
 `$CLAUDE_CONFIG_DIR` is invalid and degrades only the Claude adapter. Discovery
 and mutation authorization use the same resolver.
 
-`$COPILOT_HOME` falls back to `$HOME/.copilot`.
+Copilot root precedence is the explicit adapter root, an absolute
+`$COPILOT_HOME`, then `$HOME/.copilot`. A relative `$COPILOT_HOME` is invalid
+and degrades only the Copilot adapter.
 
 `$GROK_HOME` falls back to `$HOME/.grok`.
 

--- a/src/adapters/provider-root.ts
+++ b/src/adapters/provider-root.ts
@@ -8,6 +8,16 @@ export type ProviderRootOptions = {
   platform?: NodeJS.Platform;
 };
 
+function providerRootEnvironment(spec: ProviderSpec): string | undefined {
+  if (spec.id === "claude") {
+    return "CLAUDE_CONFIG_DIR";
+  }
+  if (spec.id === "copilot") {
+    return "COPILOT_HOME";
+  }
+  return undefined;
+}
+
 export function resolveProviderRoot(
   spec: ProviderSpec,
   home: string,
@@ -16,11 +26,12 @@ export function resolveProviderRoot(
   if (options.root !== undefined) {
     return resolve(options.root);
   }
-  if (spec.id === "claude") {
-    const configuredRoot = options.environment?.CLAUDE_CONFIG_DIR;
+  const environmentVariable = providerRootEnvironment(spec);
+  if (environmentVariable !== undefined) {
+    const configuredRoot = options.environment?.[environmentVariable];
     if (configuredRoot !== undefined && configuredRoot !== "") {
       if (!isAbsolute(configuredRoot)) {
-        throw new Error("CLAUDE_CONFIG_DIR must be an absolute path");
+        throw new Error(`${environmentVariable} must be an absolute path`);
       }
       return resolve(configuredRoot);
     }

--- a/test/adapters/provider-adapter.test.ts
+++ b/test/adapters/provider-adapter.test.ts
@@ -149,6 +149,46 @@ describe("ProviderAuditAdapter", () => {
     expect(probe).toMatchObject({ status: "available", root });
   });
 
+  it("uses COPILOT_HOME as the default Copilot root", async () => {
+    const context = await fixtureContext();
+    const root = join(context.home, "copilot-state");
+    await mkdir(join(root, "session-state"), { recursive: true });
+    const adapter = new ProviderAuditAdapter(PROVIDER_SPECS.copilot, {
+      environment: { COPILOT_HOME: root },
+      measureBytes: true,
+      maxEntries: 100,
+    });
+
+    const probe = await adapter.probe(context);
+    const collection = await adapter.collect(context, probe);
+
+    expect(probe).toMatchObject({ status: "available", root });
+    expect(collection.resources[0]?.resource.path).toBe(join(root, "session-state"));
+  });
+
+  it("fails closed for a relative COPILOT_HOME", async () => {
+    const context = await fixtureContext();
+    const adapter = new ProviderAuditAdapter(PROVIDER_SPECS.copilot, {
+      environment: { COPILOT_HOME: "relative/copilot-state" },
+      measureBytes: true,
+      maxEntries: 100,
+    });
+
+    const probe = await adapter.probe(context);
+
+    expect(probe).toMatchObject({
+      status: "degraded",
+      detail: "GitHub Copilot CLI root configuration is invalid",
+      diagnostics: [
+        {
+          code: "PROVIDER_ROOT_INVALID",
+          message: "COPILOT_HOME must be an absolute path",
+        },
+      ],
+    });
+    expect((await adapter.collect(context, probe)).resources).toEqual([]);
+  });
+
   it("proposes an experimental offline vacuum only with explicit authorization", async () => {
     const context = await fixtureContext();
     const path = join(context.home, ".codex", "state_5.sqlite");

--- a/test/adapters/provider-root.test.ts
+++ b/test/adapters/provider-root.test.ts
@@ -36,4 +36,37 @@ describe("resolveProviderRoot", () => {
       }),
     ).toThrow("CLAUDE_CONFIG_DIR must be an absolute path");
   });
+
+  it("prefers an explicit root over COPILOT_HOME", () => {
+    expect(
+      resolveProviderRoot(PROVIDER_SPECS.copilot, "/fixture/home", {
+        root: "/fixture/configured-copilot",
+        environment: { COPILOT_HOME: "/fixture/environment-copilot" },
+      }),
+    ).toBe("/fixture/configured-copilot");
+  });
+
+  it("uses an absolute COPILOT_HOME before the default", () => {
+    expect(
+      resolveProviderRoot(PROVIDER_SPECS.copilot, "/fixture/home", {
+        environment: { COPILOT_HOME: "/fixture/environment-copilot" },
+      }),
+    ).toBe("/fixture/environment-copilot");
+  });
+
+  it("falls back to the Copilot directory under the audited home", () => {
+    expect(
+      resolveProviderRoot(PROVIDER_SPECS.copilot, "/fixture/home", {
+        environment: {},
+      }),
+    ).toBe("/fixture/home/.copilot");
+  });
+
+  it("rejects a relative COPILOT_HOME", () => {
+    expect(() =>
+      resolveProviderRoot(PROVIDER_SPECS.copilot, "/fixture/home", {
+        environment: { COPILOT_HOME: "relative/copilot" },
+      }),
+    ).toThrow("COPILOT_HOME must be an absolute path");
+  });
 });


### PR DESCRIPTION
## Summary

- resolve Copilot state from explicit adapter root, then absolute `COPILOT_HOME`, then the audited home
- fail closed on relative `COPILOT_HOME` values instead of auditing the wrong directory
- document the provider-root precedence

## Owner evidence

GitHub documents `COPILOT_HOME` as the complete override for the default `~/.copilot` configuration directory.

- https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference

## Safety

This remains inventory-only. The change affects discovery only and does not create actions or mutate Copilot state.

## Verification

- 61 test files / 448 tests
- format, lint, typecheck, and build
- 9 schemas verified
- package manifest, publint, and npm pack dry run
- autoreview clean

Part of #16