### PR TITLE
chore(release): prepare 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The project follows semantic versioning after its first supported release.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-28
+
 ### Added
 
 - `agent-cache` resource identity for provider-owned disposable cache artifacts

--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ protected or eligible, creates a content-addressed plan, and revalidates the
 same facts immediately before mutation.
 
 agentrinse is not audit-only. audit establishes the evidence; apply performs
-the approved filesystem, Git metadata, and offline database changes. `0.4.0`
-removes exact configured rebuildable artifacts, quarantines proven inactive linked
-worktrees, repairs and locks their Git registrations, restores quarantined
-worktrees, permanently purges explicitly selected quarantine entries, and
-compacts supported Codex SQLite state with a retained rollback copy.
+the approved filesystem, Git metadata, and offline database changes. `0.5.0`
+removes exact configured rebuildable artifacts, quarantines proven inactive
+linked worktrees, repairs and locks their Git registrations, restores
+quarantined worktrees, permanently purges explicitly selected quarantine
+entries, and compacts supported Codex SQLite state with a retained rollback
+copy. It also quarantines exact stale Claude debug logs and changelog cache
+files with a seven-day undo window.
 
 the point is confidence: make real cleanup changes without deleting the
 session, branch, worktree, database content, or cache that another agent still
@@ -33,22 +35,24 @@ optional external handoff for broader macOS and project debris.
 
 ## cleanup actions
 
-| Action                 | Risk         | What changes                                                                  | Recovery                                |
-| ---------------------- | ------------ | ----------------------------------------------------------------------------- | --------------------------------------- |
-| 🧹 artifact removal    | safe         | atomically isolates and removes an exact configured rebuildable directory     | rebuild from the project                |
-| 🌿 worktree quarantine | recoverable  | moves a linked worktree, creates a recovery ref, and repairs Git registration | `agentrinse undo <run-id>`              |
-| 🗜️ Codex DB vacuum     | experimental | builds and verifies a compacted SQLite copy, then retains the original file   | `agentrinse undo <run-id>` before reuse |
-| ↩️ worktree undo       | recoverable  | restores the worktree path and Git registration                               | original quarantine remains journaled   |
-| 🗑️ recovery purge      | destructive  | permanently removes an explicitly selected worktree or DB rollback copy       | none                                    |
-| ⚙️ config init         | operational  | creates the default config without overwriting an existing file               | edit or remove the generated config     |
-| 🔒 lock recovery       | operational  | removes only a stale AgentRinse lock after proving its process is gone        | rerun the interrupted command           |
+| Action                 | Risk         | What changes                                                                   | Recovery                                |
+| ---------------------- | ------------ | ------------------------------------------------------------------------------ | --------------------------------------- |
+| 🧹 artifact removal    | safe         | atomically isolates and removes an exact configured rebuildable directory      | rebuild from the project                |
+| 🌿 worktree quarantine | recoverable  | moves a linked worktree, creates a recovery ref, and repairs Git registration  | `agentrinse undo <run-id>`              |
+| 🧾 provider quarantine | recoverable  | moves an exact provider-owned disposable file into private recovery storage    | `agentrinse undo <run-id>`              |
+| 🗜️ Codex DB vacuum     | experimental | builds and verifies a compacted SQLite copy, then retains the original file    | `agentrinse undo <run-id>` before reuse |
+| ↩️ recovery undo       | recoverable  | restores a quarantined worktree, provider file, or database original           | recovery remains journaled              |
+| 🗑️ recovery purge      | destructive  | permanently removes an explicitly selected worktree, provider file, or DB copy | none                                    |
+| ⚙️ config init         | operational  | creates the default config without overwriting an existing file                | edit or remove the generated config     |
+| 🔒 lock recovery       | operational  | removes only a stale AgentRinse lock after proving its process is gone         | rerun the interrupted command           |
 
