### PR TITLE
chore(deps): keep Node types on release runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,10 @@ updates:
         dependency-type: development
       runtime-dependencies:
         dependency-type: production
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary

Keep `@types/node` on the Node 24 line used by CI and releases while continuing to accept 24.x minor and patch updates.

## Why

The package supports Node 22+ and validates/releases on Node 24. A Node 26 type surface could allow APIs that are unavailable on supported runtimes. This closes the recurrence behind #1 without freezing compatible updates.

## Validation

- parsed the Dependabot YAML and asserted the exact ignore rule
- `oxfmt --check .github/dependabot.yml`
- `git diff --check`
- autoreview clean (0.99 confidence)

Closes #1.