### PR TITLE
feat(opencode): report native maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The project follows semantic versioning after its first supported release.
   log after 30 days, with a seven-day undo window before purge
 - Zed log-root discovery for the native macOS log directory, explicit
   user-data roots, and absolute Flatpak/XDG data roots on Linux
+- report-only OpenCode maintenance findings for the native snapshot Git
+  garbage-collection schedule and the separate append-only server log
 
 ### Safety
 
@@ -19,6 +21,9 @@ The project follows semantic versioning after its first supported release.
   `Zed.log`, ACP logs, neighboring files, databases, threads, crash reports,
   settings, credentials, extensions, active Zed processes, and open
   descriptors
+- OpenCode findings are pinned to the inspected `1.18.9` source contract,
+  remain unknown-confidence until the installed version is proven, and never
+  invoke Git or remove logs
 
 ## [0.5.0] - 2026-07-28
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ compaction for the exact current Codex `state_5`, `logs_2`, `goals_1`, and
 `memories_1` SQLite contracts. Claude cleanup is limited to exact old debug
 text files and its rebuildable changelog cache. AgentRinse also reports
 Claude's native retention policy and Copilot's native session and process-log
-maintenance. Docker remains audit-only.
+maintenance. It also reports OpenCode's owner-run snapshot compaction and its
+separate append-only server log. Docker remains audit-only.
 
 ## agent integrations
 