-Codex sessions and every other provider store remain report-only. `0.4.0`
-adds one narrow exception: explicit offline compaction for the exact current
-Codex `state_5`, `logs_2`, `goals_1`, and `memories_1` SQLite contracts. Claude
-cleanup is limited to exact old debug text files and its rebuildable changelog
-cache. AgentRinse also reports Claude's native retention policy for sessions,
-debug data, paste cache, and image cache. Docker remains audit-only.
+provider sessions, transcripts, credentials, configuration, and logical
+database records remain report-only. `0.5.0` supports explicit offline
+compaction for the exact current Codex `state_5`, `logs_2`, `goals_1`, and
+`memories_1` SQLite contracts. Claude cleanup is limited to exact old debug
+text files and its rebuildable changelog cache. AgentRinse also reports
+Claude's native retention policy and Copilot's native session and process-log
+maintenance. Docker remains audit-only.
 
 ## agent integrations
 
@@ -97,7 +101,7 @@ brew install vincentkoc/tap/agentrinse
 one-off use:
 
 ```bash
-npx agentrinse@0.4.0 doctor
+npx agentrinse@0.5.0 doctor
 ```
 
 then:
@@ -217,7 +221,7 @@ agentrinse is built around refusal:
 
 there is no generic `--force` escape hatch.
 
-agentrinse `0.4.0` never removes:
+agentrinse `0.5.0` never removes:
 
 - provider sessions, transcripts, logical database rows, credentials, or configuration
 - unsupported provider databases or Codex databases with unknown migrations
@@ -327,12 +331,12 @@ it can be verified before apply.
 
 ## platform support
 
-| Platform       | `0.4.0` support                                                |
-| -------------- | -------------------------------------------------------------- |
-| macOS          | audit, artifact/worktree cleanup, Codex DB vacuum, undo, purge |
-| Linux          | audit, artifact/worktree cleanup, Codex DB vacuum, undo, purge |
-| WSL            | Linux contract inside the WSL filesystem                       |
-| native Windows | audit-only; mutation remains blocked before `1.0.0`            |
+| Platform       | `0.5.0` support                                                 |
+| -------------- | --------------------------------------------------------------- |
+| macOS          | audit, artifact/worktree/Claude cleanup, DB vacuum, undo, purge |
+| Linux          | audit, artifact/worktree/Claude cleanup, DB vacuum, undo, purge |
+| WSL            | Linux contract inside the WSL filesystem                        |
+| native Windows | audit-only; mutation remains blocked before `1.0.0`             |
 
 Git and `lsof` are required for the complete diagnostic and process-ownership
 contract. Codex DB maintenance additionally requires `sqlite3`. Docker is
@@ -367,9 +371,9 @@ unreleased build at real developer state.
 
 ## status
 
