### PR TITLE
feat(cursor): report native database maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The project follows semantic versioning after its first supported release.
   user-data roots, and absolute Flatpak/XDG data roots on Linux
 - report-only OpenCode maintenance findings for the native snapshot Git
   garbage-collection schedule and the separate append-only server log
+- exact Cursor global `state.vscdb` inventory with backup, WAL, and SHM
+  companion diagnostics
+- report-only Cursor owner-command findings for orphaned agent KV garbage
+  collection and user-selected old-chat deletion
 
 ### Safety
 
@@ -24,6 +28,8 @@ The project follows semantic versioning after its first supported release.
 - OpenCode findings are pinned to the inspected `1.18.9` source contract,
   remain unknown-confidence until the installed version is proven, and never
   invoke Git or remove logs
+- Cursor databases, chat history, workspace state, backups, and companions
+  remain protected; AgentRinse never invokes either command-palette operation
 
 ## [0.5.0] - 2026-07-28
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ compaction for the exact current Codex `state_5`, `logs_2`, `goals_1`, and
 text files and its rebuildable changelog cache. AgentRinse also reports
 Claude's native retention policy and Copilot's native session and process-log
 maintenance. It also reports OpenCode's owner-run snapshot compaction and its
-separate append-only server log. Docker remains audit-only.
+separate append-only server log, plus Cursor's owner-run state database
+maintenance. Docker remains audit-only.
 
 ## agent integrations
 
