### PR TITLE
feat(copilot): report native maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The project follows semantic versioning after its first supported release.
 - report-only Claude native retention findings for sessions, debug data, paste
   cache, and image cache, including the documented default and any valid user
   `cleanupPeriodDays`
+- report-only Copilot native maintenance findings for local session pruning and
+  the versioned direct process-log startup sweep
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -56,28 +56,29 @@ provider state is report-only unless the table below says otherwise.
 agentrinse never erases transcripts, sessions, credentials, configuration, or
 logical memory records.
 
-| Logo                                                                        | Client                                                      | Mode                   | What it protects                                                    |
-| --------------------------------------------------------------------------- | ----------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------- |
-| <img width="48px" src="docs/client-openai.jpg" alt="OpenAI Codex" />        | [OpenAI Codex](https://github.com/openai/codex)             | audit + offline vacuum | sessions, workspace roots, reachability, and supported SQLite state |
-| <img width="48px" src="docs/client-claude.jpg" alt="Claude Code" />         | [Claude Code](https://code.claude.com/docs/en/overview)     | retention + quarantine | sessions, caches, roots, native retention, and exact old files      |
-| <img width="48px" src="docs/client-cursor.jpg" alt="Cursor" />              | [Cursor](https://cursor.com/docs)                           | audit-only             | local agent state and workspace references                          |
-| <img width="48px" src="docs/client-copilot.png" alt="GitHub Copilot CLI" /> | [GitHub Copilot CLI](https://github.com/github/copilot-cli) | audit-only             | local session and configuration state                               |
-| <img width="48px" src="docs/client-zed.svg" alt="Zed" />                    | [Zed](https://zed.dev/docs/ai/overview)                     | audit-only             | local agent state                                                   |
-| <img width="48px" src="docs/client-opencode.png" alt="OpenCode" />          | [OpenCode](https://opencode.ai/)                            | audit-only             | local agent state                                                   |
-| <img width="48px" src="docs/client-grok-build.svg" alt="Grok Build" />      | [Grok Build](https://docs.x.ai/build/overview)              | audit-only             | local agent state                                                   |
+| Logo                                                                        | Client                                                      | Mode                    | What it protects                                                    |
+| --------------------------------------------------------------------------- | ----------------------------------------------------------- | ----------------------- | ------------------------------------------------------------------- |
+| <img width="48px" src="docs/client-openai.jpg" alt="OpenAI Codex" />        | [OpenAI Codex](https://github.com/openai/codex)             | audit + offline vacuum  | sessions, workspace roots, reachability, and supported SQLite state |
+| <img width="48px" src="docs/client-claude.jpg" alt="Claude Code" />         | [Claude Code](https://code.claude.com/docs/en/overview)     | retention + quarantine  | sessions, caches, roots, native retention, and exact old files      |
+| <img width="48px" src="docs/client-cursor.jpg" alt="Cursor" />              | [Cursor](https://cursor.com/docs)                           | audit-only              | local agent state and workspace references                          |
+| <img width="48px" src="docs/client-copilot.png" alt="GitHub Copilot CLI" /> | [GitHub Copilot CLI](https://github.com/github/copilot-cli) | audit + native guidance | local sessions, process logs, and provider-owned maintenance        |
+| <img width="48px" src="docs/client-zed.svg" alt="Zed" />                    | [Zed](https://zed.dev/docs/ai/overview)                     | audit-only              | local agent state                                                   |
+| <img width="48px" src="docs/client-opencode.png" alt="OpenCode" />          | [OpenCode](https://opencode.ai/)                            | audit-only              | local agent state                                                   |
+| <img width="48px" src="docs/client-grok-build.svg" alt="Grok Build" />      | [Grok Build](https://docs.x.ai/build/overview)              | audit-only              | local agent state                                                   |
 
 ## cleanup surfaces
 
-| Icon                                                                 | Surface                              | Mode               | What it understands                                                     |
-| -------------------------------------------------------------------- | ------------------------------------ | ------------------ | ----------------------------------------------------------------------- |
-| 🌿                                                                   | Git worktrees                        | audit + quarantine | linked worktrees, refs, dirtiness, locks, processes, and provider roots |
-| 🧹                                                                   | Build artifacts                      | safe-clean         | exact configured rebuildable directories                                |
-| 🗜️                                                                   | Codex SQLite state                   | experimental       | schema versions, free pages, sidecars, owner processes, and rollback    |
-| <img width="48px" src="docs/client-claude.jpg" alt="Claude Code" />  | Claude native retention              | report-only        | default or user retention, settings validity, and provider ownership    |
-| <img width="48px" src="docs/client-claude.jpg" alt="Claude Code" />  | Claude logs and changelog cache      | recoverable        | exact old files, provider liveness, seven-day undo, and explicit purge  |
-| ⚡                                                                   | Agent runtimes                       | audit-only, opt-in | installed agent executables and versions                                |
-| <img width="48px" src="docs/client-docker-agent.svg" alt="Docker" /> | [Docker](https://docs.docker.com/)   | audit-only, opt-in | images and containers                                                   |
-| 🕳️                                                                   | [Mole](https://github.com/tw93/Mole) | suggestions only   | external dry-run cleanup opportunities on macOS                         |
+| Icon                                                                        | Surface                              | Mode               | What it understands                                                     |
+| --------------------------------------------------------------------------- | ------------------------------------ | ------------------ | ----------------------------------------------------------------------- |
+| 🌿                                                                          | Git worktrees                        | audit + quarantine | linked worktrees, refs, dirtiness, locks, processes, and provider roots |
+| 🧹                                                                          | Build artifacts                      | safe-clean         | exact configured rebuildable directories                                |
+| 🗜️                                                                          | Codex SQLite state                   | experimental       | schema versions, free pages, sidecars, owner processes, and rollback    |
+| <img width="48px" src="docs/client-claude.jpg" alt="Claude Code" />         | Claude native retention              | report-only        | default or user retention, settings validity, and provider ownership    |
+| <img width="48px" src="docs/client-claude.jpg" alt="Claude Code" />         | Claude logs and changelog cache      | recoverable        | exact old files, provider liveness, seven-day undo, and explicit purge  |
+| <img width="48px" src="docs/client-copilot.png" alt="GitHub Copilot CLI" /> | Copilot native maintenance           | report-only        | local session pruning and versioned process-log retention               |
+| ⚡                                                                          | Agent runtimes                       | audit-only, opt-in | installed agent executables and versions                                |
+| <img width="48px" src="docs/client-docker-agent.svg" alt="Docker" />        | [Docker](https://docs.docker.com/)   | audit-only, opt-in | images and containers                                                   |
+| 🕳️                                                                          | [Mole](https://github.com/tw93/Mole) | suggestions only   | external dry-run cleanup opportunities on macOS                         |
 
 ## install
 

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -11,7 +11,7 @@ is proven.
 | Codex          | sessions, worktrees, four SQLite DBs, offline compaction  | conditional     |
 | Claude         | sessions, caches, native retention, exact file quarantine | conditional     |
 | Cursor         | workspace state, global state, logs                       | all             |
-| GitHub Copilot | CLI sessions and logs                                     | all             |
+| GitHub Copilot | CLI sessions, logs, native maintenance guidance           | all             |
 | Zed            | user-data root                                            | all             |
 | OpenCode       | database, logs, snapshots                                 | all             |
 | Grok Build     | version-gated data root                                   | all             |
@@ -90,7 +90,15 @@ does not make workspace storage disposable.
 ### GitHub Copilot
 
 Configuration, authentication, custom agents, skills, and plugins are
-permanent protection roots. Sessions and logs are only inventoried.
+permanent protection roots. Sessions and logs remain report-only.
+
+AgentRinse reports Copilot's local-only `/session prune` command, including
+dry-run support and the default protection for named and current sessions. It
+also reports the process-log startup retention introduced in Copilot CLI
+`1.0.52`: direct `process-*.log` files older than seven days or beyond the
+newest 50 are provider-pruned, while extension logs are outside that contract.
+The provider adapter does not execute Copilot to determine its installed
+version, so both findings stay unknown-confidence and emit no action.
 
 ### Zed
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -2061,8 +2061,12 @@ Inventory:
   protected
 - cloud-synced status is not evidence that a local session may be deleted
 - editor extension logs inherit the host editor's lifecycle
-- CLI logs may become a safe age-filtered action after exact current CLI
-  retention behavior is tested
+- report the local-only `/session prune --older-than <days>` owner command,
+  including dry-run support and named-session opt-in
+- report the `1.0.52+` process-log startup sweep for direct `process-*.log`
+  files older than seven days or beyond the newest 50
+- keep both findings unknown-confidence until installed CLI support is proven
+- extension logs remain outside the process-log startup sweep
 
 AgentRinse should prefer Copilot CLI commands or documented configuration
 paths over inspecting undocumented editor database keys.

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -100,6 +100,13 @@ signal. Malformed, unreadable, changing, symlinked, oversized, invalid, or
 unverified settings downgrade the finding to unknown confidence. AgentRinse
 does not substitute the default or emit a cleanup action in that state.
 
+Copilot native maintenance is also report-only. AgentRinse records the
+local-only session-prune contract and the process-log startup retention
+introduced in Copilot CLI `1.0.52`, but does not execute the installed CLI to
+prove support. These findings remain unknown-confidence and emit no action.
+Synced sessions, named sessions, the current session, extension logs, and
+Copilot configuration remain protected.
+
 ## Recoverable Codex Database Boundary
 
 `database.vacuum` is `experimental` and excluded by every lower risk ceiling.

--- a/src/adapters/copilot-maintenance.ts
+++ b/src/adapters/copilot-maintenance.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+
+const copilotSessionPruneFactsSchema = z.object({
+  provider: z.literal("copilot"),
+  kind: z.literal("session-prune"),
+  command: z.literal("/session prune --older-than <days> [--dry-run] [--include-named]"),
+  localOnly: z.literal(true),
+  dryRunSupported: z.literal(true),
+  currentSessionExcluded: z.literal(true),
+  namedSessionsExcludedByDefault: z.literal(true),
+  installedSupportKnown: z.literal(false),
+});
+
+const copilotProcessLogRetentionFactsSchema = z.object({
+  provider: z.literal("copilot"),
+  kind: z.literal("process-log-retention"),
+  introducedVersion: z.literal("1.0.52"),
+  filePattern: z.literal("process-*.log"),
+  maxAgeDays: z.literal(7),
+  maxFiles: z.literal(50),
+  extensionLogsExcluded: z.literal(true),
+  installedSupportKnown: z.literal(false),
+});
+
+export const copilotNativeMaintenanceFactsSchema = z.discriminatedUnion("kind", [
+  copilotSessionPruneFactsSchema,
+  copilotProcessLogRetentionFactsSchema,
+]);
+
+export type CopilotNativeMaintenanceFacts = z.infer<typeof copilotNativeMaintenanceFactsSchema>;
+
+export function copilotNativeMaintenanceFor(
+  relativePath: string,
+): CopilotNativeMaintenanceFacts | undefined {
+  if (relativePath === "session-state") {
+    return {
+      provider: "copilot",
+      kind: "session-prune",
+      command: "/session prune --older-than <days> [--dry-run] [--include-named]",
+      localOnly: true,
+      dryRunSupported: true,
+      currentSessionExcluded: true,
+      namedSessionsExcludedByDefault: true,
+      installedSupportKnown: false,
+    };
+  }
+  if (relativePath === "logs") {
+    return {
+      provider: "copilot",
+      kind: "process-log-retention",
+      introducedVersion: "1.0.52",
+      filePattern: "process-*.log",
+      maxAgeDays: 7,
+      maxFiles: 50,
+      extensionLogsExcluded: true,
+      installedSupportKnown: false,
+    };
+  }
+  return undefined;
+}

--- a/src/adapters/provider-adapter.ts
+++ b/src/adapters/provider-adapter.ts
@@ -40,6 +40,10 @@ import {
   inspectClaudeNativeRetention,
   usesClaudeNativeRetention,
 } from "./claude-retention.js";
+import {
+  copilotNativeMaintenanceFactsSchema,
+  copilotNativeMaintenanceFor,
+} from "./copilot-maintenance.js";
 import { collectProviderReachability } from "./provider-reachability.js";
 import { resolveProviderRoot } from "./provider-root.js";
 import type { ProviderSpec } from "./provider-specs.js";
@@ -260,6 +264,10 @@ export class ProviderAuditAdapter implements AuditAdapter {
       context.signal?.throwIfAborted();
       const path =
         candidate.relativePath === "." ? probe.root : join(probe.root, candidate.relativePath);
+      const copilotNativeMaintenance =
+        this.spec.id === "copilot"
+          ? copilotNativeMaintenanceFor(candidate.relativePath)
+          : undefined;
 
       try {
         const stats = await lstat(path);
@@ -325,6 +333,9 @@ export class ProviderAuditAdapter implements AuditAdapter {
             ...(claudeRetention !== undefined && usesClaudeNativeRetention(candidate.relativePath)
               ? { nativeRetention: claudeRetention.facts }
               : {}),
+            ...(copilotNativeMaintenance === undefined
+              ? {}
+              : { nativeMaintenance: copilotNativeMaintenance }),
             ...(databaseInspection === undefined
               ? {}
               : {
@@ -375,6 +386,9 @@ export class ProviderAuditAdapter implements AuditAdapter {
     );
     const claudeNativeRetention = claudeNativeRetentionFactsSchema.safeParse(
       resource.facts.nativeRetention,
+    );
+    const copilotNativeMaintenance = copilotNativeMaintenanceFactsSchema.safeParse(
+      resource.facts.nativeMaintenance,
     );
     const claudeProviderFileContract =
       typeof resource.facts.policyId === "string"
@@ -598,6 +612,39 @@ export class ProviderAuditAdapter implements AuditAdapter {
             source: this.id,
             observedAt,
             detail: "Claude owns this retention sweep; AgentRinse does not mutate the resource.",
+          },
+        ],
+        facts: resource.facts,
+        candidateActions: [],
+        ...(resource.measuredBytes === undefined ? {} : { measuredBytes: resource.measuredBytes }),
+        warnings: [],
+      };
+    }
+    if (this.spec.id === "copilot" && copilotNativeMaintenance.success) {
+      const detail =
+        copilotNativeMaintenance.data.kind === "session-prune"
+          ? "Current Copilot CLI documents local-only session pruning with dry-run support; AgentRinse did not probe the installed CLI version."
+          : "Copilot CLI 1.0.52 introduced startup pruning for direct process logs older than seven days or beyond the newest 50; AgentRinse did not probe the installed CLI version.";
+      return {
+        schemaVersion: 1,
+        findingId: `${resource.resource.id}:${sha256(context.auditId)}`,
+        auditId: context.auditId,
+        observedAt,
+        resource: resource.resource,
+        state: "protected",
+        confidence: "unknown",
+        roots: [
+          {
+            code: "copilot-native-maintenance-version-unverified",
+            source: this.id,
+            observedAt,
+            detail,
+          },
+          {
+            code: "provider-owned-report-only",
+            source: this.id,
+            observedAt,
+            detail: "Copilot owns this maintenance path; AgentRinse does not mutate the resource.",
           },
         ],
         facts: resource.facts,

--- a/test/adapters/copilot-maintenance.test.ts
+++ b/test/adapters/copilot-maintenance.test.ts
@@ -1,0 +1,81 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ProviderAuditAdapter } from "../../src/adapters/provider-adapter.js";
+import { PROVIDER_SPECS } from "../../src/adapters/provider-specs.js";
+import type { AuditContext } from "../../src/contracts/adapter.js";
+
+async function fixtureContext(): Promise<AuditContext> {
+  return {
+    home: await mkdtemp(join(tmpdir(), "agentrinse-copilot-maintenance-")),
+    now: new Date("2026-07-27T00:00:00.000Z"),
+    auditId: "audit-copilot-maintenance",
+  };
+}
+
+describe("Copilot native maintenance reporting", () => {
+  it("reports native session and process-log maintenance without creating actions", async () => {
+    const context = await fixtureContext();
+    const root = join(context.home, "copilot-state");
+    await mkdir(join(root, "session-state"), { recursive: true });
+    await mkdir(join(root, "logs", "extensions"), { recursive: true });
+    await writeFile(join(root, "session-state", "session.jsonl"), "synthetic\n");
+    await writeFile(join(root, "logs", "process-1-2.log"), "synthetic\n");
+    await writeFile(join(root, "logs", "extensions", "extension.log"), "synthetic\n");
+    const adapter = new ProviderAuditAdapter(PROVIDER_SPECS.copilot, {
+      environment: { COPILOT_HOME: root },
+      measureBytes: true,
+      maxEntries: 100,
+    });
+
+    const probe = await adapter.probe(context);
+    const collection = await adapter.collect(context, probe);
+    const sessions = collection.resources.find(
+      (resource) => resource.resource.displayName === "Copilot CLI session state",
+    );
+    const logs = collection.resources.find(
+      (resource) => resource.resource.displayName === "Copilot CLI logs",
+    );
+    const findings = await Promise.all(
+      collection.resources.map((resource) => adapter.classify(context, resource)),
+    );
+
+    expect(sessions?.facts.nativeMaintenance).toEqual({
+      provider: "copilot",
+      kind: "session-prune",
+      command: "/session prune --older-than <days> [--dry-run] [--include-named]",
+      localOnly: true,
+      dryRunSupported: true,
+      currentSessionExcluded: true,
+      namedSessionsExcludedByDefault: true,
+      installedSupportKnown: false,
+    });
+    expect(logs?.facts.nativeMaintenance).toEqual({
+      provider: "copilot",
+      kind: "process-log-retention",
+      introducedVersion: "1.0.52",
+      filePattern: "process-*.log",
+      maxAgeDays: 7,
+      maxFiles: 50,
+      extensionLogsExcluded: true,
+      installedSupportKnown: false,
+    });
+    expect(findings).toHaveLength(2);
+    expect(
+      findings.every(
+        (finding) =>
+          finding.state === "protected" &&
+          finding.confidence === "unknown" &&
+          finding.candidateActions.length === 0,
+      ),
+    ).toBe(true);
+    expect(
+      findings.every(
+        (finding) => finding.roots[0]?.code === "copilot-native-maintenance-version-unverified",
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- report Copilot local session pruning on the `session-state` resource
- report versioned startup retention for direct process logs
- keep both findings unknown-confidence because the default provider adapter does not execute the installed CLI
- emit zero cleanup actions

## Owner evidence

GitHub documents that `/session prune` affects only local sessions and leaves synced copies untouched. The current Copilot CLI contract supports an age threshold, dry-run, named-session opt-in, and current-session exclusion. Copilot CLI `1.0.52` introduced startup pruning for direct `process-*.log` files older than seven days or beyond the newest 50; extension logs are outside that sweep.

- https://docs.github.com/en/copilot/concepts/agents/copilot-cli/chronicle
- https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference
- https://github.com/github/copilot-cli/blob/main/changelog.md

## Safety boundary

- report-only; no session, database, log, or configuration mutation
- no Copilot process execution from the default provider adapter
- installed support is explicitly unverified
- synced sessions, named sessions, the current session, and extension logs remain protected

## Verification

- 62 test files / 449 tests
- format, lint, typecheck, and build
- 9 schemas verified
- package manifest, publint, and npm pack dry run
- autoreview clean

Part of #16