-`0.4.0` ships the complete audit → plan → revalidate → apply loop, safe
-configured artifact cleanup, recoverable Git worktree quarantine, and
-recoverable offline Codex database compaction. Docker and non-Codex provider
-state remain report-only.
+`0.5.0` ships the complete audit → plan → revalidate → apply loop, safe
+configured artifact cleanup, recoverable Git worktree and Claude file
+quarantine, and recoverable offline Codex database compaction. Cursor, Zed,
+OpenCode, Grok Build, and Docker remain report-only.
 
 MIT licensed. built by [Vincent Koc](https://github.com/vincentkoc).

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -25,7 +25,7 @@ schemas.
 {
   "schemaVersion": 1,
   "command": "audit",
-  "agentrinseVersion": "0.4.0",
+  "agentrinseVersion": "0.5.0",
   "startedAt": "2026-07-24T00:00:00.000Z",
   "completedAt": "2026-07-24T00:00:01.000Z",
   "status": "ok",
@@ -95,7 +95,7 @@ resource is skipped rather than substituted.
 
 ## Exit Status
 
-Current `0.4.0` behavior:
+Current `0.5.0` behavior:
 
 | Code  | Meaning                                      |
 | ----- | -------------------------------------------- |

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -20,12 +20,13 @@ Run `agentrinse doctor` to verify the current machine without mutating it.
 
 ## macOS
 
-macOS is Tier 1 for `0.4.0`.
+macOS is Tier 1 for `0.5.0`.
 
 - provider, Git, Docker, and configured artifact inventory
 - `lsof` process ownership proof
 - safe configured artifact apply
 - recoverable linked-worktree quarantine, undo, and purge
+- recoverable exact Claude debug-log and changelog-cache quarantine
 - experimental recoverable offline Codex database compaction
 - optional Mole detection through `mo --version`
 - external `mo purge --dry-run` and `mo clean --dry-run` suggestions from the
@@ -36,13 +37,14 @@ cleanup.
 
 ## Linux
 
-Linux is Tier 2 for `0.4.0`.
+Linux is Tier 2 for `0.5.0`.
 
 - provider, Git, Docker, and configured artifact inventory
 - same-user `/proc` process ownership inspection
 - `lsof` fallback when procfs is incomplete or restricted
 - safe configured artifact apply
 - recoverable linked-worktree quarantine, undo, and purge
+- recoverable exact Claude debug-log and changelog-cache quarantine
 - experimental recoverable offline Codex database compaction
 
 If neither `/proc` nor `lsof` can prove a target idle, apply skips it.
@@ -54,13 +56,17 @@ automatically.
 ## WSL
 
 WSL follows the Linux contract for paths and processes inside the WSL
-filesystem. Do not use `0.4.0` to mutate Windows-mounted project trees unless
+filesystem. Do not use `0.5.0` to mutate Windows-mounted project trees unless
 doctor and a disposable canary prove path identity, ownership, rename, and
 mount behavior for that exact setup.
 
 ## Native Windows
 
 Native Windows is audit-only before `1.0.0`.
+
+Audit and plan evidence persists with verified current-user or local
+Administrators ownership and explicit current-user, `SYSTEM`, and
+Administrators access rules.
 
 Process start identity, descriptor ownership, path semantics, and atomic
 isolation have not reached the mutation proof bar. Doctor reports this
@@ -70,4 +76,4 @@ limitation and recommends WSL for supported artifact apply.
 
 When enabled, Docker uses the current CLI context and structured output.
 Unavailable CLI, context, or daemon state degrades only Docker inventory.
-`0.4.0` does not remove any Docker resource.
+`0.5.0` does not remove any Docker resource.

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -2,11 +2,11 @@
 
 Status: active implementation
 
-Target version: 0.4.0
+Target version: 0.5.0
 
 Created: 2026-07-23
 
-Updated: 2026-07-24
+Updated: 2026-07-28
 
 Owner: Vincent Koc
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentrinse",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": false,
   "description": "Safe, local-first cleanup for agentic development.",
   "keywords": [

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.4.0";
+export const VERSION = "0.5.0";


### PR DESCRIPTION
## Summary

- release recoverable Claude debug-log and changelog-cache quarantine
- document Claude/Copilot maintenance coverage and Windows ACL-backed audit persistence
- bump package, CLI, changelog, and release documentation to 0.5.0

## Safety

Provider sessions, transcripts, credentials, configuration, and logical database records remain protected. Claude mutation is limited to exact stale debug logs and rebuildable changelog-cache files, with process/descriptor/change revalidation and a seven-day undo window. Cursor, Zed, OpenCode, Grok Build, and Docker remain report-only.

## Validation

- `pnpm check`
- `pnpm smoke`
- `pnpm pack:check`
- `pnpm smoke:package`
- autoreview: clean, confidence 0.97
- AWS Crabbox Node 24.15.0 / pnpm 11.2.2: all four release gates passed
- Crabbox run: https://crabbox.openclaw.ai/portal/runs/run_efa701ef6776

## Release

After merge, create `v0.5.0`, verify GitHub/npm artifacts and checksum, then update the Homebrew formula to the exact release asset SHA-256.