@@ -69,7 +70,7 @@ logical memory records.
 | --------------------------------------------------------------------------- | ----------------------------------------------------------- | ----------------------- | ------------------------------------------------------------------- |
 | <img width="48px" src="docs/client-openai.jpg" alt="OpenAI Codex" />        | [OpenAI Codex](https://github.com/openai/codex)             | audit + offline vacuum  | sessions, workspace roots, reachability, and supported SQLite state |
 | <img width="48px" src="docs/client-claude.jpg" alt="Claude Code" />         | [Claude Code](https://code.claude.com/docs/en/overview)     | retention + quarantine  | sessions, caches, roots, native retention, and exact old files      |
-| <img width="48px" src="docs/client-cursor.jpg" alt="Cursor" />              | [Cursor](https://cursor.com/docs)                           | audit-only              | local agent state and workspace references                          |
+| <img width="48px" src="docs/client-cursor.jpg" alt="Cursor" />              | [Cursor](https://cursor.com/docs)                           | audit + native guidance | workspace state, DB companions, and owner maintenance               |
 | <img width="48px" src="docs/client-copilot.png" alt="GitHub Copilot CLI" /> | [GitHub Copilot CLI](https://github.com/github/copilot-cli) | audit + native guidance | local sessions, process logs, and provider-owned maintenance        |
 | <img width="48px" src="docs/client-zed.svg" alt="Zed" />                    | [Zed](https://zed.dev/docs/ai/overview)                     | audit + quarantine      | local agent state and the exact stale rotated application log       |
 | <img width="48px" src="docs/client-opencode.png" alt="OpenCode" />          | [OpenCode](https://opencode.ai/)                            | audit + native guidance | local state, snapshot GC, and server-log retention                  |
@@ -87,6 +88,7 @@ logical memory records.
 | <img width="48px" src="docs/client-copilot.png" alt="GitHub Copilot CLI" /> | Copilot native maintenance           | report-only        | local session pruning and versioned process-log retention               |
 | <img width="48px" src="docs/client-zed.svg" alt="Zed" />                    | Zed rotated application log          | recoverable        | exact `Zed.log.old`, provider liveness, seven-day undo, and purge       |
 | <img width="48px" src="docs/client-opencode.png" alt="OpenCode" />          | OpenCode native maintenance          | report-only        | hourly snapshot GC and the append-only server-log contract              |
+| <img width="48px" src="docs/client-cursor.jpg" alt="Cursor" />              | Cursor database maintenance          | report-only        | exact DB companions, orphan KV GC, and destructive chat cleanup         |
 | ⚡                                                                          | Agent runtimes                       | audit-only, opt-in | installed agent executables and versions                                |
 | <img width="48px" src="docs/client-docker-agent.svg" alt="Docker" />        | [Docker](https://docs.docker.com/)   | audit-only, opt-in | images and containers                                                   |
 | 🕳️                                                                          | [Mole](https://github.com/tw93/Mole) | suggestions only   | external dry-run cleanup opportunities on macOS                         |
@@ -382,7 +384,7 @@ unreleased build at real developer state.
 configured artifact cleanup, recoverable Git worktree and Claude file
 quarantine, and recoverable offline Codex database compaction. Current main
 also quarantines the exact stale Zed `Zed.log.old` file and reports OpenCode's
-native maintenance contract. Cursor, Grok Build, Docker, and all other Zed and
-OpenCode state remain non-mutating.
+native maintenance contract plus Cursor's owner database commands. Grok Build,
+Docker, and all other Cursor, Zed, and OpenCode state remain non-mutating.
 
 MIT licensed. built by [Vincent Koc](https://github.com/vincentkoc).

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -10,7 +10,7 @@ recoverable whole-worktree action when every safety gate is proven.
 | -------------- | --------------------------------------------------------- | --------------- |
 | Codex          | sessions, worktrees, four SQLite DBs, offline compaction  | conditional     |
 | Claude         | sessions, caches, native retention, exact file quarantine | conditional     |
-| Cursor         | workspace state, global state, logs                       | all             |
+| Cursor         | workspace state, exact global DB, native maintenance      | all             |
 | GitHub Copilot | CLI sessions, logs, native maintenance guidance           | all             |
 | Zed            | user-data root and exact rotated-log quarantine           | conditional     |
 | OpenCode       | database, logs, snapshots, native maintenance guidance    | all             |
@@ -86,6 +86,25 @@ enumerate or mutate neighboring cache files, `paste-cache`, `image-cache`,
 
 Workspace and global databases can carry chat history. A missing project path
 does not make workspace storage disposable.
+
+AgentRinse inventories the exact global
+`User/globalStorage/state.vscdb` file and reports the byte size and file type
+of its `.backup`, `-wal`, and `-shm` companions without following symlinks or
+opening SQLite. Workspace storage and editor logs remain directory-level
+report-only resources.
+
+Cursor staff guidance current on 2026-07-13 documents two command-palette
+operations:
+
+- `Developer: GC Agent KV Blobs` removes orphaned agent KV blob data, preserves
+  existing chats, then runs SQLite `VACUUM`
+- `Developer: Delete Old Chats...` deletes chats older than a user-selected
+  cutoff, then runs `VACUUM`
+
+AgentRinse reports both commands with unknown confidence because it does not
+probe the installed Cursor version. It never invokes either operation. The
+second command is destructive logical history deletion and remains entirely
+user-owned.
 
 ### GitHub Copilot
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -2000,7 +2000,7 @@ Initial platform defaults:
 Inventory:
 
 - `User/workspaceStorage`
-- `User/globalStorage`
+- `User/globalStorage/state.vscdb`
 - editor logs
 - `state.vscdb`, backup, WAL, and SHM companions
 - workspace metadata that maps a storage hash to a project path
@@ -2021,9 +2021,11 @@ AgentRinse may report:
 - total bytes by workspace
 - missing workspace paths
 - old log directories
-- SQLite free-page estimates using read-only access
+- exact global database bytes
+- backup, WAL, and SHM companion status and bytes without following symlinks
 - active Cursor processes and open descriptors
 - database backup duplication
+- provider-owned database maintenance commands
 
 It must not:
 
@@ -2032,8 +2034,22 @@ It must not:
 - compact a database while Cursor or Cursor helpers are running
 - treat a missing workspace path as proof that its chat history is disposable
 
-Future log cleanup may become `safe` after versioned retention tests. Future
-offline compaction remains `experimental` and requires a rollback copy.
+Cursor staff guidance current on 2026-07-13 exposes two owner operations in the
+command palette:
+
+1. `Developer: GC Agent KV Blobs` removes orphaned agent KV blob data while
+   preserving existing chats, then runs SQLite `VACUUM`.
+2. `Developer: Delete Old Chats...` deletes chat history older than a
+   user-selected cutoff, then runs SQLite `VACUUM`.
+
+AgentRinse reports the commands but never invokes them. The installed Cursor
+version is not probed, so the finding remains unknown-confidence. The old-chat
+operation is destructive logical deletion, not cache cleanup, and stays
+entirely user-owned.
+
+Future log cleanup may become `safe` after versioned retention tests. Direct
+offline compaction remains excluded while Cursor provides its own maintenance
+path and the editor-internal schema remains version-sensitive.
 
 ## GitHub Copilot Adapter
 
@@ -3211,7 +3227,7 @@ Exit criteria:
 | inactive worktree artifacts     |          3d | remove artifacts      | safe        | rebuild         |
 | clean unreachable worktree      |         14d | quarantine            | recoverable | 7d undo         |
 | Codex/Claude sessions           |         any | report only           | n/a         | provider-owned  |
-| Cursor workspace/global state   |         any | report only           | n/a         | editor-owned    |
+| Cursor workspace/global state   |         any | report + native facts | n/a         | editor-owned    |
 | GitHub Copilot sessions         |         any | report only           | n/a         | provider-owned  |
 | Zed database/agent state        |         any | report only           | n/a         | editor-owned    |
 | Zed `Zed.log.old`               |         30d | quarantine            | recoverable | 7d undo         |
@@ -3741,6 +3757,10 @@ Primary references current as of 2026-07-27:
   `https://code.claude.com/docs/en/claude-directory`
 - Cursor documentation:
   `https://cursor.com/docs`
+- Cursor owner database maintenance:
+  `https://forum.cursor.com/t/cursor-2-6-repeated-vacuum-operations-over-3-hours/157387/40`
+- Cursor chat retention command:
+  `https://forum.cursor.com/t/where-are-agent-transcripts-stored/168976/2`
 - GitHub Copilot CLI configuration directory:
   `https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference`
 - GitHub Copilot CLI session data:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -70,10 +70,11 @@ Current:
 - native macOS, explicit-root, Flatpak, and XDG log-root resolution
 - active Zed, descriptor, symlink, age, and exact-path refusal
 - report-only OpenCode snapshot GC and server-log retention contracts
+- exact Cursor global database and companion diagnostics
+- report-only Cursor orphan KV GC and old-chat maintenance commands
 
 Remaining:
 
-- Cursor database diagnostics and optional compaction
 - filtered Docker build-cache cleanup
 - owner-managed old agent runtime removal
 

--- a/src/adapters/cursor-maintenance.ts
+++ b/src/adapters/cursor-maintenance.ts
@@ -1,0 +1,110 @@
+import { lstat } from "node:fs/promises";
+
+import { z } from "zod";
+
+const cursorOwnerCommandSchema = z.object({
+  command: z.string().min(1),
+  interface: z.literal("command-palette"),
+  destructive: z.boolean(),
+  runsVacuum: z.literal(true),
+});
+
+export const cursorNativeMaintenanceFactsSchema = z.object({
+  provider: z.literal("cursor"),
+  kind: z.literal("database-maintenance"),
+  evidenceDate: z.literal("2026-07-13"),
+  automaticRetention: z.literal(false),
+  installedSupportKnown: z.literal(false),
+  commands: z.tuple([
+    cursorOwnerCommandSchema.extend({
+      command: z.literal("Developer: GC Agent KV Blobs"),
+      destructive: z.literal(false),
+      scope: z.literal("orphaned-agent-kv-blobs"),
+      preservesExistingChats: z.literal(true),
+    }),
+    cursorOwnerCommandSchema.extend({
+      command: z.literal("Developer: Delete Old Chats..."),
+      destructive: z.literal(true),
+      scope: z.literal("chat-history-by-age"),
+      userChoosesCutoff: z.literal(true),
+    }),
+  ]),
+});
+
+export type CursorNativeMaintenanceFacts = z.infer<typeof cursorNativeMaintenanceFactsSchema>;
+
+const cursorDatabaseCompanionSchema = z.object({
+  suffix: z.enum([".backup", "-wal", "-shm"]),
+  status: z.enum(["missing", "regular", "symlink", "other", "unknown"]),
+  measuredBytes: z.number().int().nonnegative().optional(),
+  reason: z.string().min(1).optional(),
+});
+
+export const cursorDatabaseCompanionsSchema = z.array(cursorDatabaseCompanionSchema).length(3);
+
+export type CursorDatabaseCompanions = z.infer<typeof cursorDatabaseCompanionsSchema>;
+
+export function cursorNativeMaintenanceFor(
+  relativePath: string,
+): CursorNativeMaintenanceFacts | undefined {
+  if (relativePath !== "User/globalStorage/state.vscdb") {
+    return undefined;
+  }
+  return {
+    provider: "cursor",
+    kind: "database-maintenance",
+    evidenceDate: "2026-07-13",
+    automaticRetention: false,
+    installedSupportKnown: false,
+    commands: [
+      {
+        command: "Developer: GC Agent KV Blobs",
+        interface: "command-palette",
+        destructive: false,
+        runsVacuum: true,
+        scope: "orphaned-agent-kv-blobs",
+        preservesExistingChats: true,
+      },
+      {
+        command: "Developer: Delete Old Chats...",
+        interface: "command-palette",
+        destructive: true,
+        runsVacuum: true,
+        scope: "chat-history-by-age",
+        userChoosesCutoff: true,
+      },
+    ],
+  };
+}
+
+export async function inspectCursorDatabaseCompanions(
+  databasePath: string,
+): Promise<CursorDatabaseCompanions> {
+  return Promise.all(
+    ([".backup", "-wal", "-shm"] as const).map(async (suffix) => {
+      try {
+        const stats = await lstat(`${databasePath}${suffix}`);
+        if (stats.isSymbolicLink()) {
+          return { suffix, status: "symlink" as const };
+        }
+        if (!stats.isFile()) {
+          return { suffix, status: "other" as const };
+        }
+        return { suffix, status: "regular" as const, measuredBytes: stats.size };
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          "code" in error &&
+          (error as NodeJS.ErrnoException).code === "ENOENT"
+        ) {
+          return { suffix, status: "missing" as const };
+        }
+        return {
+          suffix,
+          status: "unknown" as const,
+          reason: error instanceof Error ? error.message : String(error),
+        };
+      }
+    }),
+  );
+}

--- a/src/adapters/cursor-maintenance.ts
+++ b/src/adapters/cursor-maintenance.ts
@@ -79,6 +79,7 @@ export function cursorNativeMaintenanceFor(
 
 export async function inspectCursorDatabaseCompanions(
   databasePath: string,
+  measureBytes: boolean,
 ): Promise<CursorDatabaseCompanions> {
   return Promise.all(
     ([".backup", "-wal", "-shm"] as const).map(async (suffix) => {
@@ -90,7 +91,11 @@ export async function inspectCursorDatabaseCompanions(
         if (!stats.isFile()) {
           return { suffix, status: "other" as const };
         }
-        return { suffix, status: "regular" as const, measuredBytes: stats.size };
+        return {
+          suffix,
+          status: "regular" as const,
+          ...(measureBytes ? { measuredBytes: stats.size } : {}),
+        };
       } catch (error) {
         if (
           error instanceof Error &&

--- a/src/adapters/cursor-maintenance.ts
+++ b/src/adapters/cursor-maintenance.ts
@@ -1,4 +1,5 @@
 import { lstat } from "node:fs/promises";
+import { join } from "node:path";
 
 import { z } from "zod";
 
@@ -44,10 +45,19 @@ export const cursorDatabaseCompanionsSchema = z.array(cursorDatabaseCompanionSch
 
 export type CursorDatabaseCompanions = z.infer<typeof cursorDatabaseCompanionsSchema>;
 
+export type CursorDatabaseParentInspection =
+  | { status: "safe" }
+  | { status: "missing" }
+  | { status: "blocked"; code: "symlink" | "not-directory" | "unreadable"; reason: string };
+
+function relativePathParts(relativePath: string): string[] {
+  return relativePath.split(/[\\/]+/u).filter(Boolean);
+}
+
 export function cursorNativeMaintenanceFor(
   relativePath: string,
 ): CursorNativeMaintenanceFacts | undefined {
-  if (relativePath.split(/[\\/]+/u).join("/") !== "User/globalStorage/state.vscdb") {
+  if (relativePathParts(relativePath).join("/") !== "User/globalStorage/state.vscdb") {
     return undefined;
   }
   return {
@@ -75,6 +85,48 @@ export function cursorNativeMaintenanceFor(
       },
     ],
   };
+}
+
+export async function inspectCursorDatabaseParents(
+  ownerRoot: string,
+  relativePath: string,
+): Promise<CursorDatabaseParentInspection> {
+  const parents = relativePathParts(relativePath).slice(0, -1);
+  let current = ownerRoot;
+  for (const part of parents) {
+    current = join(current, part);
+    try {
+      const stats = await lstat(current);
+      if (stats.isSymbolicLink()) {
+        return {
+          status: "blocked",
+          code: "symlink",
+          reason: "A Cursor database parent directory is a symlink.",
+        };
+      }
+      if (!stats.isDirectory()) {
+        return {
+          status: "blocked",
+          code: "not-directory",
+          reason: "A Cursor database parent path is not a directory.",
+        };
+      }
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        (error as NodeJS.ErrnoException).code === "ENOENT"
+      ) {
+        return { status: "missing" };
+      }
+      return {
+        status: "blocked",
+        code: "unreadable",
+        reason: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+  return { status: "safe" };
 }
 
 export async function inspectCursorDatabaseCompanions(

--- a/src/adapters/cursor-maintenance.ts
+++ b/src/adapters/cursor-maintenance.ts
@@ -47,7 +47,7 @@ export type CursorDatabaseCompanions = z.infer<typeof cursorDatabaseCompanionsSc
 export function cursorNativeMaintenanceFor(
   relativePath: string,
 ): CursorNativeMaintenanceFacts | undefined {
-  if (relativePath !== "User/globalStorage/state.vscdb") {
+  if (relativePath.split(/[\\/]+/u).join("/") !== "User/globalStorage/state.vscdb") {
     return undefined;
   }
   return {

--- a/src/adapters/provider-adapter.ts
+++ b/src/adapters/provider-adapter.ts
@@ -247,6 +247,8 @@ export class ProviderAuditAdapter implements AuditAdapter {
           : undefined;
       const cursorNativeMaintenance =
         this.spec.id === "cursor" ? cursorNativeMaintenanceFor(candidate.relativePath) : undefined;
+      const canonicalKey = `${this.id}:${candidate.kind}:${resolve(path)}`;
+      const resourceId = `${this.id}:${candidate.kind}:${sha256(canonicalKey)}`;
 
       try {
         const stats = await lstat(path);
@@ -285,8 +287,6 @@ export class ProviderAuditAdapter implements AuditAdapter {
           databaseInspection === undefined
             ? undefined
             : await inspectCodexProcesses(this.options.databaseDependencies);
-        const canonicalKey = `${this.id}:${candidate.kind}:${resolve(path)}`;
-        const resourceId = `${this.id}:${candidate.kind}:${sha256(canonicalKey)}`;
         const cursorDatabaseCompanions =
           cursorNativeMaintenance === undefined
             ? undefined
@@ -347,6 +347,32 @@ export class ProviderAuditAdapter implements AuditAdapter {
         });
       } catch (error) {
         if (isMissing(error)) {
+          if (cursorNativeMaintenance !== undefined) {
+            const cursorDatabaseCompanions = await inspectCursorDatabaseCompanions(
+              path,
+              this.options.measureBytes,
+            );
+            if (cursorDatabaseCompanions.some((companion) => companion.status !== "missing")) {
+              resources.push({
+                resource: {
+                  id: resourceId,
+                  adapter: this.id,
+                  kind: candidate.kind,
+                  canonicalKey,
+                  displayName: candidate.displayName,
+                  path: resolve(path),
+                },
+                observedAt: context.now.toISOString(),
+                exists: false,
+                facts: {
+                  reportOnly: true,
+                  primaryDatabaseStatus: "missing",
+                  nativeMaintenance: cursorNativeMaintenance,
+                  databaseCompanions: cursorDatabaseCompanions,
+                },
+              });
+            }
+          }
           continue;
         }
 

--- a/src/adapters/provider-adapter.ts
+++ b/src/adapters/provider-adapter.ts
@@ -36,6 +36,11 @@ import {
   copilotNativeMaintenanceFor,
 } from "./copilot-maintenance.js";
 import {
+  cursorNativeMaintenanceFactsSchema,
+  cursorNativeMaintenanceFor,
+  inspectCursorDatabaseCompanions,
+} from "./cursor-maintenance.js";
+import {
   opencodeNativeMaintenanceFactsSchema,
   opencodeNativeMaintenanceFor,
 } from "./opencode-maintenance.js";
@@ -240,6 +245,8 @@ export class ProviderAuditAdapter implements AuditAdapter {
         this.spec.id === "opencode"
           ? opencodeNativeMaintenanceFor(candidate.relativePath)
           : undefined;
+      const cursorNativeMaintenance =
+        this.spec.id === "cursor" ? cursorNativeMaintenanceFor(candidate.relativePath) : undefined;
 
       try {
         const stats = await lstat(path);
@@ -280,6 +287,10 @@ export class ProviderAuditAdapter implements AuditAdapter {
             : await inspectCodexProcesses(this.options.databaseDependencies);
         const canonicalKey = `${this.id}:${candidate.kind}:${resolve(path)}`;
         const resourceId = `${this.id}:${candidate.kind}:${sha256(canonicalKey)}`;
+        const cursorDatabaseCompanions =
+          cursorNativeMaintenance === undefined
+            ? undefined
+            : await inspectCursorDatabaseCompanions(path);
 
         resources.push({
           resource: {
@@ -311,6 +322,12 @@ export class ProviderAuditAdapter implements AuditAdapter {
             ...(opencodeNativeMaintenance === undefined
               ? {}
               : { nativeMaintenance: opencodeNativeMaintenance }),
+            ...(cursorNativeMaintenance === undefined
+              ? {}
+              : {
+                  nativeMaintenance: cursorNativeMaintenance,
+                  databaseCompanions: cursorDatabaseCompanions,
+                }),
             ...(databaseInspection === undefined
               ? {}
               : {
@@ -377,6 +394,9 @@ export class ProviderAuditAdapter implements AuditAdapter {
       resource.facts.nativeMaintenance,
     );
     const opencodeNativeMaintenance = opencodeNativeMaintenanceFactsSchema.safeParse(
+      resource.facts.nativeMaintenance,
+    );
+    const cursorNativeMaintenance = cursorNativeMaintenanceFactsSchema.safeParse(
       resource.facts.nativeMaintenance,
     );
     const providerFilePolicy =
@@ -665,6 +685,37 @@ export class ProviderAuditAdapter implements AuditAdapter {
             source: this.id,
             observedAt,
             detail: "OpenCode owns this maintenance path; AgentRinse does not mutate the resource.",
+          },
+        ],
+        facts: resource.facts,
+        candidateActions: [],
+        ...(resource.measuredBytes === undefined ? {} : { measuredBytes: resource.measuredBytes }),
+        warnings: [],
+      };
+    }
+    if (this.spec.id === "cursor" && cursorNativeMaintenance.success) {
+      return {
+        schemaVersion: 1,
+        findingId: `${resource.resource.id}:${sha256(context.auditId)}`,
+        auditId: context.auditId,
+        observedAt,
+        resource: resource.resource,
+        state: "protected",
+        confidence: "unknown",
+        roots: [
+          {
+            code: "cursor-native-database-maintenance-version-unverified",
+            source: this.id,
+            observedAt,
+            detail:
+              "Current Cursor guidance exposes command-palette operations for orphaned agent KV cleanup or user-selected chat deletion, both followed by VACUUM; AgentRinse did not prove the installed Cursor version.",
+          },
+          {
+            code: "provider-owned-report-only",
+            source: this.id,
+            observedAt,
+            detail:
+              "Cursor owns its database schema and maintenance commands; AgentRinse does not open or mutate the database.",
           },
         ],
         facts: resource.facts,

--- a/src/adapters/provider-adapter.ts
+++ b/src/adapters/provider-adapter.ts
@@ -39,6 +39,7 @@ import {
   cursorNativeMaintenanceFactsSchema,
   cursorNativeMaintenanceFor,
   inspectCursorDatabaseCompanions,
+  inspectCursorDatabaseParents,
 } from "./cursor-maintenance.js";
 import {
   opencodeNativeMaintenanceFactsSchema,
@@ -249,6 +250,27 @@ export class ProviderAuditAdapter implements AuditAdapter {
         this.spec.id === "cursor" ? cursorNativeMaintenanceFor(candidate.relativePath) : undefined;
       const canonicalKey = `${this.id}:${candidate.kind}:${resolve(path)}`;
       const resourceId = `${this.id}:${candidate.kind}:${sha256(canonicalKey)}`;
+      if (cursorNativeMaintenance !== undefined) {
+        const parentInspection = await inspectCursorDatabaseParents(
+          probe.root,
+          candidate.relativePath,
+        );
+        if (parentInspection.status === "missing") {
+          continue;
+        }
+        if (parentInspection.status === "blocked") {
+          diagnostics.push({
+            severity: "warning",
+            code:
+              parentInspection.code === "symlink"
+                ? "RESOURCE_PARENT_SYMLINK_SKIPPED"
+                : "RESOURCE_PARENT_INSPECTION_FAILED",
+            message: parentInspection.reason,
+            adapter: this.id,
+          });
+          continue;
+        }
+      }
 
       try {
         const stats = await lstat(path);

--- a/src/adapters/provider-adapter.ts
+++ b/src/adapters/provider-adapter.ts
@@ -290,7 +290,7 @@ export class ProviderAuditAdapter implements AuditAdapter {
         const cursorDatabaseCompanions =
           cursorNativeMaintenance === undefined
             ? undefined
-            : await inspectCursorDatabaseCompanions(path);
+            : await inspectCursorDatabaseCompanions(path, this.options.measureBytes);
 
         resources.push({
           resource: {

--- a/src/adapters/provider-specs.ts
+++ b/src/adapters/provider-specs.ts
@@ -116,8 +116,8 @@ export const PROVIDER_SPECS: Record<ProviderAdapterId, ProviderSpec> = {
         kind: "agent-session-store",
       },
       {
-        relativePath: join("User", "globalStorage"),
-        displayName: "Cursor global state",
+        relativePath: join("User", "globalStorage", "state.vscdb"),
+        displayName: "Cursor global state database",
         kind: "agent-database",
       },
       {

--- a/test/adapters/cursor-maintenance.test.ts
+++ b/test/adapters/cursor-maintenance.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import {
   cursorNativeMaintenanceFor,
   inspectCursorDatabaseCompanions,
+  inspectCursorDatabaseParents,
 } from "../../src/adapters/cursor-maintenance.js";
 import { ProviderAuditAdapter } from "../../src/adapters/provider-adapter.js";
 import { PROVIDER_SPECS } from "../../src/adapters/provider-specs.js";
@@ -121,6 +122,36 @@ describe("Cursor native database maintenance reporting", () => {
           { suffix: "-shm", status: "missing" },
         ],
       },
+    });
+  });
+
+  it("refuses a symlinked database parent without inspecting outside files", async () => {
+    const context = await fixtureContext();
+    const root = join(context.home, "cursor-symlinked-parent");
+    const outside = await mkdtemp(join(tmpdir(), "agentrinse-cursor-outside-"));
+    await mkdir(join(root, "User"), { recursive: true });
+    await writeFile(join(outside, "state.vscdb"), "outside-database");
+    await writeFile(join(outside, "state.vscdb.backup"), "outside-backup");
+    await symlink(outside, join(root, "User", "globalStorage"));
+    const adapter = new ProviderAuditAdapter(PROVIDER_SPECS.cursor, {
+      root,
+      measureBytes: true,
+      maxEntries: 100,
+    });
+
+    const probe = await adapter.probe(context);
+    const collection = await adapter.collect(context, probe);
+
+    expect(collection.resources).toEqual([]);
+    expect(collection.diagnostics).toContainEqual(
+      expect.objectContaining({ code: "RESOURCE_PARENT_SYMLINK_SKIPPED" }),
+    );
+    await expect(
+      inspectCursorDatabaseParents(root, "User/globalStorage/state.vscdb"),
+    ).resolves.toEqual({
+      status: "blocked",
+      code: "symlink",
+      reason: "A Cursor database parent directory is a symlink.",
     });
   });
 

--- a/test/adapters/cursor-maintenance.test.ts
+++ b/test/adapters/cursor-maintenance.test.ts
@@ -73,8 +73,21 @@ describe("Cursor native database maintenance reporting", () => {
     const database = join(root, "state.vscdb");
     await writeFile(database, "database");
 
-    await expect(inspectCursorDatabaseCompanions(database)).resolves.toEqual([
+    await expect(inspectCursorDatabaseCompanions(database, true)).resolves.toEqual([
       { suffix: ".backup", status: "missing" },
+      { suffix: "-wal", status: "missing" },
+      { suffix: "-shm", status: "missing" },
+    ]);
+  });
+
+  it("omits companion byte counts when measurement is disabled", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agentrinse-cursor-companions-"));
+    const database = join(root, "state.vscdb");
+    await writeFile(database, "database");
+    await writeFile(`${database}.backup`, "backup-copy");
+
+    await expect(inspectCursorDatabaseCompanions(database, false)).resolves.toEqual([
+      { suffix: ".backup", status: "regular" },
       { suffix: "-wal", status: "missing" },
       { suffix: "-shm", status: "missing" },
     ]);

--- a/test/adapters/cursor-maintenance.test.ts
+++ b/test/adapters/cursor-maintenance.test.ts
@@ -1,0 +1,82 @@
+import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  cursorNativeMaintenanceFor,
+  inspectCursorDatabaseCompanions,
+} from "../../src/adapters/cursor-maintenance.js";
+import { ProviderAuditAdapter } from "../../src/adapters/provider-adapter.js";
+import { PROVIDER_SPECS } from "../../src/adapters/provider-specs.js";
+import type { AuditContext } from "../../src/contracts/adapter.js";
+
+async function fixtureContext(): Promise<AuditContext> {
+  return {
+    home: await mkdtemp(join(tmpdir(), "agentrinse-cursor-maintenance-")),
+    now: new Date("2026-07-29T00:00:00.000Z"),
+    auditId: "audit-cursor-maintenance",
+  };
+}
+
+describe("Cursor native database maintenance reporting", () => {
+  it("inventories the exact global database and its companions without creating actions", async () => {
+    const context = await fixtureContext();
+    const root = join(context.home, "cursor-data");
+    const database = join(root, "User", "globalStorage", "state.vscdb");
+    await mkdir(join(root, "User", "workspaceStorage", "workspace"), { recursive: true });
+    await mkdir(join(root, "logs"), { recursive: true });
+    await mkdir(join(root, "User", "globalStorage"), { recursive: true });
+    await writeFile(database, "database");
+    await writeFile(`${database}.backup`, "backup-copy");
+    await writeFile(`${database}-wal`, "wal");
+    await symlink(join(root, "outside-shm"), `${database}-shm`);
+    const adapter = new ProviderAuditAdapter(PROVIDER_SPECS.cursor, {
+      root,
+      measureBytes: true,
+      maxEntries: 100,
+    });
+
+    const probe = await adapter.probe(context);
+    const collection = await adapter.collect(context, probe);
+    const databaseResource = collection.resources.find(
+      (resource) => resource.resource.displayName === "Cursor global state database",
+    );
+    const finding = databaseResource
+      ? await adapter.classify(context, databaseResource)
+      : undefined;
+
+    expect(databaseResource?.resource.path).toBe(database);
+    expect(databaseResource?.measuredBytes).toBe(8);
+    expect(databaseResource?.facts.databaseCompanions).toEqual([
+      { suffix: ".backup", status: "regular", measuredBytes: 11 },
+      { suffix: "-wal", status: "regular", measuredBytes: 3 },
+      { suffix: "-shm", status: "symlink" },
+    ]);
+    expect(databaseResource?.facts.nativeMaintenance).toEqual(
+      cursorNativeMaintenanceFor("User/globalStorage/state.vscdb"),
+    );
+    expect(finding).toMatchObject({
+      state: "protected",
+      confidence: "unknown",
+      candidateActions: [],
+      roots: [
+        { code: "cursor-native-database-maintenance-version-unverified" },
+        { code: "provider-owned-report-only" },
+      ],
+    });
+  });
+
+  it("reports missing database companions without following paths", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agentrinse-cursor-companions-"));
+    const database = join(root, "state.vscdb");
+    await writeFile(database, "database");
+
+    await expect(inspectCursorDatabaseCompanions(database)).resolves.toEqual([
+      { suffix: ".backup", status: "missing" },
+      { suffix: "-wal", status: "missing" },
+      { suffix: "-shm", status: "missing" },
+    ]);
+  });
+});

--- a/test/adapters/cursor-maintenance.test.ts
+++ b/test/adapters/cursor-maintenance.test.ts
@@ -79,4 +79,8 @@ describe("Cursor native database maintenance reporting", () => {
       { suffix: "-shm", status: "missing" },
     ]);
   });
+
+  it("recognizes the Windows global database path", () => {
+    expect(cursorNativeMaintenanceFor("User\\globalStorage\\state.vscdb")).toBeDefined();
+  });
 });

--- a/test/adapters/cursor-maintenance.test.ts
+++ b/test/adapters/cursor-maintenance.test.ts
@@ -93,6 +93,37 @@ describe("Cursor native database maintenance reporting", () => {
     ]);
   });
 
+  it("reports backup-only recovery state when the primary database is missing", async () => {
+    const context = await fixtureContext();
+    const root = join(context.home, "cursor-backup-only");
+    const database = join(root, "User", "globalStorage", "state.vscdb");
+    await mkdir(join(root, "User", "globalStorage"), { recursive: true });
+    await writeFile(`${database}.backup`, "backup-copy");
+    const adapter = new ProviderAuditAdapter(PROVIDER_SPECS.cursor, {
+      root,
+      measureBytes: true,
+      maxEntries: 100,
+    });
+
+    const probe = await adapter.probe(context);
+    const collection = await adapter.collect(context, probe);
+    const databaseResource = collection.resources.find(
+      (resource) => resource.resource.displayName === "Cursor global state database",
+    );
+
+    expect(databaseResource).toMatchObject({
+      exists: false,
+      facts: {
+        primaryDatabaseStatus: "missing",
+        databaseCompanions: [
+          { suffix: ".backup", status: "regular", measuredBytes: 11 },
+          { suffix: "-wal", status: "missing" },
+          { suffix: "-shm", status: "missing" },
+        ],
+      },
+    });
+  });
+
   it("recognizes the Windows global database path", () => {
     expect(cursorNativeMaintenanceFor("User\\globalStorage\\state.vscdb")).toBeDefined();
   });


### PR DESCRIPTION
## Summary

- inventory the exact Cursor global `state.vscdb` and backup/WAL/SHM companions
- report Cursor owner commands for orphaned agent KV GC and user-selected old-chat deletion
- preserve report-only behavior, including backup-only recovery states and symlink-parent refusal

Part of #16.

## Ownership and safety

- owner: Cursor
- discovery evidence: Cursor staff guidance current on 2026-07-13
- protection roots: workspace/global databases, chat history, backups, companions, settings, auth, and unknown installed versions
- risk class: report-only
- revalidation: no action is emitted; collection rechecks every parent and refuses symlinks
- recovery: not applicable because AgentRinse performs no mutation

## Verification

- `./node_modules/.bin/oxfmt --check .`
- `./node_modules/.bin/oxlint src test`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `./node_modules/.bin/vitest run` (65 files, 474 passed, 1 skipped)
- build, 9 JSON schemas, package manifest, and publint checks
- autoreview clean after Windows path, measurement, backup-only, and symlink-parent fixes