@@ -71,7 +72,7 @@ logical memory records.
 | <img width="48px" src="docs/client-cursor.jpg" alt="Cursor" />              | [Cursor](https://cursor.com/docs)                           | audit-only              | local agent state and workspace references                          |
 | <img width="48px" src="docs/client-copilot.png" alt="GitHub Copilot CLI" /> | [GitHub Copilot CLI](https://github.com/github/copilot-cli) | audit + native guidance | local sessions, process logs, and provider-owned maintenance        |
 | <img width="48px" src="docs/client-zed.svg" alt="Zed" />                    | [Zed](https://zed.dev/docs/ai/overview)                     | audit + quarantine      | local agent state and the exact stale rotated application log       |
-| <img width="48px" src="docs/client-opencode.png" alt="OpenCode" />          | [OpenCode](https://opencode.ai/)                            | audit-only              | local agent state                                                   |
+| <img width="48px" src="docs/client-opencode.png" alt="OpenCode" />          | [OpenCode](https://opencode.ai/)                            | audit + native guidance | local state, snapshot GC, and server-log retention                  |
 | <img width="48px" src="docs/client-grok-build.svg" alt="Grok Build" />      | [Grok Build](https://docs.x.ai/build/overview)              | audit-only              | local agent state                                                   |
 
 ## cleanup surfaces
@@ -85,6 +86,7 @@ logical memory records.
 | <img width="48px" src="docs/client-claude.jpg" alt="Claude Code" />         | Claude logs and changelog cache      | recoverable        | exact old files, provider liveness, seven-day undo, and explicit purge  |
 | <img width="48px" src="docs/client-copilot.png" alt="GitHub Copilot CLI" /> | Copilot native maintenance           | report-only        | local session pruning and versioned process-log retention               |
 | <img width="48px" src="docs/client-zed.svg" alt="Zed" />                    | Zed rotated application log          | recoverable        | exact `Zed.log.old`, provider liveness, seven-day undo, and purge       |
+| <img width="48px" src="docs/client-opencode.png" alt="OpenCode" />          | OpenCode native maintenance          | report-only        | hourly snapshot GC and the append-only server-log contract              |
 | ⚡                                                                          | Agent runtimes                       | audit-only, opt-in | installed agent executables and versions                                |
 | <img width="48px" src="docs/client-docker-agent.svg" alt="Docker" />        | [Docker](https://docs.docker.com/)   | audit-only, opt-in | images and containers                                                   |
 | 🕳️                                                                          | [Mole](https://github.com/tw93/Mole) | suggestions only   | external dry-run cleanup opportunities on macOS                         |
@@ -379,7 +381,8 @@ unreleased build at real developer state.
 `0.5.0` ships the complete audit → plan → revalidate → apply loop, safe
 configured artifact cleanup, recoverable Git worktree and Claude file
 quarantine, and recoverable offline Codex database compaction. Current main
-also quarantines the exact stale Zed `Zed.log.old` file. Cursor, OpenCode, Grok
-Build, Docker, and all other Zed state remain report-only.
+also quarantines the exact stale Zed `Zed.log.old` file and reports OpenCode's
+native maintenance contract. Cursor, Grok Build, Docker, and all other Zed and
+OpenCode state remain non-mutating.
 
 MIT licensed. built by [Vincent Koc](https://github.com/vincentkoc).

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -13,7 +13,7 @@ recoverable whole-worktree action when every safety gate is proven.
 | Cursor         | workspace state, global state, logs                       | all             |
 | GitHub Copilot | CLI sessions, logs, native maintenance guidance           | all             |
 | Zed            | user-data root and exact rotated-log quarantine           | conditional     |
-| OpenCode       | database, logs, snapshots                                 | all             |
+| OpenCode       | database, logs, snapshots, native maintenance guidance    | all             |
 | Grok Build     | version-gated data root                                   | all             |
 | Runtime        | opt-in selected executable and Claude native versions     | all             |
 | Git            | worktree audit and recoverable linked-worktree quarantine | conditional     |
@@ -122,6 +122,17 @@ protected.
 
 Snapshot repositories are recovery state, not ordinary Git cache. AgentRinse
 never runs Git garbage collection inside them.
+
+The inspected OpenCode `1.18.9` source schedules its own snapshot
+`git gc --prune=7.days` after a one-minute delay and repeats it hourly while
+the snapshot service is active. AgentRinse reports that owner maintenance but
+does not invoke it, because the installed OpenCode version is not probed.
+
+The same source writes server logs by appending to
+`$XDG_DATA_HOME/opencode/log/opencode.log` and defines no server-log retention
+sweep. OpenCode Desktop's separate seven-day cleanup applies to its Electron
+user-data log runs, not this server log directory. AgentRinse reports the
+distinction and emits no action for either log surface.
 
 ### Grok Build
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -2165,8 +2165,21 @@ MVP behavior:
 - detect recursive/self-capture risk
 - report stale temporary pack candidates
 - explain the OpenCode setting that controls snapshots
+- report the owner-run snapshot garbage-collection contract
 - never run Git garbage collection inside a snapshot repository
 - never delete snapshot objects or packs
+
+OpenCode `1.18.9` schedules its own snapshot
+`git gc --prune=7.days` after one minute and repeats it hourly while the
+snapshot service is active. AgentRinse reports this version-pinned owner
+maintenance with unknown confidence until the installed OpenCode version is
+proven. It does not duplicate or trigger the Git operation.
+
+The same shipped source appends server logs to
+`$XDG_DATA_HOME/opencode/log/opencode.log` without a server-log retention
+sweep. OpenCode Desktop owns a distinct Electron log root and removes entries
+older than seven days there. AgentRinse must not apply the desktop policy to
+the server log directory.
 
 Future cleanup requires one of:
 
@@ -3189,30 +3202,30 @@ Exit criteria:
 
 ## Default Policy Table
 
-| Resource                       | Default age | Action               | Risk        | Recovery        |
-| ------------------------------ | ----------: | -------------------- | ----------- | --------------- |
-| active worktree                |         any | none                 | n/a         | protected       |
-| dirty worktree                 |         any | none                 | n/a         | protected       |
-| unpushed worktree              |         any | none                 | n/a         | protected       |
-| locked worktree                |         any | none                 | n/a         | protected       |
-| inactive worktree artifacts    |          3d | remove artifacts     | safe        | rebuild         |
-| clean unreachable worktree     |         14d | quarantine           | recoverable | 7d undo         |
-| Codex/Claude sessions          |         any | report only          | n/a         | provider-owned  |
-| Cursor workspace/global state  |         any | report only          | n/a         | editor-owned    |
-| GitHub Copilot sessions        |         any | report only          | n/a         | provider-owned  |
-| Zed database/agent state       |         any | report only          | n/a         | editor-owned    |
-| Zed `Zed.log.old`              |         30d | quarantine           | recoverable | 7d undo         |
-| OpenCode database/snapshots    |         any | report only          | n/a         | provider-owned  |
-| Grok Build sessions/task state |         any | report only          | n/a         | provider-owned  |
-| Codex logs DB free pages       |   threshold | report only          | n/a         | phase 4         |
-| dangling Docker image          |         14d | remove exact image   | safe        | rebuild/pull    |
-| Docker build cache             |          7d | filtered prune       | safe        | rebuild         |
-| unlabeled stopped container    |         any | report only          | n/a         | owner decision  |
-| labeled stopped container      |         14d | report only          | n/a         | future design   |
-| Docker network                 |         14d | narrow removal       | safe        | recreate        |
-| Docker volume                  |         any | report only          | n/a         | protected       |
-| old agent runtime              |         14d | report, later remove | safe        | package manager |
-| Mole cleanup                   |         any | handoff              | external    | Mole-owned      |
+| Resource                        | Default age | Action                | Risk        | Recovery        |
+| ------------------------------- | ----------: | --------------------- | ----------- | --------------- |
+| active worktree                 |         any | none                  | n/a         | protected       |
+| dirty worktree                  |         any | none                  | n/a         | protected       |
+| unpushed worktree               |         any | none                  | n/a         | protected       |
+| locked worktree                 |         any | none                  | n/a         | protected       |
+| inactive worktree artifacts     |          3d | remove artifacts      | safe        | rebuild         |
+| clean unreachable worktree      |         14d | quarantine            | recoverable | 7d undo         |
+| Codex/Claude sessions           |         any | report only           | n/a         | provider-owned  |
+| Cursor workspace/global state   |         any | report only           | n/a         | editor-owned    |
+| GitHub Copilot sessions         |         any | report only           | n/a         | provider-owned  |
+| Zed database/agent state        |         any | report only           | n/a         | editor-owned    |
+| Zed `Zed.log.old`               |         30d | quarantine            | recoverable | 7d undo         |
+| OpenCode database/log/snapshots |         any | report + native facts | n/a         | provider-owned  |
+| Grok Build sessions/task state  |         any | report only           | n/a         | provider-owned  |
+| Codex logs DB free pages        |   threshold | report only           | n/a         | phase 4         |
+| dangling Docker image           |         14d | remove exact image    | safe        | rebuild/pull    |
+| Docker build cache              |          7d | filtered prune        | safe        | rebuild         |
+| unlabeled stopped container     |         any | report only           | n/a         | owner decision  |
+| labeled stopped container       |         14d | report only           | n/a         | future design   |
+| Docker network                  |         14d | narrow removal        | safe        | recreate        |
+| Docker volume                   |         any | report only           | n/a         | protected       |
+| old agent runtime               |         14d | report, later remove  | safe        | package manager |
+| Mole cleanup                    |         any | handoff               | external    | Mole-owned      |
 
 Defaults are intentionally conservative. Power comes from good root discovery,
 not aggressive age thresholds.
@@ -3421,8 +3434,21 @@ configuration, or neighboring files.
 
 The shared executor does not decide retention. Each provider adapter needs a
 separate evidence-backed policy for its known log or cache files before it may
-emit the action. Claude transcript retention and OpenCode snapshot compaction
-therefore remain separate provider-owned designs.
+emit the action. Claude transcript retention remains provider-owned. OpenCode
+snapshot compaction is already owner-run, so AgentRinse reports the pinned
+contract and does not add a competing Git operation.
+
+### 2026-07-29: OpenCode owns snapshot Git maintenance
+
+OpenCode `1.18.9` stores snapshot repositories below its data root and runs
+`git gc --prune=7.days` after one minute, then hourly, under its own per-snapshot
+lock. AgentRinse reports this behavior instead of invoking Git against recovery
+state.
+
+The CLI/server logger appends to one `opencode.log` and does not define the
+desktop application's seven-day cleanup. AgentRinse keeps both surfaces
+protected, reports the distinction, and emits no cleanup action until a
+versioned owner contract includes exact scope and recovery behavior.
 
 ### 2026-07-28: Zed cleanup is one rotated log
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -69,11 +69,11 @@ Current:
 - exact stale Zed `Zed.log.old` quarantine
 - native macOS, explicit-root, Flatpak, and XDG log-root resolution
 - active Zed, descriptor, symlink, age, and exact-path refusal
+- report-only OpenCode snapshot GC and server-log retention contracts
 
 Remaining:
 
 - Cursor database diagnostics and optional compaction
-- provider-native retention operations
 - filtered Docker build-cache cleanup
 - owner-managed old agent runtime removal
 

--- a/src/adapters/opencode-maintenance.ts
+++ b/src/adapters/opencode-maintenance.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+
+const opencodeSnapshotGcFactsSchema = z.object({
+  provider: z.literal("opencode"),
+  kind: z.literal("snapshot-gc"),
+  sourceVersion: z.literal("1.18.9"),
+  pruneAgeDays: z.literal(7),
+  startupDelayMinutes: z.literal(1),
+  intervalHours: z.literal(1),
+  snapshotsMustBeEnabled: z.literal(true),
+  installedSupportKnown: z.literal(false),
+});
+
+const opencodeServerLogFactsSchema = z.object({
+  provider: z.literal("opencode"),
+  kind: z.literal("server-log-retention"),
+  sourceVersion: z.literal("1.18.9"),
+  fileName: z.literal("opencode.log"),
+  writeMode: z.literal("append"),
+  automaticRetention: z.literal(false),
+  desktopRetentionIsSeparate: z.literal(true),
+  installedSupportKnown: z.literal(false),
+});
+
+export const opencodeNativeMaintenanceFactsSchema = z.discriminatedUnion("kind", [
+  opencodeSnapshotGcFactsSchema,
+  opencodeServerLogFactsSchema,
+]);
+
+export type OpenCodeNativeMaintenanceFacts = z.infer<typeof opencodeNativeMaintenanceFactsSchema>;
+
+export function opencodeNativeMaintenanceFor(
+  relativePath: string,
+): OpenCodeNativeMaintenanceFacts | undefined {
+  if (relativePath === "snapshot") {
+    return {
+      provider: "opencode",
+      kind: "snapshot-gc",
+      sourceVersion: "1.18.9",
+      pruneAgeDays: 7,
+      startupDelayMinutes: 1,
+      intervalHours: 1,
+      snapshotsMustBeEnabled: true,
+      installedSupportKnown: false,
+    };
+  }
+  if (relativePath === "log") {
+    return {
+      provider: "opencode",
+      kind: "server-log-retention",
+      sourceVersion: "1.18.9",
+      fileName: "opencode.log",
+      writeMode: "append",
+      automaticRetention: false,
+      desktopRetentionIsSeparate: true,
+      installedSupportKnown: false,
+    };
+  }
+  return undefined;
+}

--- a/src/adapters/provider-adapter.ts
+++ b/src/adapters/provider-adapter.ts
@@ -35,6 +35,10 @@ import {
   copilotNativeMaintenanceFactsSchema,
   copilotNativeMaintenanceFor,
 } from "./copilot-maintenance.js";
+import {
+  opencodeNativeMaintenanceFactsSchema,
+  opencodeNativeMaintenanceFor,
+} from "./opencode-maintenance.js";
 import { collectProviderReachability } from "./provider-reachability.js";
 import { resolveProviderRoot } from "./provider-root.js";
 import type { ProviderSpec } from "./provider-specs.js";
@@ -232,6 +236,10 @@ export class ProviderAuditAdapter implements AuditAdapter {
         this.spec.id === "copilot"
           ? copilotNativeMaintenanceFor(candidate.relativePath)
           : undefined;
+      const opencodeNativeMaintenance =
+        this.spec.id === "opencode"
+          ? opencodeNativeMaintenanceFor(candidate.relativePath)
+          : undefined;
 
       try {
         const stats = await lstat(path);
@@ -300,6 +308,9 @@ export class ProviderAuditAdapter implements AuditAdapter {
             ...(copilotNativeMaintenance === undefined
               ? {}
               : { nativeMaintenance: copilotNativeMaintenance }),
+            ...(opencodeNativeMaintenance === undefined
+              ? {}
+              : { nativeMaintenance: opencodeNativeMaintenance }),
             ...(databaseInspection === undefined
               ? {}
               : {
@@ -363,6 +374,9 @@ export class ProviderAuditAdapter implements AuditAdapter {
       resource.facts.nativeRetention,
     );
     const copilotNativeMaintenance = copilotNativeMaintenanceFactsSchema.safeParse(
+      resource.facts.nativeMaintenance,
+    );
+    const opencodeNativeMaintenance = opencodeNativeMaintenanceFactsSchema.safeParse(
       resource.facts.nativeMaintenance,
     );
     const providerFilePolicy =
@@ -615,6 +629,42 @@ export class ProviderAuditAdapter implements AuditAdapter {
             source: this.id,
             observedAt,
             detail: "Copilot owns this maintenance path; AgentRinse does not mutate the resource.",
+          },
+        ],
+        facts: resource.facts,
+        candidateActions: [],
+        ...(resource.measuredBytes === undefined ? {} : { measuredBytes: resource.measuredBytes }),
+        warnings: [],
+      };
+    }
+    if (this.spec.id === "opencode" && opencodeNativeMaintenance.success) {
+      const detail =
+        opencodeNativeMaintenance.data.kind === "snapshot-gc"
+          ? "OpenCode 1.18.9 schedules snapshot Git garbage collection after one minute and hourly, pruning objects older than seven days; AgentRinse did not probe the installed version."
+          : "OpenCode 1.18.9 appends server logs to opencode.log without a server-log retention sweep; the desktop application's separate seven-day log cleanup does not cover this directory.";
+      return {
+        schemaVersion: 1,
+        findingId: `${resource.resource.id}:${sha256(context.auditId)}`,
+        auditId: context.auditId,
+        observedAt,
+        resource: resource.resource,
+        state: "protected",
+        confidence: "unknown",
+        roots: [
+          {
+            code:
+              opencodeNativeMaintenance.data.kind === "snapshot-gc"
+                ? "opencode-native-snapshot-gc-version-unverified"
+                : "opencode-server-log-retention-version-unverified",
+            source: this.id,
+            observedAt,
+            detail,
+          },
+          {
+            code: "provider-owned-report-only",
+            source: this.id,
+            observedAt,
+            detail: "OpenCode owns this maintenance path; AgentRinse does not mutate the resource.",
           },
         ],
         facts: resource.facts,

--- a/test/adapters/opencode-maintenance.test.ts
+++ b/test/adapters/opencode-maintenance.test.ts
@@ -1,0 +1,87 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ProviderAuditAdapter } from "../../src/adapters/provider-adapter.js";
+import { PROVIDER_SPECS } from "../../src/adapters/provider-specs.js";
+import type { AuditContext } from "../../src/contracts/adapter.js";
+
+async function fixtureContext(): Promise<AuditContext> {
+  return {
+    home: await mkdtemp(join(tmpdir(), "agentrinse-opencode-maintenance-")),
+    now: new Date("2026-07-29T00:00:00.000Z"),
+    auditId: "audit-opencode-maintenance",
+  };
+}
+
+describe("OpenCode native maintenance reporting", () => {
+  it("reports owner snapshot GC and server-log retention without creating actions", async () => {
+    const context = await fixtureContext();
+    const root = join(context.home, "opencode-data");
+    await mkdir(join(root, "log"), { recursive: true });
+    await mkdir(join(root, "snapshot", "project", "worktree"), { recursive: true });
+    await writeFile(join(root, "opencode.db"), "synthetic\n");
+    await writeFile(join(root, "log", "opencode.log"), "synthetic\n");
+    await writeFile(join(root, "snapshot", "project", "worktree", "HEAD"), "synthetic\n");
+    const adapter = new ProviderAuditAdapter(PROVIDER_SPECS.opencode, {
+      root,
+      measureBytes: true,
+      maxEntries: 100,
+    });
+
+    const probe = await adapter.probe(context);
+    const collection = await adapter.collect(context, probe);
+    const database = collection.resources.find(
+      (resource) => resource.resource.displayName === "OpenCode database",
+    );
+    const logs = collection.resources.find(
+      (resource) => resource.resource.displayName === "OpenCode logs",
+    );
+    const snapshots = collection.resources.find(
+      (resource) => resource.resource.displayName === "OpenCode snapshots",
+    );
+    const findings = await Promise.all(
+      collection.resources.map((resource) => adapter.classify(context, resource)),
+    );
+
+    expect(database?.facts.nativeMaintenance).toBeUndefined();
+    expect(logs?.facts.nativeMaintenance).toEqual({
+      provider: "opencode",
+      kind: "server-log-retention",
+      sourceVersion: "1.18.9",
+      fileName: "opencode.log",
+      writeMode: "append",
+      automaticRetention: false,
+      desktopRetentionIsSeparate: true,
+      installedSupportKnown: false,
+    });
+    expect(snapshots?.facts.nativeMaintenance).toEqual({
+      provider: "opencode",
+      kind: "snapshot-gc",
+      sourceVersion: "1.18.9",
+      pruneAgeDays: 7,
+      startupDelayMinutes: 1,
+      intervalHours: 1,
+      snapshotsMustBeEnabled: true,
+      installedSupportKnown: false,
+    });
+    expect(findings).toHaveLength(3);
+    expect(
+      findings.every(
+        (finding) =>
+          finding.state === "protected" &&
+          finding.candidateActions.length === 0 &&
+          finding.roots.some((rootEvidence) => rootEvidence.code === "provider-owned-report-only"),
+      ),
+    ).toBe(true);
+    expect(
+      findings.find((finding) => finding.resource.displayName === "OpenCode logs")?.roots[0]?.code,
+    ).toBe("opencode-server-log-retention-version-unverified");
+    expect(
+      findings.find((finding) => finding.resource.displayName === "OpenCode snapshots")?.roots[0]
+        ?.code,
+    ).toBe("opencode-native-snapshot-gc-version-unverified");
+  });
+});


### PR DESCRIPTION
## Summary

- report the OpenCode 1.18.9 owner-run snapshot GC schedule
- distinguish append-only CLI/server logs from Desktop seven-day log cleanup
- keep OpenCode database, logs, and snapshots protected with no candidate actions

Part of #16.

## Ownership and safety

- owner: OpenCode
- discovery evidence: shipped `v1.18.9` source at `f28d72d15e00f51f7e30f9cbf08b810f292bb3ee`
- protection roots: database, logs, snapshots, sessions, config, auth, and unknown installed versions
- risk class: report-only
- revalidation: none required because no action is emitted
- recovery: not applicable because AgentRinse performs no mutation

## Verification

- `./node_modules/.bin/oxfmt --check .`
- `./node_modules/.bin/oxlint src test`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `./node_modules/.bin/vitest run` (64 files, 468 passed, 1 skipped)
- build, 9 JSON schemas, package manifest, and publint checks
- autoreview clean, 0.93 correctness
