### PR TITLE
feat(zed): quarantine stale rotated logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The project follows semantic versioning after its first supported release.
 
 ## [Unreleased]
 
+### Added
+
+- recoverable quarantine for the exact Zed `Zed.log.old` rotated application
+  log after 30 days, with a seven-day undo window before purge
+- Zed log-root discovery for the native macOS log directory, explicit
+  user-data roots, and absolute Flatpak/XDG data roots on Linux
+
+### Safety
+
+- Zed cleanup never enumerates the log directory and excludes the active
+  `Zed.log`, ACP logs, neighboring files, databases, threads, crash reports,
+  settings, credentials, extensions, active Zed processes, and open
+  descriptors
+
 ## [0.5.0] - 2026-07-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ entries, and compacts supported Codex SQLite state with a retained rollback
 copy. It also quarantines exact stale Claude debug logs and changelog cache
 files with a seven-day undo window.
 
+current main extends that recoverable boundary to Zed's exact stale
+`Zed.log.old` rotated application log. the latest published release remains
+`0.5.0`.
+
 the point is confidence: make real cleanup changes without deleting the
 session, branch, worktree, database content, or cache that another agent still
 needs.
@@ -66,7 +70,7 @@ logical memory records.
 | <img width="48px" src="docs/client-claude.jpg" alt="Claude Code" />         | [Claude Code](https://code.claude.com/docs/en/overview)     | retention + quarantine  | sessions, caches, roots, native retention, and exact old files      |
 | <img width="48px" src="docs/client-cursor.jpg" alt="Cursor" />              | [Cursor](https://cursor.com/docs)                           | audit-only              | local agent state and workspace references                          |
 | <img width="48px" src="docs/client-copilot.png" alt="GitHub Copilot CLI" /> | [GitHub Copilot CLI](https://github.com/github/copilot-cli) | audit + native guidance | local sessions, process logs, and provider-owned maintenance        |
-| <img width="48px" src="docs/client-zed.svg" alt="Zed" />                    | [Zed](https://zed.dev/docs/ai/overview)                     | audit-only              | local agent state                                                   |
+| <img width="48px" src="docs/client-zed.svg" alt="Zed" />                    | [Zed](https://zed.dev/docs/ai/overview)                     | audit + quarantine      | local agent state and the exact stale rotated application log       |
 | <img width="48px" src="docs/client-opencode.png" alt="OpenCode" />          | [OpenCode](https://opencode.ai/)                            | audit-only              | local agent state                                                   |
 | <img width="48px" src="docs/client-grok-build.svg" alt="Grok Build" />      | [Grok Build](https://docs.x.ai/build/overview)              | audit-only              | local agent state                                                   |
 
@@ -80,6 +84,7 @@ logical memory records.
 | <img width="48px" src="docs/client-claude.jpg" alt="Claude Code" />         | Claude native retention              | report-only        | default or user retention, settings validity, and provider ownership    |
 | <img width="48px" src="docs/client-claude.jpg" alt="Claude Code" />         | Claude logs and changelog cache      | recoverable        | exact old files, provider liveness, seven-day undo, and explicit purge  |
 | <img width="48px" src="docs/client-copilot.png" alt="GitHub Copilot CLI" /> | Copilot native maintenance           | report-only        | local session pruning and versioned process-log retention               |
+| <img width="48px" src="docs/client-zed.svg" alt="Zed" />                    | Zed rotated application log          | recoverable        | exact `Zed.log.old`, provider liveness, seven-day undo, and purge       |
 | ⚡                                                                          | Agent runtimes                       | audit-only, opt-in | installed agent executables and versions                                |
 | <img width="48px" src="docs/client-docker-agent.svg" alt="Docker" />        | [Docker](https://docs.docker.com/)   | audit-only, opt-in | images and containers                                                   |
 | 🕳️                                                                          | [Mole](https://github.com/tw93/Mole) | suggestions only   | external dry-run cleanup opportunities on macOS                         |
@@ -373,7 +378,8 @@ unreleased build at real developer state.
 
 `0.5.0` ships the complete audit → plan → revalidate → apply loop, safe
 configured artifact cleanup, recoverable Git worktree and Claude file
-quarantine, and recoverable offline Codex database compaction. Cursor, Zed,
-OpenCode, Grok Build, and Docker remain report-only.
+quarantine, and recoverable offline Codex database compaction. Current main
+also quarantines the exact stale Zed `Zed.log.old` file. Cursor, OpenCode, Grok
+Build, Docker, and all other Zed state remain report-only.
 
 MIT licensed. built by [Vincent Koc](https://github.com/vincentkoc).

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -1,10 +1,10 @@
 # Adapter Matrix
 
 Provider and Docker adapters are read-only except for versioned Codex database
-maintenance and exact Claude debug-log and changelog-cache quarantine. Artifact
-cleanup is scoped to explicitly configured rebuildable directories. The Git
-adapter can emit one recoverable whole-worktree action when every safety gate
-is proven.
+maintenance, exact Claude debug-log and changelog-cache quarantine, and the
+exact stale Zed rotated application log. Artifact cleanup is scoped to
+explicitly configured rebuildable directories. The Git adapter can emit one
+recoverable whole-worktree action when every safety gate is proven.
 
 | Adapter        | Current capability                                        | Protected state |
 | -------------- | --------------------------------------------------------- | --------------- |
@@ -12,7 +12,7 @@ is proven.
 | Claude         | sessions, caches, native retention, exact file quarantine | conditional     |
 | Cursor         | workspace state, global state, logs                       | all             |
 | GitHub Copilot | CLI sessions, logs, native maintenance guidance           | all             |
-| Zed            | user-data root                                            | all             |
+| Zed            | user-data root and exact rotated-log quarantine           | conditional     |
 | OpenCode       | database, logs, snapshots                                 | all             |
 | Grok Build     | version-gated data root                                   | all             |
 | Runtime        | opt-in selected executable and Claude native versions     | all             |
@@ -102,8 +102,21 @@ version, so both findings stay unknown-confidence and emit no action.
 
 ### Zed
 
-The user-data directory may be overridden. If the active directory cannot be
-resolved, discovery is incomplete and cleanup must fail closed.
+Zed keeps its native macOS application logs under
+`$HOME/Library/Logs/Zed`. Other platforms and explicit user-data roots keep
+logs under the resolved data root's `logs` directory. Linux data-root
+resolution honors absolute `FLATPAK_XDG_DATA_HOME` and `XDG_DATA_HOME` values.
+Relative environment paths make discovery incomplete.
+
+AgentRinse checks only the exact regular file `Zed.log.old`; it does not
+enumerate the log directory. The file may produce
+`provider.file-quarantine` after 30 days, with a seven-day undo window. The
+action is `recoverable`, requires an explicit recoverable risk ceiling, and
+requires all Zed and headless Zed processes stopped with no open descriptor.
+
+The active `Zed.log`, ACP logs, neighboring files, databases, threads, crash
+reports, settings, credentials, extensions, and every unknown Zed path remain
+protected.
 
 ### OpenCode
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,13 +104,20 @@ resolves its root from the explicit adapter `root`, then an absolute
 degrades the Claude adapter rather than auditing the wrong directory. Copilot
 uses the same explicit-root precedence with absolute `$COPILOT_HOME`, then
 `$HOME/.copilot`; a relative value degrades only the Copilot adapter. The same
-resolution is repeated before any provider-file action is authorized. Claude
-debug-log quarantine requires `plan --max-risk recoverable` and matching apply
-authorization. Missing default roots mean the provider is absent, not broken.
-Codex can propose offline database maintenance only with
+resolution is repeated before any provider-file action is authorized.
+
+Zed uses `$HOME/Library/Logs/Zed` as the native macOS log root. An explicit
+Zed adapter `root` uses its `logs` child. Linux and other Unix-like defaults
+use `FLATPAK_XDG_DATA_HOME/zed/logs`, then `XDG_DATA_HOME/zed/logs`, then the
+platform default; environment paths must be absolute. Only the exact stale
+`Zed.log.old` file can produce an action.
+
+Claude and Zed provider-file quarantine require
+`plan --max-risk recoverable` and matching apply authorization. Missing
+default roots mean the provider is absent, not broken. Codex can propose
+offline database maintenance only with
 `audit --allow-offline-vacuum`; the flag is intentionally not persisted in
-configuration. A
-missing explicit root is a doctor warning.
+configuration. A missing explicit root is a doctor warning.
 
 Git is disabled by default and requires an explicit repository root. When
 enabled, eligible linked worktrees may produce `recoverable` quarantine

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -35,6 +35,9 @@ macOS is Tier 1 for `0.5.0`.
 Mole remains external. AgentRinse does not embed, invoke, or parse Mole
 cleanup.
 
+Current main after `0.5.0` also supports recoverable quarantine for the exact
+native Zed `$HOME/Library/Logs/Zed/Zed.log.old` file after 30 days.
+
 ## Linux
 
 Linux is Tier 2 for `0.5.0`.
@@ -48,6 +51,9 @@ Linux is Tier 2 for `0.5.0`.
 - experimental recoverable offline Codex database compaction
 
 If neither `/proc` nor `lsof` can prove a target idle, apply skips it.
+
+Current main after `0.5.0` also supports recoverable quarantine for the exact
+`Zed.log.old` file under the resolved Zed data root's `logs` directory.
 
 Stale-lock recovery uses the kernel-held `lockf` utility on macOS and `flock`
 from `util-linux` on Linux. A crashed recovery process releases the mutex

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -2,7 +2,7 @@
 
 Status: active implementation
 
-Target version: 0.5.0
+Target version: 0.6.0
 
 Created: 2026-07-23
 
@@ -186,8 +186,10 @@ Current upstream behavior affects the product boundary:
   deleting a workspace database can make agent history inaccessible.
 - GitHub Copilot CLI keeps configuration, local sessions, logs, and
   customizations under its configurable Copilot directory.
-- Zed exposes a configurable user-data directory containing its database,
-  extensions, and logs.
+- Zed exposes a configurable user-data directory containing its database and
+  extensions. Native macOS logs live under `$HOME/Library/Logs/Zed`; other
+  supported layouts use a `logs` directory beneath the resolved data root.
+  Zed maintains one active `Zed.log` and one rotated `Zed.log.old`.
 - OpenCode stores session data and snapshots under its data directory; its
   snapshot Git repositories can become a major disk consumer and also carry
   user-visible undo state.
@@ -205,7 +207,8 @@ Consequences:
 - AgentRinse must not raw-delete Codex or Claude transcripts in its first
   releases.
 - AgentRinse must not raw-delete Cursor, Copilot, Zed, OpenCode, or Grok Build
-  sessions in its first releases.
+  sessions in its first releases. Zed cleanup is limited to the exact rotated
+  application log under a registered recoverable policy.
 - AgentRinse must cooperate with provider-native lifecycle behavior.
 - AgentRinse must treat a session-linked worktree as reachable even if its
   filesystem timestamps appear old.
@@ -2076,15 +2079,17 @@ paths over inspecting undocumented editor database keys.
 ### Ownership boundary
 
 Zed owns its user-data database, agent threads, ACP state, extensions,
-settings, authentication, and editor logs.
+settings, authentication, crash reports, and editor logs.
 
 ### Discovery
 
 Resolve the user-data directory from the running command/configuration when
 available. Platform defaults:
 
-- macOS: `$HOME/Library/Application Support/Zed`
-- Linux: `$XDG_DATA_HOME/zed`, normally `$HOME/.local/share/zed`
+- macOS data: `$HOME/Library/Application Support/Zed`
+- macOS logs: `$HOME/Library/Logs/Zed`
+- Linux data: `$FLATPAK_XDG_DATA_HOME/zed` or `$XDG_DATA_HOME/zed`, normally
+  `$HOME/.local/share/zed`
 - Windows: `%LOCALAPPDATA%\Zed`
 
 The `zed --user-data-dir <DIR>` option means the default location is not
@@ -2105,7 +2110,13 @@ Inventory:
 - extensions are package-manager-owned and not arbitrary cache candidates
 - ACP logs may contain tool messages or sensitive context and are never parsed
   for cleanup intent
-- log cleanup is disabled until a tested retention boundary exists
+- the exact regular `Zed.log.old` file may be quarantined after 30 days with a
+  seven-day undo window
+- the active `Zed.log`, ACP logs, neighboring files, crash reports, databases,
+  threads, settings, credentials, extensions, and unknown paths remain
+  protected
+- provider-file mutation requires exact owner-root authorization, stopped Zed
+  and headless Zed processes, and no open descriptor
 - no database compaction while Zed or a Zed headless server is running
 
 ## OpenCode Adapter
@@ -2751,6 +2762,8 @@ Tests cover:
 - Cursor workspace-path mapping and missing-project protection
 - Copilot CLI local-session and log separation
 - Zed custom user-data directories
+- Zed native macOS and XDG log roots
+- exact old, recent, active, neighboring, and symlinked Zed log cases
 - OpenCode snapshot growth and self-capture detection
 - Grok Build version-gated path discovery
 - no transcript content in output or run manifests
@@ -3059,6 +3072,33 @@ Exit criteria:
 - active provider processes block mutation
 - exact Docker context and object identity are revalidated before mutation
 
+### `0.5.0`: exact provider files
+
+Deliver:
+
+- shared recoverable provider-file quarantine, undo, purge, and recovery
+- exact Claude debug-log and changelog-cache policies
+- provider-native retention reporting
+
+Exit criteria:
+
+- exact owner root, policy, path, process, descriptor, inode, content, and age
+  checks fail closed
+- packaged recovery proof covers apply, undo, and purge
+
+### `0.6.0`: additional provider policies
+
+Deliver:
+
+- exact stale Zed `Zed.log.old` quarantine
+- native macOS, explicit-root, Flatpak, and XDG log-root resolution
+
+Exit criteria:
+
+- no active log, ACP log, database, thread, configuration, credential,
+  extension, crash report, neighboring file, or symlink can match
+- active Zed processes and open descriptors block mutation
+
 ### `1.0.0`: stable contracts
 
 Deliver:
@@ -3161,6 +3201,7 @@ Exit criteria:
 | Cursor workspace/global state  |         any | report only          | n/a         | editor-owned    |
 | GitHub Copilot sessions        |         any | report only          | n/a         | provider-owned  |
 | Zed database/agent state       |         any | report only          | n/a         | editor-owned    |
+| Zed `Zed.log.old`              |         30d | quarantine           | recoverable | 7d undo         |
 | OpenCode database/snapshots    |         any | report only          | n/a         | provider-owned  |
 | Grok Build sessions/task state |         any | report only          | n/a         | provider-owned  |
 | Codex logs DB free pages       |   threshold | report only          | n/a         | phase 4         |
@@ -3356,6 +3397,10 @@ reachability without expanding mutation. Release `0.3.0` adds recoverable
 worktree quarantine and undo. Release `0.4.0` adds recoverable offline Codex
 database compaction.
 
+Release `0.5.0` adds recoverable exact provider-file cleanup and the first
+Claude policies. Release `0.6.0` expands that owner-registered boundary to the
+single rotated Zed application log.
+
 ### 2026-07-25: provider cleanup uses exact recoverable files
 
 Provider-specific cleanup is built on `provider.file-quarantine`, not generic
@@ -3378,6 +3423,19 @@ The shared executor does not decide retention. Each provider adapter needs a
 separate evidence-backed policy for its known log or cache files before it may
 emit the action. Claude transcript retention and OpenCode snapshot compaction
 therefore remain separate provider-owned designs.
+
+### 2026-07-28: Zed cleanup is one rotated log
+
+Zed cleanup is limited to the exact `Zed.log.old` regular file that Zed's
+source defines beside the active `Zed.log`. AgentRinse checks no wildcard and
+does not enumerate the log directory. The policy requires 30 days of age,
+seven days of recoverable quarantine, the exact native or configured log root,
+stopped Zed processes, and no open descriptor.
+
+The active log, ACP logs, databases, threads, crash reports, settings,
+credentials, extensions, neighboring files, symlinks, and unknown paths remain
+protected. This policy does not authorize Zed database compaction or session
+cleanup.
 
 ### 2026-07-24: operational UX precedes mutation growth
 
@@ -3602,6 +3660,7 @@ decision-log entry. They must not be smuggled in as adapter fixes.
 - [x] exact provider-file quarantine, undo, purge, and recovery foundation
 - [x] recoverable Claude debug-log quarantine
 - [x] recoverable Claude changelog-cache quarantine
+- [x] recoverable Zed rotated-log quarantine
 - [x] Claude native retention and cache inventory reporting
 
 ### Documentation and release

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -49,6 +49,9 @@ They record the exact owner root, relative path, provider, policy ID, inode,
 single-link count, mode, size, mtime, and streamed content digest. Provider
 adapters must opt into this primitive with their own registered disposal
 policy; the recovery layer never discovers or widens provider targets.
+For Zed's native macOS default, the recorded owner root is the external
+`$HOME/Library/Logs/Zed` directory rather than its user-data root. The same
+pinned-root, identity, undo, and purge checks apply.
 
 ## Restore a Quarantined Worktree
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -53,6 +53,23 @@ Shipped:
 - `VACUUM INTO`, full integrity proof, locked atomic exchange, undo, and expiry
   purge
 
+## 0.5: Exact Provider Files
+
+Shipped:
+
+- shared recoverable provider-file quarantine, undo, purge, and recovery
+- exact stale Claude debug-log quarantine
+- exact Claude changelog-cache quarantine
+- Claude native retention and Copilot native maintenance reporting
+
+## 0.6: Additional Provider Policies
+
+Current:
+
+- exact stale Zed `Zed.log.old` quarantine
+- native macOS, explicit-root, Flatpak, and XDG log-root resolution
+- active Zed, descriptor, symlink, age, and exact-path refusal
+
 Remaining:
 
 - Cursor database diagnostics and optional compaction

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -83,6 +83,15 @@ quarantine. JSONL, nested paths, neighboring or undocumented cache files,
 recent files, incomplete directory enumeration, active Claude processes, and
 open descriptors remain protected.
 
+The registered Zed owner contract is the single exact `Zed.log.old` regular
+file. Its owner root is `$HOME/Library/Logs/Zed` for the native macOS default
+or `logs` beneath an explicit or non-macOS Zed data root. It also requires a
+minimum age of 30 days and seven days of recoverable quarantine. AgentRinse
+does not enumerate the log directory. The active `Zed.log`, ACP logs,
+neighboring files, databases, threads, crash reports, settings, credentials,
+extensions, recent files, active Zed processes, and open descriptors remain
+protected.
+
 ## Native Provider Retention Reporting
 
 Claude native retention is report-only. AgentRinse inventories project

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1,7 +1,16 @@
 import { execFile } from "node:child_process";
-import { access, mkdir, mkdtemp, readFile, realpath, utimes, writeFile } from "node:fs/promises";
+import {
+  access,
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
@@ -10,10 +19,10 @@ const packageJson = JSON.parse(await readFile(new URL("../package.json", import.
 const { assertDestructiveFixtureRoot } = await import("../dist/core/safety.js");
 const installedCli = process.env.AGENTRINSE_SMOKE_CLI;
 const sourceCli = fileURLToPath(new URL("../dist/cli.js", import.meta.url));
-const runCli = (args, cwd = process.cwd()) =>
+const runCli = (args, cwd = process.cwd(), environment = process.env) =>
   installedCli
-    ? execFileAsync(installedCli, args, { cwd })
-    : execFileAsync(process.execPath, [sourceCli, ...args], { cwd });
+    ? execFileAsync(installedCli, args, { cwd, env: environment })
+    : execFileAsync(process.execPath, [sourceCli, ...args], { cwd, env: environment });
 const root = await realpath(await mkdtemp(join(tmpdir(), "agentrinse-smoke-")));
 await assertDestructiveFixtureRoot(root);
 const home = join(root, "home");
@@ -28,7 +37,10 @@ const worktreePlanPath2 = join(root, "worktree-plan-2.json");
 const zedConfigPath = join(root, "zed-config.json");
 const zedAuditPath = join(root, "zed-audit.json");
 const zedPlanPath = join(root, "zed-plan.json");
+const zedAuditPath2 = join(root, "zed-audit-2.json");
+const zedPlanPath2 = join(root, "zed-plan-2.json");
 const statePath = join(root, "state");
+const fixtureBin = join(root, "fixture-bin");
 const project = join(home, "project");
 const artifact = join(project, "node_modules");
 const worktreeMain = join(home, "worktree-repo");
@@ -36,6 +48,27 @@ const worktreeLinked = join(home, "worktree-task");
 const worktreeRemote = join(home, "worktree-remote.git");
 const zedRoot = join(home, "zed-data");
 const zedLogs = join(zedRoot, "logs");
+const zedRotatedLog = join(zedLogs, "Zed.log.old");
+const zedActiveLog = join(zedLogs, "Zed.log");
+const zedRotatedContents = "synthetic rotated Zed log\n";
+const zedActiveContents = "synthetic active Zed log\n";
+
+await mkdir(fixtureBin, { recursive: true });
+if (process.platform !== "win32") {
+  const fakePs = join(fixtureBin, "ps");
+  const fakeLsof = join(fixtureBin, "lsof");
+  await writeFile(fakePs, "#!/bin/sh\nprintf '1 /sbin/init\\n'\n");
+  await writeFile(fakeLsof, "#!/bin/sh\nexit 1\n");
+  await chmod(fakePs, 0o755);
+  await chmod(fakeLsof, 0o755);
+}
+const providerFixtureEnvironment = {
+  ...process.env,
+  PATH:
+    process.platform === "win32"
+      ? process.env.PATH
+      : `${fixtureBin}${delimiter}${process.env.PATH ?? ""}`,
+};
 
 for (const [command, option] of [
   ["audit", "--allow-offline-vacuum"],
@@ -134,14 +167,13 @@ try {
 }
 
 await mkdir(zedLogs, { recursive: true });
-const zedRotatedLog = join(zedLogs, "Zed.log.old");
-await writeFile(zedRotatedLog, "synthetic rotated Zed log\n");
+await writeFile(zedRotatedLog, zedRotatedContents);
 await utimes(
   zedRotatedLog,
   new Date("2026-06-01T00:00:00.000Z"),
   new Date("2026-06-01T00:00:00.000Z"),
 );
-await writeFile(join(zedLogs, "Zed.log"), "synthetic active Zed log\n");
+await writeFile(zedActiveLog, zedActiveContents);
 await writeFile(
   zedConfigPath,
   `${JSON.stringify(
@@ -183,6 +215,149 @@ if (
   zedPlan.actions[0]?.adapter !== "zed"
 ) {
   throw new Error("smoke Zed audit did not produce one recoverable rotated-log action");
+}
+const zedApply = JSON.parse(
+  (
+    await runCli(
+      [
+        "apply",
+        "--plan",
+        zedPlanPath,
+        "--config",
+        zedConfigPath,
+        "--state-dir",
+        statePath,
+        "--max-risk",
+        "recoverable",
+        "--yes",
+        "--json",
+      ],
+      process.cwd(),
+      providerFixtureEnvironment,
+    )
+  ).stdout,
+);
+if (
+  zedApply.status !== "completed" ||
+  zedApply.actions?.[0]?.type !== "provider.file-quarantine" ||
+  zedApply.actions?.[0]?.status !== "applied" ||
+  zedApply.reclaimedBytes !== 0 ||
+  zedApply.quarantinedBytes !== Buffer.byteLength(zedRotatedContents)
+) {
+  throw new Error("smoke Zed quarantine did not retain the exact rotated log");
+}
+try {
+  await access(zedRotatedLog);
+  throw new Error("smoke Zed quarantine left the rotated log in place");
+} catch (error) {
+  if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") {
+    throw error;
+  }
+}
+if ((await readFile(zedActiveLog, "utf8")) !== zedActiveContents) {
+  throw new Error("smoke Zed quarantine changed the active log");
+}
+
+const zedUndo = JSON.parse(
+  (
+    await runCli(
+      [
+        "undo",
+        zedApply.runId,
+        "--home",
+        home,
+        "--config",
+        zedConfigPath,
+        "--state-dir",
+        statePath,
+        "--yes",
+        "--json",
+      ],
+      process.cwd(),
+      providerFixtureEnvironment,
+    )
+  ).stdout,
+);
+if (
+  zedUndo.length !== 1 ||
+  zedUndo[0]?.status !== "restored" ||
+  (await readFile(zedRotatedLog, "utf8")) !== zedRotatedContents ||
+  (await readFile(zedActiveLog, "utf8")) !== zedActiveContents
+) {
+  throw new Error("smoke Zed undo did not restore only the rotated log");
+}
+
+await runCli(["audit", "--home", home, "--config", zedConfigPath, "--output", zedAuditPath2]);
+await runCli([
+  "plan",
+  "--audit",
+  zedAuditPath2,
+  "--config",
+  zedConfigPath,
+  "--output",
+  zedPlanPath2,
+]);
+const zedApply2 = JSON.parse(
+  (
+    await runCli(
+      [
+        "apply",
+        "--plan",
+        zedPlanPath2,
+        "--config",
+        zedConfigPath,
+        "--state-dir",
+        statePath,
+        "--max-risk",
+        "recoverable",
+        "--yes",
+        "--json",
+      ],
+      process.cwd(),
+      providerFixtureEnvironment,
+    )
+  ).stdout,
+);
+const zedPurge = JSON.parse(
+  (
+    await runCli(
+      [
+        "purge",
+        "--run",
+        zedApply2.runId,
+        "--apply",
+        "--home",
+        home,
+        "--config",
+        zedConfigPath,
+        "--state-dir",
+        statePath,
+        "--yes",
+        "--json",
+      ],
+      process.cwd(),
+      providerFixtureEnvironment,
+    )
+  ).stdout,
+);
+if (
+  zedPurge.applied !== true ||
+  zedPurge.entries?.length !== 1 ||
+  zedPurge.entries[0]?.status !== "purged" ||
+  zedPurge.reclaimedBytes !== Buffer.byteLength(zedRotatedContents)
+) {
+  throw new Error("smoke Zed purge did not reclaim the exact rotated log");
+}
+try {
+  await access(zedRotatedLog);
+  throw new Error("smoke Zed purge restored the rotated log");
+} catch (error) {
+  if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") {
+    throw error;
+  }
+}
+if ((await readFile(zedActiveLog, "utf8")) !== zedActiveContents) {
+  throw new Error("smoke Zed purge changed the active log");
 }
 
 await execFileAsync("git", ["init", "-b", "main"], { cwd: project });
@@ -414,6 +589,9 @@ process.stdout.write(
     closeoutWorktrees: closeout.data.worktrees,
     reclaimedBytes: run.reclaimedBytes,
     zedPlanActions: zedPlan.actions.length,
+    zedApplied: zedApply.actions.length,
+    zedUndo: zedUndo.length,
+    zedPurgedBytes: zedPurge.reclaimedBytes,
     quarantinedBytes: worktreeApply.quarantinedBytes,
     worktreeUndo: undo.length,
     worktreePurgedBytes: purge.reclaimedBytes,

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { access, mkdir, mkdtemp, readFile, realpath, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, realpath, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -25,12 +25,17 @@ const worktreeAuditPath = join(root, "worktree-audit.json");
 const worktreePlanPath = join(root, "worktree-plan.json");
 const worktreeAuditPath2 = join(root, "worktree-audit-2.json");
 const worktreePlanPath2 = join(root, "worktree-plan-2.json");
+const zedConfigPath = join(root, "zed-config.json");
+const zedAuditPath = join(root, "zed-audit.json");
+const zedPlanPath = join(root, "zed-plan.json");
 const statePath = join(root, "state");
 const project = join(home, "project");
 const artifact = join(project, "node_modules");
 const worktreeMain = join(home, "worktree-repo");
 const worktreeLinked = join(home, "worktree-task");
 const worktreeRemote = join(home, "worktree-remote.git");
+const zedRoot = join(home, "zed-data");
+const zedLogs = join(zedRoot, "logs");
 
 for (const [command, option] of [
   ["audit", "--allow-offline-vacuum"],
@@ -126,6 +131,58 @@ try {
   if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") {
     throw error;
   }
+}
+
+await mkdir(zedLogs, { recursive: true });
+const zedRotatedLog = join(zedLogs, "Zed.log.old");
+await writeFile(zedRotatedLog, "synthetic rotated Zed log\n");
+await utimes(
+  zedRotatedLog,
+  new Date("2026-06-01T00:00:00.000Z"),
+  new Date("2026-06-01T00:00:00.000Z"),
+);
+await writeFile(join(zedLogs, "Zed.log"), "synthetic active Zed log\n");
+await writeFile(
+  zedConfigPath,
+  `${JSON.stringify(
+    {
+      schemaVersion: 1,
+      adapters: {
+        codex: { enabled: false },
+        claude: { enabled: false },
+        cursor: { enabled: false },
+        copilot: { enabled: false },
+        zed: { enabled: true, root: zedRoot },
+        opencode: { enabled: false },
+        grok: { enabled: false },
+        runtime: { enabled: false },
+        git: { enabled: false },
+        docker: { enabled: false },
+      },
+      plan: {
+        ttlMinutes: 30,
+        maxRisk: "recoverable",
+      },
+    },
+    null,
+    2,
+  )}\n`,
+);
+await runCli(["audit", "--home", home, "--config", zedConfigPath, "--output", zedAuditPath]);
+await runCli(["plan", "--audit", zedAuditPath, "--config", zedConfigPath, "--output", zedPlanPath]);
+const zedAudit = JSON.parse(await readFile(zedAuditPath, "utf8"));
+const zedPlan = JSON.parse(await readFile(zedPlanPath, "utf8"));
+const zedFindings = zedAudit.findings.filter(
+  (finding) => finding.facts?.policyId === "zed.rotated-log",
+);
+if (
+  zedFindings.length !== 1 ||
+  zedFindings[0]?.state !== "eligible" ||
+  zedPlan.actions?.length !== 1 ||
+  zedPlan.actions[0]?.type !== "provider.file-quarantine" ||
+  zedPlan.actions[0]?.adapter !== "zed"
+) {
+  throw new Error("smoke Zed audit did not produce one recoverable rotated-log action");
 }
 
 await execFileAsync("git", ["init", "-b", "main"], { cwd: project });
@@ -356,6 +413,7 @@ process.stdout.write(
     applied: 1,
     closeoutWorktrees: closeout.data.worktrees,
     reclaimedBytes: run.reclaimedBytes,
+    zedPlanActions: zedPlan.actions.length,
     quarantinedBytes: worktreeApply.quarantinedBytes,
     worktreeUndo: undo.length,
     worktreePurgedBytes: purge.reclaimedBytes,

--- a/src/adapters/provider-adapter.ts
+++ b/src/adapters/provider-adapter.ts
@@ -38,6 +38,7 @@ import {
 import { collectProviderReachability } from "./provider-reachability.js";
 import { resolveProviderRoot } from "./provider-root.js";
 import type { ProviderSpec } from "./provider-specs.js";
+import { collectZedRotatedLog } from "./zed-logs.js";
 
 export type ProviderAdapterOptions = {
   root?: string;
@@ -183,6 +184,19 @@ export class ProviderAuditAdapter implements AuditAdapter {
           detail: `${this.spec.displayName} ownership metadata could not be inspected.`,
         });
       }
+      if (
+        this.spec.id === "zed" &&
+        probe.status === "absent" &&
+        this.options.inventoryResources !== false
+      ) {
+        return collectZedRotatedLog(context, {
+          ...(this.options.root === undefined ? {} : { root: this.options.root }),
+          ...(this.options.platform === undefined ? {} : { platform: this.options.platform }),
+          ...(this.options.environment === undefined
+            ? {}
+            : { environment: this.options.environment }),
+        });
+      }
       return { resources: [], diagnostics: [] };
     }
 
@@ -324,6 +338,17 @@ export class ProviderAuditAdapter implements AuditAdapter {
       resources.push(...changelogCache.resources);
       diagnostics.push(...debugLogs.diagnostics);
       diagnostics.push(...changelogCache.diagnostics);
+    }
+    if (this.spec.id === "zed") {
+      const rotatedLog = await collectZedRotatedLog(context, {
+        ...(this.options.root === undefined ? {} : { root: this.options.root }),
+        ...(this.options.platform === undefined ? {} : { platform: this.options.platform }),
+        ...(this.options.environment === undefined
+          ? {}
+          : { environment: this.options.environment }),
+      });
+      resources.push(...rotatedLog.resources);
+      diagnostics.push(...rotatedLog.diagnostics);
     }
 
     return { resources, diagnostics };

--- a/src/adapters/provider-adapter.ts
+++ b/src/adapters/provider-adapter.ts
@@ -8,22 +8,13 @@ import type { AdapterProbe } from "../contracts/report.js";
 import type { ResourceSnapshot } from "../contracts/resource.js";
 import {
   databaseIdentitySchema,
+  providerFileQuarantineActionSchema,
   providerFileIdentitySchema,
   type DatabaseVacuumAction,
-  type ProviderFileQuarantineAction,
 } from "../contracts/action.js";
 import { sha256 } from "../core/digest.js";
 import { measurePath } from "../core/measure.js";
-import {
-  CLAUDE_CHANGELOG_CACHE_MIN_AGE_MINUTES,
-  CLAUDE_CHANGELOG_CACHE_POLICY_ID,
-  CLAUDE_CHANGELOG_CACHE_QUARANTINE_TTL_MINUTES,
-  CLAUDE_DEBUG_LOG_MIN_AGE_MINUTES,
-  CLAUDE_DEBUG_LOG_POLICY_ID,
-  CLAUDE_DEBUG_LOG_QUARANTINE_TTL_MINUTES,
-  isClaudeChangelogCacheRelativePath,
-  isClaudeDebugLogRelativePath,
-} from "../core/provider-file-policy.js";
+import { PROVIDER_FILE_POLICIES } from "../core/provider-file-policy.js";
 import type { ReachabilityIndex } from "../core/reachability.js";
 import {
   codexDatabaseContractMatches,
@@ -47,47 +38,6 @@ import {
 import { collectProviderReachability } from "./provider-reachability.js";
 import { resolveProviderRoot } from "./provider-root.js";
 import type { ProviderSpec } from "./provider-specs.js";
-
-type ClaudeProviderFileQuarantineAction = Extract<
-  ProviderFileQuarantineAction,
-  { adapter: "claude" }
->;
-
-type ClaudeProviderFileContract = {
-  policyId: string;
-  minAgeMinutes: number;
-  quarantineTtlMinutes: number;
-  matchesRelativePath(relativePath: string): boolean;
-  description: string;
-  rootCode: string;
-  rootDetail: string;
-  tooRecentDetail: string;
-};
-
-const CLAUDE_PROVIDER_FILE_CONTRACTS: readonly ClaudeProviderFileContract[] = [
-  {
-    policyId: CLAUDE_DEBUG_LOG_POLICY_ID,
-    minAgeMinutes: CLAUDE_DEBUG_LOG_MIN_AGE_MINUTES,
-    quarantineTtlMinutes: CLAUDE_DEBUG_LOG_QUARANTINE_TTL_MINUTES,
-    matchesRelativePath: isClaudeDebugLogRelativePath,
-    description: "Quarantine a Claude debug log older than 30 days",
-    rootCode: "claude-debug-log-owner-contract",
-    rootDetail:
-      "Claude documents direct debug logs as disposable application data with no user-facing loss.",
-    tooRecentDetail: "The debug log is newer than the 30-day cleanup threshold.",
-  },
-  {
-    policyId: CLAUDE_CHANGELOG_CACHE_POLICY_ID,
-    minAgeMinutes: CLAUDE_CHANGELOG_CACHE_MIN_AGE_MINUTES,
-    quarantineTtlMinutes: CLAUDE_CHANGELOG_CACHE_QUARANTINE_TTL_MINUTES,
-    matchesRelativePath: isClaudeChangelogCacheRelativePath,
-    description: "Quarantine the Claude changelog cache after 30 days",
-    rootCode: "claude-changelog-cache-owner-contract",
-    rootDetail:
-      "Claude documents cache/changelog.md as a rebuildable release-notes cache refreshed in the background.",
-    tooRecentDetail: "The changelog cache is newer than the 30-day cleanup threshold.",
-  },
-];
 
 export type ProviderAdapterOptions = {
   root?: string;
@@ -390,45 +340,40 @@ export class ProviderAuditAdapter implements AuditAdapter {
     const copilotNativeMaintenance = copilotNativeMaintenanceFactsSchema.safeParse(
       resource.facts.nativeMaintenance,
     );
-    const claudeProviderFileContract =
+    const providerFilePolicy =
       typeof resource.facts.policyId === "string"
-        ? CLAUDE_PROVIDER_FILE_CONTRACTS.find(
-            (contract) =>
-              contract.policyId === resource.facts.policyId &&
+        ? PROVIDER_FILE_POLICIES.find(
+            (policy) =>
+              policy.id === resource.facts.policyId &&
               providerFileIdentity.success &&
-              contract.matchesRelativePath(providerFileIdentity.data.relativePath),
+              policy.matchesRelativePath(providerFileIdentity.data.relativePath),
           )
         : undefined;
     if (
-      this.spec.id === "claude" &&
       providerFileIdentity.success &&
-      providerFileIdentity.data.provider === "claude" &&
-      claudeProviderFileContract !== undefined
+      providerFileIdentity.data.provider === this.spec.id &&
+      providerFilePolicy?.provider === this.spec.id
     ) {
-      const claudeIdentity = {
-        ...providerFileIdentity.data,
-        provider: "claude" as const,
-      };
+      const identity = providerFileIdentity.data;
       const oldEnough =
-        context.now.getTime() - claudeIdentity.mtimeMs >=
-        claudeProviderFileContract.minAgeMinutes * 60_000;
-      const candidateActions: ClaudeProviderFileQuarantineAction[] = oldEnough
+        context.now.getTime() - identity.mtimeMs >= providerFilePolicy.minAgeMinutes * 60_000;
+      const candidateActions = oldEnough
         ? [
-            {
+            providerFileQuarantineActionSchema.parse({
               actionId: `provider.file-quarantine:${sha256(
-                `${claudeProviderFileContract.policyId}:${claudeIdentity.fingerprint}`,
+                `${providerFilePolicy.id}:${identity.fingerprint}`,
               )}`,
               type: "provider.file-quarantine",
-              adapter: "claude",
+              adapter: providerFilePolicy.provider,
               resourceId: resource.resource.id,
-              policyId: claudeProviderFileContract.policyId,
+              policyId: providerFilePolicy.id,
               risk: "recoverable",
-              description: claudeProviderFileContract.description,
+              description: providerFilePolicy.description,
               expectedReclaimBytes: 0,
-              pendingQuarantineBytes: claudeIdentity.measuredBytes,
-              quarantineTtlMinutes: claudeProviderFileContract.quarantineTtlMinutes,
-              target: claudeIdentity,
-            },
+              pendingQuarantineBytes: identity.measuredBytes,
+              quarantineTtlMinutes: providerFilePolicy.quarantineTtlMinutes,
+              target: identity,
+            }),
           ]
         : [];
       return {
@@ -441,10 +386,10 @@ export class ProviderAuditAdapter implements AuditAdapter {
         confidence: "certain",
         roots: [
           {
-            code: claudeProviderFileContract.rootCode,
+            code: providerFilePolicy.rootCode,
             source: this.id,
             observedAt,
-            detail: claudeProviderFileContract.rootDetail,
+            detail: providerFilePolicy.rootDetail,
           },
           ...(oldEnough
             ? []
@@ -453,13 +398,13 @@ export class ProviderAuditAdapter implements AuditAdapter {
                   code: "provider-file-too-recent",
                   source: this.id,
                   observedAt,
-                  detail: claudeProviderFileContract.tooRecentDetail,
+                  detail: providerFilePolicy.tooRecentDetail,
                 },
               ]),
         ],
         facts: resource.facts,
         candidateActions,
-        measuredBytes: claudeIdentity.measuredBytes,
+        measuredBytes: identity.measuredBytes,
         estimatedReclaimBytes: 0,
         warnings: [],
       };

--- a/src/adapters/provider-root.ts
+++ b/src/adapters/provider-root.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, resolve } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 
 import type { ProviderSpec } from "./provider-specs.js";
 
@@ -18,6 +18,20 @@ function providerRootEnvironment(spec: ProviderSpec): string | undefined {
   return undefined;
 }
 
+function resolveAbsoluteEnvironmentPath(
+  environment: NodeJS.ProcessEnv,
+  name: string,
+): string | undefined {
+  const value = environment[name];
+  if (value === undefined || value === "") {
+    return undefined;
+  }
+  if (!isAbsolute(value)) {
+    throw new Error(`${name} must be an absolute path`);
+  }
+  return resolve(value);
+}
+
 export function resolveProviderRoot(
   spec: ProviderSpec,
   home: string,
@@ -25,6 +39,19 @@ export function resolveProviderRoot(
 ): string {
   if (options.root !== undefined) {
     return resolve(options.root);
+  }
+  if (
+    spec.id === "zed" &&
+    (options.platform ?? process.platform) !== "darwin" &&
+    (options.platform ?? process.platform) !== "win32"
+  ) {
+    const environment = options.environment ?? process.env;
+    const dataHome =
+      resolveAbsoluteEnvironmentPath(environment, "FLATPAK_XDG_DATA_HOME") ??
+      resolveAbsoluteEnvironmentPath(environment, "XDG_DATA_HOME");
+    if (dataHome !== undefined) {
+      return join(dataHome, "zed");
+    }
   }
   const environmentVariable = providerRootEnvironment(spec);
   if (environmentVariable !== undefined) {

--- a/src/adapters/zed-logs.ts
+++ b/src/adapters/zed-logs.ts
@@ -1,0 +1,126 @@
+import { lstat } from "node:fs/promises";
+import { basename, join } from "node:path";
+
+import type { AuditContext, CollectionResult } from "../contracts/adapter.js";
+import { sha256 } from "../core/digest.js";
+import { inspectProviderFile } from "../core/provider-file-identity.js";
+import {
+  PROVIDER_FILE_POLICIES,
+  resolveProviderFileOwnerRoot,
+  type ProviderFilePolicy,
+  ZED_ROTATED_LOG_MIN_AGE_MINUTES,
+  ZED_ROTATED_LOG_POLICY_ID,
+} from "../core/provider-file-policy.js";
+
+export type ZedLogOptions = {
+  root?: string;
+  platform?: NodeJS.Platform;
+  environment?: NodeJS.ProcessEnv;
+};
+
+function isMissing(error: unknown): boolean {
+  return (
+    error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}
+
+function zedRotatedLogPolicy(): ProviderFilePolicy {
+  const policy = PROVIDER_FILE_POLICIES.find(
+    (candidate) => candidate.id === ZED_ROTATED_LOG_POLICY_ID && candidate.provider === "zed",
+  );
+  if (policy === undefined) {
+    throw new Error("Zed rotated-log policy is not registered");
+  }
+  return policy;
+}
+
+const ZED_ROTATED_LOG_POLICY = zedRotatedLogPolicy();
+
+export async function collectZedRotatedLog(
+  context: AuditContext,
+  options: ZedLogOptions = {},
+): Promise<CollectionResult> {
+  const ownerRoot = resolveProviderFileOwnerRoot(ZED_ROTATED_LOG_POLICY, context.home, options);
+  try {
+    const rootStats = await lstat(ownerRoot);
+    if (rootStats.isSymbolicLink() || !rootStats.isDirectory()) {
+      return {
+        resources: [],
+        diagnostics: [
+          {
+            severity: "warning",
+            code: "ZED_LOG_ROOT_UNSAFE",
+            message: "Zed log cleanup requires a direct non-symlink directory.",
+            adapter: "zed",
+          },
+        ],
+      };
+    }
+  } catch (error) {
+    if (isMissing(error)) {
+      return { resources: [], diagnostics: [] };
+    }
+    return {
+      resources: [],
+      diagnostics: [
+        {
+          severity: "warning",
+          code: "ZED_LOG_ROOT_INSPECTION_FAILED",
+          message: error instanceof Error ? error.message : String(error),
+          adapter: "zed",
+        },
+      ],
+    };
+  }
+
+  const path = join(ownerRoot, "Zed.log.old");
+  try {
+    const stats = await lstat(path);
+    const cutoffMs = context.now.getTime() - ZED_ROTATED_LOG_MIN_AGE_MINUTES * 60_000;
+    if (!stats.isFile() || stats.isSymbolicLink() || stats.mtimeMs > cutoffMs) {
+      return { resources: [], diagnostics: [] };
+    }
+    const identity = await inspectProviderFile(path, ownerRoot, "zed");
+    const canonicalKey = `zed:rotated-log:${identity.path}`;
+    return {
+      resources: [
+        {
+          resource: {
+            id: `zed:agent-log-store:${sha256(canonicalKey)}`,
+            adapter: "zed",
+            kind: ZED_ROTATED_LOG_POLICY.resourceKind,
+            canonicalKey,
+            displayName: `${ZED_ROTATED_LOG_POLICY.displayName} ${basename(identity.path)}`,
+            path: identity.path,
+          },
+          observedAt: context.now.toISOString(),
+          exists: true,
+          measuredBytes: identity.measuredBytes,
+          facts: {
+            reportOnly: false,
+            maintenanceAction: "provider.file-quarantine",
+            policyId: ZED_ROTATED_LOG_POLICY_ID,
+            minAgeMinutes: ZED_ROTATED_LOG_MIN_AGE_MINUTES,
+            providerFileIdentity: identity,
+          },
+        },
+      ],
+      diagnostics: [],
+    };
+  } catch (error) {
+    if (isMissing(error)) {
+      return { resources: [], diagnostics: [] };
+    }
+    return {
+      resources: [],
+      diagnostics: [
+        {
+          severity: "warning",
+          code: "ZED_ROTATED_LOG_INSPECTION_FAILED",
+          message: error instanceof Error ? error.message : String(error),
+          adapter: "zed",
+        },
+      ],
+    };
+  }
+}

--- a/src/core/provider-file-policy.ts
+++ b/src/core/provider-file-policy.ts
@@ -29,6 +29,9 @@ export const CLAUDE_DEBUG_LOG_QUARANTINE_TTL_MINUTES = 7 * 24 * 60;
 export const CLAUDE_CHANGELOG_CACHE_POLICY_ID = "claude.changelog-cache";
 export const CLAUDE_CHANGELOG_CACHE_MIN_AGE_MINUTES = 30 * 24 * 60;
 export const CLAUDE_CHANGELOG_CACHE_QUARANTINE_TTL_MINUTES = 7 * 24 * 60;
+export const ZED_ROTATED_LOG_POLICY_ID = "zed.rotated-log";
+export const ZED_ROTATED_LOG_MIN_AGE_MINUTES = 30 * 24 * 60;
+export const ZED_ROTATED_LOG_QUARANTINE_TTL_MINUTES = 7 * 24 * 60;
 
 export function isClaudeDebugLogRelativePath(relativePath: string): boolean {
   const components = relativePath.split(sep);
@@ -43,6 +46,11 @@ export function isClaudeDebugLogRelativePath(relativePath: string): boolean {
 export function isClaudeChangelogCacheRelativePath(relativePath: string): boolean {
   const components = relativePath.split(sep);
   return components.length === 2 && components[0] === "cache" && components[1] === "changelog.md";
+}
+
+export function isZedRotatedLogRelativePath(relativePath: string): boolean {
+  const components = relativePath.split(sep);
+  return components.length === 1 && components[0] === "Zed.log.old";
 }
 
 export type ProviderFileOwnerRootOptions = {
@@ -138,6 +146,30 @@ export const PROVIDER_FILE_POLICIES: readonly ProviderFilePolicy[] = [
         "Claude changelog caches",
         CLAUDE_CHANGELOG_CACHE_MIN_AGE_MINUTES,
         CLAUDE_CHANGELOG_CACHE_QUARANTINE_TTL_MINUTES,
+      );
+    },
+  },
+  {
+    id: ZED_ROTATED_LOG_POLICY_ID,
+    provider: "zed",
+    ownerRoot: "zed-log-root",
+    resourceKind: "agent-log-store",
+    displayName: "Zed rotated log",
+    minAgeMinutes: ZED_ROTATED_LOG_MIN_AGE_MINUTES,
+    quarantineTtlMinutes: ZED_ROTATED_LOG_QUARANTINE_TTL_MINUTES,
+    description: "Quarantine Zed.log.old after 30 days",
+    rootCode: "zed-rotated-log-owner-contract",
+    rootDetail:
+      "Zed defines Zed.log.old as the single rotated application log beside the active Zed.log.",
+    tooRecentDetail: "The rotated Zed log is newer than the 30-day cleanup threshold.",
+    matchesRelativePath: isZedRotatedLogRelativePath,
+    validateAction(action, now) {
+      return validateAgeAndRecoveryWindow(
+        action,
+        now,
+        "Zed rotated logs",
+        ZED_ROTATED_LOG_MIN_AGE_MINUTES,
+        ZED_ROTATED_LOG_QUARANTINE_TTL_MINUTES,
       );
     },
   },

--- a/src/core/provider-file-policy.ts
+++ b/src/core/provider-file-policy.ts
@@ -1,14 +1,24 @@
 import { realpath } from "node:fs/promises";
-import { resolve, sep } from "node:path";
+import { join, resolve, sep } from "node:path";
 
 import { resolveProviderRoot } from "../adapters/provider-root.js";
 import { PROVIDER_SPECS } from "../adapters/provider-specs.js";
 import type { AgentRinseConfig } from "../config/schema.js";
 import type { ProviderFileQuarantineAction, ProviderMutationId } from "../contracts/action.js";
+import type { ResourceKind } from "../contracts/resource.js";
 
 export type ProviderFilePolicy = {
   id: string;
   provider: ProviderMutationId;
+  ownerRoot: "provider-root" | "zed-log-root";
+  resourceKind: ResourceKind;
+  displayName: string;
+  minAgeMinutes: number;
+  quarantineTtlMinutes: number;
+  description: string;
+  rootCode: string;
+  rootDetail: string;
+  tooRecentDetail: string;
   matchesRelativePath(relativePath: string): boolean;
   validateAction(action: ProviderFileQuarantineAction, now: Date): string | undefined;
 };
@@ -35,6 +45,34 @@ export function isClaudeChangelogCacheRelativePath(relativePath: string): boolea
   return components.length === 2 && components[0] === "cache" && components[1] === "changelog.md";
 }
 
+export type ProviderFileOwnerRootOptions = {
+  root?: string;
+  platform?: NodeJS.Platform;
+  environment?: NodeJS.ProcessEnv;
+};
+
+export function resolveProviderFileOwnerRoot(
+  policy: ProviderFilePolicy,
+  home: string,
+  options: ProviderFileOwnerRootOptions = {},
+): string {
+  const platform = options.platform ?? process.platform;
+  const providerRoot = resolveProviderRoot(PROVIDER_SPECS[policy.provider], resolve(home), {
+    ...(options.root === undefined ? {} : { root: options.root }),
+    platform,
+    environment: options.environment ?? process.env,
+  });
+  if (policy.ownerRoot === "provider-root") {
+    return providerRoot;
+  }
+  if (policy.provider !== "zed") {
+    throw new Error(`unsupported provider-file owner-root contract: ${policy.provider}`);
+  }
+  return options.root === undefined && platform === "darwin"
+    ? resolve(home, "Library", "Logs", "Zed")
+    : join(providerRoot, "logs");
+}
+
 function validateAgeAndRecoveryWindow(
   action: ProviderFileQuarantineAction,
   now: Date,
@@ -58,6 +96,16 @@ export const PROVIDER_FILE_POLICIES: readonly ProviderFilePolicy[] = [
   {
     id: CLAUDE_DEBUG_LOG_POLICY_ID,
     provider: "claude",
+    ownerRoot: "provider-root",
+    resourceKind: "agent-log-store",
+    displayName: "Claude debug log",
+    minAgeMinutes: CLAUDE_DEBUG_LOG_MIN_AGE_MINUTES,
+    quarantineTtlMinutes: CLAUDE_DEBUG_LOG_QUARANTINE_TTL_MINUTES,
+    description: "Quarantine a Claude debug log older than 30 days",
+    rootCode: "claude-debug-log-owner-contract",
+    rootDetail:
+      "Claude documents direct debug logs as disposable application data with no user-facing loss.",
+    tooRecentDetail: "The debug log is newer than the 30-day cleanup threshold.",
     matchesRelativePath: isClaudeDebugLogRelativePath,
     validateAction(action, now) {
       return validateAgeAndRecoveryWindow(
@@ -72,6 +120,16 @@ export const PROVIDER_FILE_POLICIES: readonly ProviderFilePolicy[] = [
   {
     id: CLAUDE_CHANGELOG_CACHE_POLICY_ID,
     provider: "claude",
+    ownerRoot: "provider-root",
+    resourceKind: "agent-cache",
+    displayName: "Claude changelog cache",
+    minAgeMinutes: CLAUDE_CHANGELOG_CACHE_MIN_AGE_MINUTES,
+    quarantineTtlMinutes: CLAUDE_CHANGELOG_CACHE_QUARANTINE_TTL_MINUTES,
+    description: "Quarantine the Claude changelog cache after 30 days",
+    rootCode: "claude-changelog-cache-owner-contract",
+    rootDetail:
+      "Claude documents cache/changelog.md as a rebuildable release-notes cache refreshed in the background.",
+    tooRecentDetail: "The changelog cache is newer than the 30-day cleanup threshold.",
     matchesRelativePath: isClaudeChangelogCacheRelativePath,
     validateAction(action, now) {
       return validateAgeAndRecoveryWindow(
@@ -94,15 +152,6 @@ export async function authorizeProviderFileAction(
   now: Date = new Date(),
 ): Promise<void> {
   const explicitRoot = config.adapters[action.adapter]?.root;
-  const configuredRoot = resolveProviderRoot(PROVIDER_SPECS[action.adapter], resolve(home), {
-    ...(explicitRoot === undefined ? {} : { root: explicitRoot }),
-    platform,
-    environment,
-  });
-  const physicalRoot = await realpath(configuredRoot);
-  if (action.target.ownerRoot !== physicalRoot) {
-    throw new Error(`provider-file target is outside the configured ${action.adapter} root`);
-  }
   const policy = PROVIDER_FILE_POLICIES.find(
     (candidate) => candidate.id === action.policyId && candidate.provider === action.adapter,
   );
@@ -110,6 +159,15 @@ export async function authorizeProviderFileAction(
     throw new Error(
       `provider-file target is not approved by policy ${action.adapter}:${action.policyId}`,
     );
+  }
+  const configuredRoot = resolveProviderFileOwnerRoot(policy, home, {
+    ...(explicitRoot === undefined ? {} : { root: explicitRoot }),
+    platform,
+    environment,
+  });
+  const physicalRoot = await realpath(configuredRoot);
+  if (action.target.ownerRoot !== physicalRoot) {
+    throw new Error(`provider-file target is outside the configured ${action.adapter} root`);
   }
   const refusal = policy.validateAction(action, now);
   if (refusal !== undefined) {

--- a/test/adapters/provider-root.test.ts
+++ b/test/adapters/provider-root.test.ts
@@ -69,4 +69,34 @@ describe("resolveProviderRoot", () => {
       }),
     ).toThrow("COPILOT_HOME must be an absolute path");
   });
+
+  it("uses FLATPAK_XDG_DATA_HOME for Zed before XDG_DATA_HOME", () => {
+    expect(
+      resolveProviderRoot(PROVIDER_SPECS.zed, "/fixture/home", {
+        platform: "linux",
+        environment: {
+          FLATPAK_XDG_DATA_HOME: "/fixture/flatpak-data",
+          XDG_DATA_HOME: "/fixture/xdg-data",
+        },
+      }),
+    ).toBe("/fixture/flatpak-data/zed");
+  });
+
+  it("uses XDG_DATA_HOME for Zed on Linux", () => {
+    expect(
+      resolveProviderRoot(PROVIDER_SPECS.zed, "/fixture/home", {
+        platform: "linux",
+        environment: { XDG_DATA_HOME: "/fixture/xdg-data" },
+      }),
+    ).toBe("/fixture/xdg-data/zed");
+  });
+
+  it("rejects a relative Zed XDG data root", () => {
+    expect(() =>
+      resolveProviderRoot(PROVIDER_SPECS.zed, "/fixture/home", {
+        platform: "linux",
+        environment: { XDG_DATA_HOME: "relative/zed-data" },
+      }),
+    ).toThrow("XDG_DATA_HOME must be an absolute path");
+  });
 });

--- a/test/adapters/zed-logs.test.ts
+++ b/test/adapters/zed-logs.test.ts
@@ -1,0 +1,190 @@
+import { mkdir, mkdtemp, realpath, symlink, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ProviderAuditAdapter } from "../../src/adapters/provider-adapter.js";
+import { PROVIDER_SPECS } from "../../src/adapters/provider-specs.js";
+import type { AuditContext } from "../../src/contracts/adapter.js";
+import {
+  isZedRotatedLogRelativePath,
+  ZED_ROTATED_LOG_POLICY_ID,
+} from "../../src/core/provider-file-policy.js";
+
+const NOW = new Date("2026-07-28T00:00:00.000Z");
+const OLD = new Date("2026-06-01T00:00:00.000Z");
+
+async function fixtureContext(): Promise<AuditContext> {
+  return {
+    home: await mkdtemp(join(tmpdir(), "agentrinse-zed-logs-")),
+    now: NOW,
+    auditId: "audit-zed-logs",
+  };
+}
+
+async function writeDatedFile(path: string, value: string, date: Date): Promise<void> {
+  await writeFile(path, value);
+  await utimes(path, date, date);
+}
+
+function adapter(options: { root?: string; platform?: NodeJS.Platform } = {}) {
+  return new ProviderAuditAdapter(PROVIDER_SPECS.zed, {
+    environment: {},
+    measureBytes: true,
+    maxEntries: 100,
+    ...options,
+  });
+}
+
+describe("Zed rotated-log cleanup", () => {
+  it("proposes recoverable quarantine only for the old rotated macOS log", async () => {
+    const context = await fixtureContext();
+    const dataRoot = join(context.home, "Library", "Application Support", "Zed");
+    const logRoot = join(context.home, "Library", "Logs", "Zed");
+    await mkdir(dataRoot, { recursive: true });
+    await mkdir(logRoot, { recursive: true });
+    await writeDatedFile(join(logRoot, "Zed.log.old"), "synthetic rotated log\n", OLD);
+    await writeDatedFile(join(logRoot, "Zed.log"), "synthetic active log\n", OLD);
+    await writeDatedFile(join(logRoot, "Zed.log.old.backup"), "synthetic neighbor\n", OLD);
+    const zed = adapter({ platform: "darwin" });
+
+    const probe = await zed.probe(context);
+    const collection = await zed.collect(context, probe);
+    const exactLogs = collection.resources.filter(
+      (resource) => resource.facts.policyId === ZED_ROTATED_LOG_POLICY_ID,
+    );
+    const finding = await zed.classify(context, exactLogs[0]!);
+
+    expect(exactLogs).toHaveLength(1);
+    expect(exactLogs[0]).toMatchObject({
+      resource: {
+        kind: "agent-log-store",
+        path: await realpath(join(logRoot, "Zed.log.old")),
+      },
+    });
+    expect(
+      collection.resources.some(
+        (resource) =>
+          resource.resource.path?.endsWith("Zed.log") ||
+          resource.resource.path?.endsWith("Zed.log.old.backup"),
+      ),
+    ).toBe(false);
+    expect(finding).toMatchObject({
+      state: "eligible",
+      confidence: "certain",
+      roots: [{ code: "zed-rotated-log-owner-contract" }],
+      candidateActions: [
+        {
+          type: "provider.file-quarantine",
+          adapter: "zed",
+          policyId: ZED_ROTATED_LOG_POLICY_ID,
+          risk: "recoverable",
+          expectedReclaimBytes: 0,
+          quarantineTtlMinutes: 7 * 24 * 60,
+        },
+      ],
+    });
+  });
+
+  it("finds the external macOS log when the user-data root is absent", async () => {
+    const context = await fixtureContext();
+    const logRoot = join(context.home, "Library", "Logs", "Zed");
+    await mkdir(logRoot, { recursive: true });
+    await writeDatedFile(join(logRoot, "Zed.log.old"), "synthetic rotated log\n", OLD);
+    const zed = adapter({ platform: "darwin" });
+
+    const probe = await zed.probe(context);
+    const collection = await zed.collect(context, probe);
+
+    expect(probe.status).toBe("absent");
+    expect(collection.resources).toHaveLength(1);
+    expect(collection.resources[0]?.facts.policyId).toBe(ZED_ROTATED_LOG_POLICY_ID);
+  });
+
+  it("uses the logs directory under an explicit Zed data root", async () => {
+    const context = await fixtureContext();
+    const root = join(context.home, "custom-zed");
+    const logs = join(root, "logs");
+    await mkdir(logs, { recursive: true });
+    await writeDatedFile(join(logs, "Zed.log.old"), "synthetic custom rotated log\n", OLD);
+    const zed = adapter({ root, platform: "darwin" });
+
+    const probe = await zed.probe(context);
+    const collection = await zed.collect(context, probe);
+    const rotatedLog = collection.resources.find(
+      (resource) => resource.facts.policyId === ZED_ROTATED_LOG_POLICY_ID,
+    );
+
+    expect(probe).toMatchObject({ status: "available", root });
+    expect(rotatedLog?.resource.path).toBe(await realpath(join(logs, "Zed.log.old")));
+  });
+
+  it("does not collect a recent rotated log", async () => {
+    const context = await fixtureContext();
+    const root = join(context.home, "Library", "Application Support", "Zed");
+    const logs = join(context.home, "Library", "Logs", "Zed");
+    await mkdir(root, { recursive: true });
+    await mkdir(logs, { recursive: true });
+    await writeDatedFile(
+      join(logs, "Zed.log.old"),
+      "synthetic recent rotated log\n",
+      new Date("2026-07-20T00:00:00.000Z"),
+    );
+    const zed = adapter({ platform: "darwin" });
+
+    const probe = await zed.probe(context);
+    const collection = await zed.collect(context, probe);
+
+    expect(
+      collection.resources.some(
+        (resource) => resource.facts.policyId === ZED_ROTATED_LOG_POLICY_ID,
+      ),
+    ).toBe(false);
+  });
+
+  it("does not follow a symlinked log root or rotated log", async () => {
+    const rootContext = await fixtureContext();
+    const dataRoot = join(rootContext.home, "Library", "Application Support", "Zed");
+    const logsParent = join(rootContext.home, "Library", "Logs");
+    const outside = await mkdtemp(join(tmpdir(), "agentrinse-zed-logs-target-"));
+    await mkdir(dataRoot, { recursive: true });
+    await mkdir(logsParent, { recursive: true });
+    await writeDatedFile(join(outside, "Zed.log.old"), "outside\n", OLD);
+    await symlink(outside, join(logsParent, "Zed"));
+    const zed = adapter({ platform: "darwin" });
+
+    const rootProbe = await zed.probe(rootContext);
+    const rootCollection = await zed.collect(rootContext, rootProbe);
+
+    expect(rootCollection.resources).toHaveLength(1);
+    expect(rootCollection.diagnostics).toContainEqual(
+      expect.objectContaining({ code: "ZED_LOG_ROOT_UNSAFE" }),
+    );
+
+    const fileContext = await fixtureContext();
+    const fileDataRoot = join(fileContext.home, "Library", "Application Support", "Zed");
+    const fileLogRoot = join(fileContext.home, "Library", "Logs", "Zed");
+    const outsideFile = join(fileContext.home, "outside.log");
+    await mkdir(fileDataRoot, { recursive: true });
+    await mkdir(fileLogRoot, { recursive: true });
+    await writeDatedFile(outsideFile, "outside\n", OLD);
+    await symlink(outsideFile, join(fileLogRoot, "Zed.log.old"));
+
+    const fileProbe = await zed.probe(fileContext);
+    const fileCollection = await zed.collect(fileContext, fileProbe);
+
+    expect(
+      fileCollection.resources.some(
+        (resource) => resource.facts.policyId === ZED_ROTATED_LOG_POLICY_ID,
+      ),
+    ).toBe(false);
+  });
+
+  it("matches only the exact rotated log filename", () => {
+    expect(isZedRotatedLogRelativePath("Zed.log.old")).toBe(true);
+    expect(isZedRotatedLogRelativePath("Zed.log")).toBe(false);
+    expect(isZedRotatedLogRelativePath("Zed.log.old.backup")).toBe(false);
+    expect(isZedRotatedLogRelativePath(join("nested", "Zed.log.old"))).toBe(false);
+  });
+});

--- a/test/core/provider-file-policy.test.ts
+++ b/test/core/provider-file-policy.test.ts
@@ -11,6 +11,7 @@ import {
   authorizeProviderFileAction,
   CLAUDE_CHANGELOG_CACHE_POLICY_ID,
   CLAUDE_DEBUG_LOG_POLICY_ID,
+  ZED_ROTATED_LOG_POLICY_ID,
 } from "../../src/core/provider-file-policy.js";
 
 async function actionFor(
@@ -49,6 +50,31 @@ async function cacheActionFor(
     resourceId: "claude:agent-cache:policy-test",
     policyId: CLAUDE_CHANGELOG_CACHE_POLICY_ID,
     description: "quarantine a synthetic Claude changelog cache",
+  };
+}
+
+async function zedActionFor(
+  ownerRoot: string,
+  relativePath: string,
+  mtime = new Date("2026-06-01T00:00:00.000Z"),
+): Promise<Extract<ProviderFileQuarantineAction, { adapter: "zed" }>> {
+  const path = join(ownerRoot, relativePath);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, "synthetic Zed log\n");
+  await utimes(path, mtime, mtime);
+  const target = await inspectProviderFile(path, ownerRoot, "zed");
+  return {
+    actionId: "provider.file-quarantine:zed-policy-test",
+    type: "provider.file-quarantine",
+    adapter: "zed",
+    resourceId: "zed:agent-log-store:policy-test",
+    policyId: ZED_ROTATED_LOG_POLICY_ID,
+    risk: "recoverable",
+    description: "quarantine a synthetic rotated Zed log",
+    expectedReclaimBytes: 0,
+    pendingQuarantineBytes: target.measuredBytes,
+    quarantineTtlMinutes: 7 * 24 * 60,
+    target,
   };
 }
 
@@ -255,5 +281,116 @@ describe("provider file policy", () => {
         new Date("2026-07-27T00:00:00.000Z"),
       ),
     ).rejects.toThrow("at least seven days");
+  });
+
+  it("authorizes the exact old rotated Zed log under the default macOS log root", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-policy-home-"));
+    const ownerRoot = join(home, "Library", "Logs", "Zed");
+    const action = await zedActionFor(ownerRoot, "Zed.log.old");
+
+    await expect(
+      authorizeProviderFileAction(
+        action,
+        home,
+        DEFAULT_CONFIG,
+        "darwin",
+        {},
+        new Date("2026-07-28T00:00:00.000Z"),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("authorizes the rotated Zed log under an explicit data root", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-policy-home-"));
+    const dataRoot = join(home, "custom-zed");
+    const ownerRoot = join(dataRoot, "logs");
+    const action = await zedActionFor(ownerRoot, "Zed.log.old");
+    const config = {
+      ...DEFAULT_CONFIG,
+      adapters: {
+        ...DEFAULT_CONFIG.adapters,
+        zed: { enabled: true, root: dataRoot },
+      },
+    };
+
+    await expect(
+      authorizeProviderFileAction(
+        action,
+        home,
+        config,
+        "darwin",
+        {},
+        new Date("2026-07-28T00:00:00.000Z"),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it.each(["Zed.log", "Zed.log.old.backup", join("nested", "Zed.log.old")])(
+    "rejects the non-Zed-log-policy path %s",
+    async (relativePath) => {
+      const home = await mkdtemp(join(tmpdir(), "agentrinse-policy-home-"));
+      const ownerRoot = join(home, "Library", "Logs", "Zed");
+      const action = await zedActionFor(ownerRoot, relativePath);
+
+      await expect(
+        authorizeProviderFileAction(
+          action,
+          home,
+          DEFAULT_CONFIG,
+          "darwin",
+          {},
+          new Date("2026-07-28T00:00:00.000Z"),
+        ),
+      ).rejects.toThrow(
+        `provider-file target is not approved by policy zed:${ZED_ROTATED_LOG_POLICY_ID}`,
+      );
+    },
+  );
+
+  it("rejects recent rotated Zed logs, shortened recovery, and the wrong owner root", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-policy-home-"));
+    const ownerRoot = join(home, "Library", "Logs", "Zed");
+    const recent = await zedActionFor(
+      ownerRoot,
+      "Zed.log.old",
+      new Date("2026-07-20T00:00:00.000Z"),
+    );
+
+    await expect(
+      authorizeProviderFileAction(
+        recent,
+        home,
+        DEFAULT_CONFIG,
+        "darwin",
+        {},
+        new Date("2026-07-28T00:00:00.000Z"),
+      ),
+    ).rejects.toThrow("Zed rotated logs must be at least 30 days old");
+
+    const old = await zedActionFor(ownerRoot, "Zed.log.old");
+    old.quarantineTtlMinutes = 60;
+    await expect(
+      authorizeProviderFileAction(
+        old,
+        home,
+        DEFAULT_CONFIG,
+        "darwin",
+        {},
+        new Date("2026-07-28T00:00:00.000Z"),
+      ),
+    ).rejects.toThrow("at least seven days");
+
+    const wrongRoot = join(home, "wrong-zed-logs");
+    const wrong = await zedActionFor(wrongRoot, "Zed.log.old");
+    await expect(
+      authorizeProviderFileAction(
+        wrong,
+        home,
+        DEFAULT_CONFIG,
+        "darwin",
+        {},
+        new Date("2026-07-28T00:00:00.000Z"),
+      ),
+    ).rejects.toThrow("provider-file target is outside the configured zed root");
   });
 });

--- a/test/core/provider-processes.test.ts
+++ b/test/core/provider-processes.test.ts
@@ -34,6 +34,18 @@ describe("provider process inspection", () => {
     ).resolves.toEqual({ status: "busy", pids: [201, 202] });
   });
 
+  it("detects Zed application and headless processes", async () => {
+    await expect(
+      inspectProviderProcesses("zed", {
+        runPs: async () =>
+          [
+            "  211 /Applications/Zed.app/Contents/MacOS/zed",
+            "  212 /usr/local/bin/zed-editor --headless",
+          ].join("\n"),
+      }),
+    ).resolves.toEqual({ status: "busy", pids: [211, 212] });
+  });
+
   it("fails closed on incomplete process evidence", async () => {
     await expect(
       inspectProviderProcesses("opencode", {


### PR DESCRIPTION
## Summary

- register an exact provider-file policy for Zed's single rotated `Zed.log.old`
- resolve the native macOS log root plus explicit, Flatpak, and XDG data roots
- quarantine only logs older than 30 days with a seven-day undo window
- prove apply, undo, re-apply, and purge through the built and installed package

Refs #16

## Resource owner and source contract

Zed owns the data and log layouts. This change pins source evidence at
`zed-industries/zed@fee527c70fe3a701c28e4fb29b2acd61fcd1e23f`:

- data and log roots, active `Zed.log`, and rotated `Zed.log.old`:
  https://github.com/zed-industries/zed/blob/fee527c70fe3a701c28e4fb29b2acd61fcd1e23f/crates/paths/src/paths.rs#L54-L58
  and
  https://github.com/zed-industries/zed/blob/fee527c70fe3a701c28e4fb29b2acd61fcd1e23f/crates/paths/src/paths.rs#L227-L255
- file logging rotates through those exact active and old paths:
  https://github.com/zed-industries/zed/blob/fee527c70fe3a701c28e4fb29b2acd61fcd1e23f/crates/zed/src/main.rs#L293-L302

## Safety boundary

- **Discovery:** inspect only the exact `Zed.log.old`; do not enumerate the log
  directory.
- **Protection roots:** authorize the native macOS
  `$HOME/Library/Logs/Zed` root or the `logs` child beneath the exact configured
  or resolved Zed data root.
- **Risk:** `recoverable`; the default `safe` ceiling cannot select it.
- **Age:** require 30 days at audit and authorization.
- **Revalidation:** repeat provider policy, owner-root, path, file identity,
  content digest, age, provider-process, open-descriptor, link-count, and
  same-filesystem checks at the mutation boundary.
- **Recovery:** retain the exact inode for seven days; support descriptor-bound
  undo and explicit purge through the existing provider-file journal.

The active `Zed.log`, ACP logs, neighboring files, databases, threads, crash
reports, settings, credentials, extensions, symlinks, and unknown paths remain
protected.

## Verification

- `63` test files passed: `467` passed, `1` skipped
- format, lint, typecheck, build, and `9` generated schema checks passed
- source CLI smoke passed Zed apply, undo, second apply, and purge
- installed tarball smoke passed the same flow and kept active `Zed.log`
  unchanged
- package manifest, `publint`, and `npm pack --dry-run` passed
- autoreview clean after adding the missing packaged mutation/recovery proof
