### PR TITLE
feat(docker): inventory Buildx cache safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The project follows semantic versioning after its first supported release.
 - fail-closed rejection for dynamic Buildx builders whose separate inventory
   commands cannot be bound to the same worker
 - fail-closed rejection for builder nodes that expose no stable worker ID
+- protected unknown-type cache findings and complete Docker human-size suffix
+  parsing without promoting rounded values to exact measurements
 
 ### Safety
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The project follows semantic versioning after its first supported release.
   never published as an exact measured or reclaimable byte count
 - fail-closed rejection for dynamic Buildx builders whose separate inventory
   commands cannot be bound to the same worker
+- fail-closed rejection for builder nodes that expose no stable worker ID
 
 ### Safety
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ The project follows semantic versioning after its first supported release.
   malformed Buildx output from suppressing valid sibling records
 - separate exact and humanized cache-size evidence so rounded Buildx output is
   never published as an exact measured or reclaimable byte count
+- fail-closed rejection for dynamic Buildx builders whose separate inventory
+  commands cannot be bound to the same worker
 
 ### Safety
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The project follows semantic versioning after its first supported release.
   the cache capability is missing, unsupported, or unhealthy
 - effective `DOCKER_HOST` selection and before/after owner checks that discard
   inventory when the daemon or selected builder changes
+- conservative unknown last-use handling and per-record diagnostics that keep
+  malformed Buildx output from suppressing valid sibling records
 
 ### Safety
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The project follows semantic versioning after its first supported release.
   builder, worker, size, type, sharing, and conservative age facts
 - isolated Buildx diagnostics that preserve image and container inventory when
   the cache capability is missing, unsupported, or unhealthy
+- effective `DOCKER_HOST` selection and before/after owner checks that discard
+  inventory when the daemon or selected builder changes
 
 ### Safety
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The project follows semantic versioning after its first supported release.
   companion diagnostics
 - report-only Cursor owner-command findings for orphaned agent KV garbage
   collection and user-selected old-chat deletion
+- version-gated Docker Buildx cache inventory with selected context, daemon,
+  builder, worker, size, type, sharing, and conservative age facts
+- isolated Buildx diagnostics that preserve image and container inventory when
+  the cache capability is missing, unsupported, or unhealthy
 
 ### Safety
 
@@ -30,6 +34,9 @@ The project follows semantic versioning after its first supported release.
   invoke Git or remove logs
 - Cursor databases, chat history, workspace state, backups, and companions
   remain protected; AgentRinse never invokes either command-palette operation
+- Docker images, containers, networks, volumes, and build cache remain
+  protected because Buildx prune cannot condition mutation on the revalidated
+  daemon and worker identity
 
 ## [0.5.0] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The project follows semantic versioning after its first supported release.
   inventory when the daemon or selected builder changes
 - conservative unknown last-use handling and per-record diagnostics that keep
   malformed Buildx output from suppressing valid sibling records
+- separate exact and humanized cache-size evidence so rounded Buildx output is
+  never published as an exact measured or reclaimable byte count
 
 ### Safety
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ copy. It also quarantines exact stale Claude debug logs and changelog cache
 files with a seven-day undo window.
 
 current main extends that recoverable boundary to Zed's exact stale
-`Zed.log.old` rotated application log. the latest published release remains
-`0.5.0`.
+`Zed.log.old` rotated application log. it also reports OpenCode, Cursor, and
+version-gated Docker Buildx maintenance facts. the latest published release
+remains `0.5.0`.
 
 the point is confidence: make real cleanup changes without deleting the
 session, branch, worktree, database content, or cache that another agent still
@@ -58,7 +59,8 @@ text files and its rebuildable changelog cache. AgentRinse also reports
 Claude's native retention policy and Copilot's native session and process-log
 maintenance. It also reports OpenCode's owner-run snapshot compaction and its
 separate append-only server log, plus Cursor's owner-run state database
-maintenance. Docker remains audit-only.
+maintenance. Docker inventories images, containers, and supported Buildx cache
+records but remains audit-only.
 
 ## agent integrations
 
@@ -90,7 +92,7 @@ logical memory records.
 | <img width="48px" src="docs/client-opencode.png" alt="OpenCode" />          | OpenCode native maintenance          | report-only        | hourly snapshot GC and the append-only server-log contract              |
 | <img width="48px" src="docs/client-cursor.jpg" alt="Cursor" />              | Cursor database maintenance          | report-only        | exact DB companions, orphan KV GC, and destructive chat cleanup         |
 | ⚡                                                                          | Agent runtimes                       | audit-only, opt-in | installed agent executables and versions                                |
-| <img width="48px" src="docs/client-docker-agent.svg" alt="Docker" />        | [Docker](https://docs.docker.com/)   | audit-only, opt-in | images and containers                                                   |
+| <img width="48px" src="docs/client-docker-agent.svg" alt="Docker" />        | [Docker](https://docs.docker.com/)   | audit-only, opt-in | images, containers, and versioned Buildx cache                          |
 | 🕳️                                                                          | [Mole](https://github.com/tw93/Mole) | suggestions only   | external dry-run cleanup opportunities on macOS                         |
 
 ## install
@@ -384,7 +386,8 @@ unreleased build at real developer state.
 configured artifact cleanup, recoverable Git worktree and Claude file
 quarantine, and recoverable offline Codex database compaction. Current main
 also quarantines the exact stale Zed `Zed.log.old` file and reports OpenCode's
-native maintenance contract plus Cursor's owner database commands. Grok Build,
-Docker, and all other Cursor, Zed, and OpenCode state remain non-mutating.
+native maintenance contract, Cursor's owner database commands, and Docker
+Buildx cache facts. Grok Build, Docker, and all other Cursor, Zed, and OpenCode
+state remain non-mutating.
 
 MIT licensed. built by [Vincent Koc](https://github.com/vincentkoc).

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -205,6 +205,10 @@ builder driver, stable worker IDs, record identity, type, size, mutability,
 reclaimability, sharing, and conservative age evidence. Unsupported humanized
 age text is retained but treated as recent evidence.
 
+Numeric byte values remain exact measurements. Buildx humanized sizes are
+rounded upstream, so AgentRinse preserves the displayed value and an
+approximation in facts but omits exact measured and reclaimable-byte totals.
+
 Daemon failure degrades only Docker. Missing, unsupported, or unhealthy Buildx
 degrades only cache inventory; image and container inventory continues. Every
 Docker resource is protected and no prune command exists. Buildx prune

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -194,7 +194,8 @@ the selected Docker context and inventories images and containers through
 structured CLI output. It also inventories cache records from the selected
 healthy static builder when the installed Buildx version is within the
 inspected `0.33.0` through `0.35.99` contract. Dynamic builders are rejected
-because separate Buildx commands may select different workers.
+because separate Buildx commands may select different workers. Static nodes
+without stable worker IDs are also rejected.
 
 When `DOCKER_HOST` selects an engine without `DOCKER_CONTEXT`, AgentRinse
 preserves that host selection instead of adding `--context default`. It samples

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -192,8 +192,9 @@ remove superseded versions.
 The Docker adapter is disabled by default. When explicitly enabled, it probes
 the selected Docker context and inventories images and containers through
 structured CLI output. It also inventories cache records from the selected
-healthy builder when the installed Buildx version is within the inspected
-`0.33.0` through `0.35.99` contract.
+healthy static builder when the installed Buildx version is within the
+inspected `0.33.0` through `0.35.99` contract. Dynamic builders are rejected
+because separate Buildx commands may select different workers.
 
 When `DOCKER_HOST` selects an engine without `DOCKER_CONTEXT`, AgentRinse
 preserves that host selection instead of adding `--context default`. It samples

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -210,6 +210,7 @@ age text is retained but treated as recent evidence.
 Numeric byte values remain exact measurements. Buildx humanized sizes are
 rounded upstream, so AgentRinse preserves the displayed value and an
 approximation in facts but omits exact measured and reclaimable-byte totals.
+Missing optional record types remain inventoried and protected as unknown.
 
 Daemon failure degrades only Docker. Missing, unsupported, or unhealthy Buildx
 degrades only cache inventory; image and container inventory continues. Every

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -195,6 +195,11 @@ structured CLI output. It also inventories cache records from the selected
 healthy builder when the installed Buildx version is within the inspected
 `0.33.0` through `0.35.99` contract.
 
+When `DOCKER_HOST` selects an engine without `DOCKER_CONTEXT`, AgentRinse
+preserves that host selection instead of adding `--context default`. It samples
+the effective daemon and builder identity before and after collection and
+discards results if either owner changes.
+
 The cache facts include the context endpoint, daemon ID and version, selected
 builder driver, stable worker IDs, record identity, type, size, mutability,
 reclaimability, sharing, and conservative age evidence. Unsupported humanized

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -17,7 +17,7 @@ recoverable whole-worktree action when every safety gate is proven.
 | Grok Build     | version-gated data root                                   | all             |
 | Runtime        | opt-in selected executable and Claude native versions     | all             |
 | Git            | worktree audit and recoverable linked-worktree quarantine | conditional     |
-| Docker         | opt-in structured image/container inventory               | all             |
+| Docker         | opt-in structured image/container/Buildx cache inventory  | all             |
 | Artifacts      | exact configured rebuildable directories                  | conditional     |
 
 ## Artifact Rules
@@ -191,5 +191,18 @@ remove superseded versions.
 
 The Docker adapter is disabled by default. When explicitly enabled, it probes
 the selected Docker context and inventories images and containers through
-structured CLI output. Daemon failure degrades only Docker. Every resource is
-protected and no prune command exists.
+structured CLI output. It also inventories cache records from the selected
+healthy builder when the installed Buildx version is within the inspected
+`0.33.0` through `0.35.99` contract.
+
+The cache facts include the context endpoint, daemon ID and version, selected
+builder driver, stable worker IDs, record identity, type, size, mutability,
+reclaimability, sharing, and conservative age evidence. Unsupported humanized
+age text is retained but treated as recent evidence.
+
+Daemon failure degrades only Docker. Missing, unsupported, or unhealthy Buildx
+degrades only cache inventory; image and container inventory continues. Every
+Docker resource is protected and no prune command exists. Buildx prune
+re-resolves context and builder names in its own process and exposes no
+conditional daemon/worker identity binding, so post-validation cannot prevent
+the command from targeting a replacement owner.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,10 +27,12 @@ drift in CI and shipped in the npm package.
 
 Collectors and classifiers are read-only. Provider and Docker adapters emit
 protected findings by default. The Codex adapter may emit a versioned
-experimental `database.vacuum` action after explicit audit opt-in. The artifact adapter can emit one exact
-`artifacts.remove` action for each eligible configured directory. The Git
-adapter can emit one exact `worktree.quarantine` action for each fully proven
-inactive linked worktree.
+experimental `database.vacuum` action after explicit audit opt-in. The Docker
+adapter records versioned context, daemon, builder, worker, and cache evidence
+but emits no action because Buildx cannot bind prune to that owner identity.
+The artifact adapter can emit one exact `artifacts.remove` action for each
+eligible configured directory. The Git adapter can emit one exact
+`worktree.quarantine` action for each fully proven inactive linked worktree.
 
 No adapter mutates directly.
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -13,8 +13,8 @@ ownership proof.
 - `lockf` on macOS or `flock` from `util-linux` on Linux
 - local filesystem state directory with owner read/write access
 
-Docker is optional and isolated to its adapter. Mole is an optional external
-macOS handoff.
+Docker and Buildx are optional and isolated to the Docker adapter. Mole is an
+optional external macOS handoff.
 
 Run `agentrinse doctor` to verify the current machine without mutating it.
 
@@ -82,4 +82,6 @@ limitation and recommends WSL for supported artifact apply.
 
 When enabled, Docker uses the current CLI context and structured output.
 Unavailable CLI, context, or daemon state degrades only Docker inventory.
-`0.5.0` does not remove any Docker resource.
+Buildx is an optional sub-capability: supported healthy builders add
+report-only cache records, while missing or unsupported Buildx preserves image
+and container inventory. No current build removes a Docker resource.

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -571,11 +571,12 @@ These are hard product requirements.
 
 ### Docker invariants
 
-1. Docker volumes are report-only by default.
+1. Every Docker resource is report-only until its owner command can bind
+   mutation to the exact revalidated daemon and worker identity.
 2. Running containers are never removed.
 3. Images referenced by any container are protected.
 4. Build cache marked in-use is protected.
-5. Docker cleanup is scoped to the active configured context.
+5. Docker inventory is scoped to the selected context and builder.
 6. An unavailable daemon produces a finding and does not fail other adapters.
 7. AgentRinse never runs unfiltered `docker system prune -a --volumes`.
 
@@ -878,19 +879,15 @@ export type ActionDescriptor = {
 };
 ```
 
-Action type names are public machine contracts. Examples:
+Implemented action type names are public machine contracts:
 
 - `artifacts.remove`
 - `worktree.quarantine`
 - `provider.file-quarantine`
-- `worktree.prune-registration`
-- `docker.image.remove`
-- `docker.container.remove`
-- `docker.network.remove`
-- `docker.build-cache.prune`
-- `codex.logs.compact-offline`
-- `runtime.remove-old-version`
-- `mole.handoff`
+- `database.vacuum`
+
+Future action names are not reserved contracts until they enter the validated
+action schema.
 
 ### Adapter interface
 
@@ -2268,6 +2265,7 @@ Probe independently:
 - daemon availability
 - server version
 - builder availability
+- Buildx version and inspected contract range
 
 An unavailable daemon returns a degraded adapter record with the exact failed
 capability.
@@ -2278,13 +2276,11 @@ Collect:
 
 - running and stopped containers
 - images and tags
-- networks
-- volumes
 - build cache
-- labels
 - creation and last-use facts exposed by Docker
-- reference relationships
 - estimated reclaimable size
+- context endpoint and daemon identity
+- selected builder, driver, node endpoints, and worker IDs
 
 Prefer Docker JSON formats or APIs. Never scrape tables.
 
@@ -2292,24 +2288,16 @@ Prefer Docker JSON formats or APIs. Never scrape tables.
 
 #### Images
 
-Eligible:
-
-- dangling
-- older than 14 days
-- not referenced by any container
-- not pinned by label
-
-Non-dangling unused images remain report-only until a user opts in.
+All images remain report-only. The inventory records the exact daemon identity
+so equal image IDs from different engines do not collapse into one resource.
 
 #### Build cache
 
-Eligible:
-
-- not in use
-- older than 7 days
-- filtered through Docker's supported prune filters
-
-Default risk: `safe`.
+All build cache remains report-only. The current adapter distinguishes mutable,
+in-use, internal/frontend, recent, shared, and cleanup-shaped records. It emits
+no action even for an old reclaimable record because `buildx prune` re-resolves
+the selected context and builder names after AgentRinse's revalidation. The
+owner command exposes no conditional daemon or worker identity check.
 
 #### Containers
 
@@ -3093,13 +3081,15 @@ Deliver:
 - old agent runtime removal
 - a decision and proof for labeled stopped-container cleanup; keep it
   report-only if reliable recreation cannot be demonstrated
-- filtered Docker build-cache cleanup only after current owner-contract proof
+- a decision and proof for Docker build-cache cleanup; keep it report-only
+  until the owner command can bind mutation to revalidated identity
 
 Exit criteria:
 
 - database compaction retains verified rollback
 - active provider processes block mutation
-- exact Docker context and object identity are revalidated before mutation
+- Docker inventory records exact context, daemon, builder, and worker identity
+- Docker emits no action while prune can re-resolve those owners
 
 ### `0.5.0`: exact provider files
 
@@ -3198,8 +3188,8 @@ Exit criteria:
 - Never removes running containers.
 - Never removes referenced images.
 - Never mutates volumes by default.
-- Uses exact IDs or reviewed filters.
-- Detects context changes before apply.
+- Records context, daemon, builder, and worker identity.
+- Refuses mutation while the owner command cannot bind to that identity.
 
 ### Provider maintenance
 
@@ -3234,11 +3224,11 @@ Exit criteria:
 | OpenCode database/log/snapshots |         any | report + native facts | n/a         | provider-owned  |
 | Grok Build sessions/task state  |         any | report only           | n/a         | provider-owned  |
 | Codex logs DB free pages        |   threshold | report only           | n/a         | phase 4         |
-| dangling Docker image           |         14d | remove exact image    | safe        | rebuild/pull    |
-| Docker build cache              |          7d | filtered prune        | safe        | rebuild         |
+| dangling Docker image           |         any | report only           | n/a         | protected       |
+| Docker build cache              |          7d | report + owner facts  | n/a         | protected       |
 | unlabeled stopped container     |         any | report only           | n/a         | owner decision  |
 | labeled stopped container       |         14d | report only           | n/a         | future design   |
-| Docker network                  |         14d | narrow removal        | safe        | recreate        |
+| Docker network                  |         any | report only           | n/a         | protected       |
 | Docker volume                   |         any | report only           | n/a         | protected       |
 | old agent runtime               |         14d | report, later remove  | safe        | package manager |
 | Mole cleanup                    |         any | handoff               | external    | Mole-owned      |
@@ -3688,6 +3678,7 @@ decision-log entry. They must not be smuggled in as adapter fixes.
 - [x] initial Codex inventory
 - [x] initial Claude inventory
 - [x] initial Docker inventory
+- [x] versioned Docker Buildx cache inventory and owner-binding decision
 - [x] Cursor, Copilot CLI, Zed, OpenCode, and Grok inventory
 - [x] runtime audit
 - [x] Mole probe
@@ -3695,7 +3686,7 @@ decision-log entry. They must not be smuggled in as adapter fixes.
 - [x] Git dirty, staged, untracked, operation, detached, and push-state proof
 - [x] Codex and Claude session-to-worktree roots
 - [x] provider-managed worktree and pin roots
-- [ ] Docker safe cleanup
+- [ ] Docker mutation after conditional owner identity binding exists
 - [x] worktree quarantine
 - [x] worktree undo
 - [x] offline Codex database compaction

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -72,11 +72,16 @@ Current:
 - report-only OpenCode snapshot GC and server-log retention contracts
 - exact Cursor global database and companion diagnostics
 - report-only Cursor orphan KV GC and old-chat maintenance commands
+- version-gated Docker Buildx cache inventory with context, daemon, builder,
+  worker, age, and reclaimability evidence
+- explicit Docker mutation refusal while Buildx cannot condition prune on the
+  revalidated owner identity
 
 Remaining:
 
-- filtered Docker build-cache cleanup
 - owner-managed old agent runtime removal
+- Docker mutation only after the owner command exposes conditional daemon and
+  worker identity binding
 
 Every owner-specific mutation remains disabled until its current upstream
 contract, offline requirements, and recovery behavior are proven.

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -22,6 +22,12 @@ Only `artifacts.remove` mutates:
 Provider state and Docker resources remain report-only except for the explicit
 offline Codex database and exact provider-file boundaries below.
 
+Docker Buildx cache findings pin the inspected context endpoint, daemon ID,
+builder, and worker IDs. They still emit no action: the later `buildx prune`
+process would re-resolve mutable context and builder names and cannot require
+those identities to match. Revalidation followed by an unbound owner command
+would leave a deletion race, so AgentRinse refuses it.
+
 ## Recoverable Provider File Boundary
 
 `provider.file-quarantine` is a reusable `recoverable` executor for one exact

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -28,6 +28,10 @@ process would re-resolve mutable context and builder names and cannot require
 those identities to match. Revalidation followed by an unbound owner command
 would leave a deletion race, so AgentRinse refuses it.
 
+Read-only collection also samples the effective owner before and after each
+inventory window. This preserves `DOCKER_HOST` selection and discards image,
+container, or cache results when the daemon or builder identity changes.
+
 ## Recoverable Provider File Boundary
 
 `provider.file-quarantine` is a reusable `recoverable` executor for one exact

--- a/src/adapters/docker/adapter.ts
+++ b/src/adapters/docker/adapter.ts
@@ -391,6 +391,14 @@ export class DockerAuditAdapter implements AuditAdapter {
         detail: "Docker reports this build-cache record as not reclaimable.",
       };
     }
+    if (cache.recordType === undefined) {
+      return {
+        code: "docker-build-cache-type-unknown",
+        source: "docker",
+        observedAt,
+        detail: "Buildx did not expose this cache record's type.",
+      };
+    }
     if (cache.recordType === "internal" || cache.recordType === "frontend") {
       return {
         code: "docker-build-cache-internal",

--- a/src/adapters/docker/adapter.ts
+++ b/src/adapters/docker/adapter.ts
@@ -5,7 +5,7 @@ import type { AdapterProbe } from "../../contracts/report.js";
 import type { ResourceKind, ResourceSnapshot } from "../../contracts/resource.js";
 import { sha256 } from "../../core/digest.js";
 import {
-  defaultDockerRunner,
+  createDockerRunner,
   dockerBuildCacheIsOldEnough,
   inspectDockerBuildCache,
   inspectDockerContext,
@@ -18,6 +18,7 @@ import {
 
 export type DockerAuditAdapterOptions = {
   builderOverride?: string | undefined;
+  environment?: NodeJS.ProcessEnv | undefined;
 };
 
 function parseJsonLines(input: string): Record<string, unknown>[] {
@@ -38,7 +39,16 @@ function dockerContextMatches(left: DockerContextIdentity, right: DockerContextI
     left.name === right.name &&
     left.endpoint === right.endpoint &&
     left.daemonId === right.daemonId &&
-    left.serverVersion === right.serverVersion
+    left.serverVersion === right.serverVersion &&
+    left.commandPrefix.join("\0") === right.commandPrefix.join("\0")
+  );
+}
+
+function dockerScopeMatches(left: DockerScopeIdentity, right: DockerScopeIdentity): boolean {
+  return (
+    left.buildxVersion === right.buildxVersion &&
+    dockerContextMatches(left.context, right.context) &&
+    left.builder.fingerprint === right.builder.fingerprint
   );
 }
 
@@ -55,17 +65,23 @@ export class DockerAuditAdapter implements AuditAdapter {
   private dockerContext: DockerContextIdentity | undefined;
   private buildxScope: DockerScopeIdentity | undefined;
 
-  constructor(
-    private readonly runDocker: DockerRunner = defaultDockerRunner,
-    private readonly options: DockerAuditAdapterOptions = {},
-  ) {}
+  private readonly runDocker: DockerRunner;
+  private readonly options: DockerAuditAdapterOptions;
+
+  constructor(runDocker?: DockerRunner, options: DockerAuditAdapterOptions = {}) {
+    this.options = options;
+    this.runDocker = runDocker ?? createDockerRunner(this.options.environment ?? process.env);
+  }
 
   async probe(_context: AuditContext): Promise<AdapterProbe> {
     this.dockerContext = undefined;
     this.buildxScope = undefined;
 
     try {
-      this.dockerContext = await inspectDockerContext(this.runDocker);
+      this.dockerContext = await inspectDockerContext(
+        this.runDocker,
+        this.options.environment ?? process.env,
+      );
     } catch (error) {
       return {
         adapter: this.id,
@@ -84,7 +100,11 @@ export class DockerAuditAdapter implements AuditAdapter {
 
     const diagnostics: Diagnostic[] = [];
     try {
-      const scope = await inspectDockerScope(this.runDocker, this.options.builderOverride);
+      const scope = await inspectDockerScope(
+        this.runDocker,
+        this.options.builderOverride,
+        this.options.environment ?? process.env,
+      );
       if (!dockerContextMatches(this.dockerContext, scope.context)) {
         throw new Error("Docker context or daemon changed during Buildx inspection");
       }
@@ -117,10 +137,27 @@ export class DockerAuditAdapter implements AuditAdapter {
       return { resources: [], diagnostics: [] };
     }
 
+    const collectedContext = await inspectDockerContext(
+      this.runDocker,
+      this.options.environment ?? process.env,
+    );
+    if (!dockerContextMatches(this.dockerContext, collectedContext)) {
+      return {
+        resources: [],
+        diagnostics: [
+          {
+            severity: "warning",
+            code: "DOCKER_OWNER_CHANGED",
+            message: "Docker context or daemon changed after probing; inventory was discarded.",
+            adapter: this.id,
+          },
+        ],
+      };
+    }
+    this.dockerContext = collectedContext;
     const images = parseJsonLines(
       await this.runDocker([
-        "--context",
-        this.dockerContext.name,
+        ...this.dockerContext.commandPrefix,
         "image",
         "ls",
         "--no-trunc",
@@ -130,8 +167,7 @@ export class DockerAuditAdapter implements AuditAdapter {
     );
     const containers = parseJsonLines(
       await this.runDocker([
-        "--context",
-        this.dockerContext.name,
+        ...this.dockerContext.commandPrefix,
         "container",
         "ls",
         "-a",
@@ -140,6 +176,23 @@ export class DockerAuditAdapter implements AuditAdapter {
         "{{json .}}",
       ]),
     );
+    const verifiedContext = await inspectDockerContext(
+      this.runDocker,
+      this.options.environment ?? process.env,
+    );
+    if (!dockerContextMatches(this.dockerContext, verifiedContext)) {
+      return {
+        resources: [],
+        diagnostics: [
+          {
+            severity: "warning",
+            code: "DOCKER_OWNER_CHANGED",
+            message: "Docker context or daemon changed during collection; inventory was discarded.",
+            adapter: this.id,
+          },
+        ],
+      };
+    }
     const resources = [
       ...images.flatMap((image) =>
         this.toDockerResource(context, "docker-image", image, "ID", "Repository"),
@@ -152,7 +205,27 @@ export class DockerAuditAdapter implements AuditAdapter {
 
     if (this.buildxScope !== undefined) {
       try {
-        const cache = await inspectDockerBuildCache(this.buildxScope, this.runDocker);
+        const collectedScope = await inspectDockerScope(
+          this.runDocker,
+          this.options.builderOverride,
+          this.options.environment ?? process.env,
+        );
+        if (
+          !dockerContextMatches(verifiedContext, collectedScope.context) ||
+          !dockerScopeMatches(this.buildxScope, collectedScope)
+        ) {
+          throw new Error("Docker context, daemon, or builder changed before cache collection");
+        }
+        const cache = await inspectDockerBuildCache(collectedScope, this.runDocker);
+        const verifiedScope = await inspectDockerScope(
+          this.runDocker,
+          this.options.builderOverride,
+          this.options.environment ?? process.env,
+        );
+        if (!dockerScopeMatches(collectedScope, verifiedScope)) {
+          throw new Error("Docker context, daemon, or builder changed during cache collection");
+        }
+        this.buildxScope = verifiedScope;
         resources.push(...cache.map((record) => this.toBuildCacheResource(context, record)));
       } catch (error) {
         diagnostics.push({

--- a/src/adapters/docker/adapter.ts
+++ b/src/adapters/docker/adapter.ts
@@ -1,24 +1,24 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-
 import type { AuditAdapter, AuditContext, CollectionResult } from "../../contracts/adapter.js";
+import type { Diagnostic } from "../../contracts/diagnostic.js";
 import type { Finding } from "../../contracts/finding.js";
 import type { AdapterProbe } from "../../contracts/report.js";
 import type { ResourceKind, ResourceSnapshot } from "../../contracts/resource.js";
 import { sha256 } from "../../core/digest.js";
+import {
+  defaultDockerRunner,
+  dockerBuildCacheIsOldEnough,
+  inspectDockerBuildCache,
+  inspectDockerContext,
+  inspectDockerScope,
+  type DockerBuildCacheRecord,
+  type DockerContextIdentity,
+  type DockerRunner,
+  type DockerScopeIdentity,
+} from "./owner.js";
 
-const execFileAsync = promisify(execFile);
-
-export type DockerRunner = (args: string[]) => Promise<string>;
-
-async function defaultDockerRunner(args: string[]): Promise<string> {
-  const result = await execFileAsync("docker", args, {
-    encoding: "utf8",
-    maxBuffer: 8 * 1024 * 1024,
-    timeout: 10_000,
-  });
-  return result.stdout;
-}
+export type DockerAuditAdapterOptions = {
+  builderOverride?: string | undefined;
+};
 
 function parseJsonLines(input: string): Record<string, unknown>[] {
   return input
@@ -33,23 +33,39 @@ function stringField(record: Record<string, unknown>, key: string): string | und
   return typeof value === "string" && value !== "" ? value : undefined;
 }
 
+function dockerContextMatches(left: DockerContextIdentity, right: DockerContextIdentity): boolean {
+  return (
+    left.name === right.name &&
+    left.endpoint === right.endpoint &&
+    left.daemonId === right.daemonId &&
+    left.serverVersion === right.serverVersion
+  );
+}
+
+function buildCacheRecord(resource: ResourceSnapshot): DockerBuildCacheRecord | undefined {
+  const value = resource.facts["cache"];
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as DockerBuildCacheRecord;
+}
+
 export class DockerAuditAdapter implements AuditAdapter {
   readonly id = "docker";
+  private dockerContext: DockerContextIdentity | undefined;
+  private buildxScope: DockerScopeIdentity | undefined;
 
-  constructor(private readonly runDocker: DockerRunner = defaultDockerRunner) {}
+  constructor(
+    private readonly runDocker: DockerRunner = defaultDockerRunner,
+    private readonly options: DockerAuditAdapterOptions = {},
+  ) {}
 
   async probe(_context: AuditContext): Promise<AdapterProbe> {
-    try {
-      const dockerContext = (await this.runDocker(["context", "show"])).trim();
-      const version = (await this.runDocker(["version", "--format", "{{.Server.Version}}"])).trim();
+    this.dockerContext = undefined;
+    this.buildxScope = undefined;
 
-      return {
-        adapter: this.id,
-        status: "available",
-        version,
-        detail: `Docker daemon available through context ${dockerContext}`,
-        diagnostics: [],
-      };
+    try {
+      this.dockerContext = await inspectDockerContext(this.runDocker);
     } catch (error) {
       return {
         adapter: this.id,
@@ -65,34 +81,94 @@ export class DockerAuditAdapter implements AuditAdapter {
         ],
       };
     }
+
+    const diagnostics: Diagnostic[] = [];
+    try {
+      const scope = await inspectDockerScope(this.runDocker, this.options.builderOverride);
+      if (!dockerContextMatches(this.dockerContext, scope.context)) {
+        throw new Error("Docker context or daemon changed during Buildx inspection");
+      }
+      this.buildxScope = scope;
+    } catch (error) {
+      diagnostics.push({
+        severity: "warning",
+        code: "DOCKER_BUILD_CACHE_UNAVAILABLE",
+        message: error instanceof Error ? error.message : String(error),
+        adapter: this.id,
+        remediation:
+          "Install a supported Docker Buildx release and select one healthy builder to inventory build cache.",
+      });
+    }
+
+    return {
+      adapter: this.id,
+      status: "available",
+      version: this.dockerContext.serverVersion,
+      detail:
+        this.buildxScope === undefined
+          ? `Docker daemon available through context ${this.dockerContext.name}; Buildx cache inventory unavailable`
+          : `Docker daemon and Buildx ${this.buildxScope.buildxVersion} available through context ${this.dockerContext.name}`,
+      diagnostics,
+    };
   }
 
   async collect(context: AuditContext, probe: AdapterProbe): Promise<CollectionResult> {
-    if (probe.status !== "available") {
+    if (probe.status !== "available" || this.dockerContext === undefined) {
       return { resources: [], diagnostics: [] };
     }
 
     const images = parseJsonLines(
-      await this.runDocker(["image", "ls", "--no-trunc", "--format", "{{json .}}"]),
+      await this.runDocker([
+        "--context",
+        this.dockerContext.name,
+        "image",
+        "ls",
+        "--no-trunc",
+        "--format",
+        "{{json .}}",
+      ]),
     );
     const containers = parseJsonLines(
-      await this.runDocker(["container", "ls", "-a", "--no-trunc", "--format", "{{json .}}"]),
+      await this.runDocker([
+        "--context",
+        this.dockerContext.name,
+        "container",
+        "ls",
+        "-a",
+        "--no-trunc",
+        "--format",
+        "{{json .}}",
+      ]),
     );
+    const resources = [
+      ...images.flatMap((image) =>
+        this.toDockerResource(context, "docker-image", image, "ID", "Repository"),
+      ),
+      ...containers.flatMap((container) =>
+        this.toDockerResource(context, "docker-container", container, "ID", "Names"),
+      ),
+    ];
+    const diagnostics: Diagnostic[] = [];
 
-    return {
-      resources: [
-        ...images.flatMap((image) =>
-          this.toResource(context, "docker-image", image, "ID", "Repository"),
-        ),
-        ...containers.flatMap((container) =>
-          this.toResource(context, "docker-container", container, "ID", "Names"),
-        ),
-      ],
-      diagnostics: [],
-    };
+    if (this.buildxScope !== undefined) {
+      try {
+        const cache = await inspectDockerBuildCache(this.buildxScope, this.runDocker);
+        resources.push(...cache.map((record) => this.toBuildCacheResource(context, record)));
+      } catch (error) {
+        diagnostics.push({
+          severity: "warning",
+          code: "DOCKER_BUILD_CACHE_COLLECTION_FAILED",
+          message: error instanceof Error ? error.message : String(error),
+          adapter: this.id,
+          remediation: "Run docker buildx du for the selected builder and resolve its error.",
+        });
+      }
+    }
+
+    return { resources, diagnostics };
   }
 
-  private toResource(
+  private toDockerResource(
     context: AuditContext,
     kind: ResourceKind,
     facts: Record<string, unknown>,
@@ -100,11 +176,11 @@ export class DockerAuditAdapter implements AuditAdapter {
     nameField: string,
   ): ResourceSnapshot[] {
     const externalId = stringField(facts, idField);
-    if (externalId === undefined) {
+    if (externalId === undefined || this.dockerContext === undefined) {
       return [];
     }
 
-    const canonicalKey = `docker:${kind}:${externalId}`;
+    const canonicalKey = `docker:${this.dockerContext.daemonId}:${kind}:${externalId}`;
     return [
       {
         resource: {
@@ -119,14 +195,73 @@ export class DockerAuditAdapter implements AuditAdapter {
         exists: true,
         facts: {
           ...facts,
+          dockerContext: this.dockerContext,
           reportOnly: true,
         },
       },
     ];
   }
 
+  private toBuildCacheResource(
+    context: AuditContext,
+    cache: DockerBuildCacheRecord,
+  ): ResourceSnapshot {
+    const scope = this.buildxScope!;
+    const canonicalKey = [
+      "docker",
+      scope.context.daemonId,
+      "docker-build-cache",
+      scope.builder.fingerprint,
+      cache.id,
+    ].join(":");
+    return {
+      resource: {
+        id: `docker:docker-build-cache:${sha256(canonicalKey)}`,
+        adapter: this.id,
+        kind: "docker-build-cache",
+        canonicalKey,
+        displayName: cache.id,
+        externalId: cache.id,
+      },
+      observedAt: context.now.toISOString(),
+      exists: true,
+      measuredBytes: cache.sizeBytes,
+      facts: {
+        dockerScope: scope,
+        cache,
+        reportOnly: true,
+        mutationStatus: "unbound-owner-identity",
+      },
+    };
+  }
+
   async classify(context: AuditContext, resource: ResourceSnapshot): Promise<Finding> {
     const observedAt = context.now.toISOString();
+    const cache =
+      resource.resource.kind === "docker-build-cache" ? buildCacheRecord(resource) : undefined;
+    const root =
+      cache === undefined
+        ? {
+            code: "docker-resource-report-only",
+            source: "docker",
+            observedAt,
+            detail: "Docker resources are inventoried without mutation.",
+          }
+        : this.buildCacheRoot(cache, context.now, observedAt);
+    const warnings: Diagnostic[] =
+      cache?.shared === true
+        ? [
+            {
+              severity: "info",
+              code: "DOCKER_BUILD_CACHE_SHARED",
+              message:
+                "Docker reports this cache record as shared, so its size is not reclaimable.",
+              adapter: this.id,
+              resourceId: resource.resource.id,
+            },
+          ]
+        : [];
+
     return {
       schemaVersion: 1,
       findingId: `${resource.resource.id}:${sha256(context.auditId)}`,
@@ -135,17 +270,54 @@ export class DockerAuditAdapter implements AuditAdapter {
       resource: resource.resource,
       state: "protected",
       confidence: "certain",
-      roots: [
-        {
-          code: "docker-audit-only",
-          source: "docker",
-          observedAt,
-          detail: "The Docker adapter inventories resources but cannot prune them.",
-        },
-      ],
+      roots: [root],
       facts: resource.facts,
       candidateActions: [],
-      warnings: [],
+      ...(resource.measuredBytes === undefined ? {} : { measuredBytes: resource.measuredBytes }),
+      ...(cache === undefined ? {} : { estimatedReclaimBytes: cache.shared ? 0 : cache.sizeBytes }),
+      warnings,
+    };
+  }
+
+  private buildCacheRoot(cache: DockerBuildCacheRecord, now: Date, observedAt: string) {
+    if (cache.mutable) {
+      return {
+        code: "docker-build-cache-mutable",
+        source: "docker",
+        observedAt,
+        detail: "Docker reports this build-cache record as mutable.",
+      };
+    }
+    if (!cache.reclaimable) {
+      return {
+        code: "docker-build-cache-in-use",
+        source: "docker",
+        observedAt,
+        detail: "Docker reports this build-cache record as not reclaimable.",
+      };
+    }
+    if (cache.recordType === "internal" || cache.recordType === "frontend") {
+      return {
+        code: "docker-build-cache-internal",
+        source: "docker",
+        observedAt,
+        detail: `Docker classifies this as ${cache.recordType} build cache.`,
+      };
+    }
+    if (!dockerBuildCacheIsOldEnough(cache, now)) {
+      return {
+        code: "docker-build-cache-recent",
+        source: "docker",
+        observedAt,
+        detail: "The cache record lacks conservative proof that it is at least seven days old.",
+      };
+    }
+    return {
+      code: "docker-build-cache-mutation-unbound",
+      source: "docker",
+      observedAt,
+      detail:
+        "Buildx prune re-resolves context and builder names and cannot condition deletion on the revalidated daemon and worker identity.",
     };
   }
 }

--- a/src/adapters/docker/adapter.ts
+++ b/src/adapters/docker/adapter.ts
@@ -347,7 +347,9 @@ export class DockerAuditAdapter implements AuditAdapter {
       facts: resource.facts,
       candidateActions: [],
       ...(resource.measuredBytes === undefined ? {} : { measuredBytes: resource.measuredBytes }),
-      ...(cache === undefined ? {} : { estimatedReclaimBytes: cache.shared ? 0 : cache.sizeBytes }),
+      ...(cache === undefined
+        ? {}
+        : { estimatedReclaimBytes: cache.reclaimable && !cache.shared ? cache.sizeBytes : 0 }),
       warnings,
     };
   }

--- a/src/adapters/docker/adapter.ts
+++ b/src/adapters/docker/adapter.ts
@@ -313,7 +313,7 @@ export class DockerAuditAdapter implements AuditAdapter {
       },
       observedAt: context.now.toISOString(),
       exists: true,
-      measuredBytes: cache.sizeBytes,
+      ...(cache.sizeEvidence.kind === "exact" ? { measuredBytes: cache.sizeEvidence.bytes } : {}),
       facts: {
         dockerScope: scope,
         cache,
@@ -364,7 +364,12 @@ export class DockerAuditAdapter implements AuditAdapter {
       ...(resource.measuredBytes === undefined ? {} : { measuredBytes: resource.measuredBytes }),
       ...(cache === undefined
         ? {}
-        : { estimatedReclaimBytes: cache.reclaimable && !cache.shared ? cache.sizeBytes : 0 }),
+        : cache.sizeEvidence.kind === "exact"
+          ? {
+              estimatedReclaimBytes:
+                cache.reclaimable && !cache.shared ? cache.sizeEvidence.bytes : 0,
+            }
+          : {}),
       warnings,
     };
   }

--- a/src/adapters/docker/adapter.ts
+++ b/src/adapters/docker/adapter.ts
@@ -216,7 +216,14 @@ export class DockerAuditAdapter implements AuditAdapter {
         ) {
           throw new Error("Docker context, daemon, or builder changed before cache collection");
         }
-        const cache = await inspectDockerBuildCache(collectedScope, this.runDocker);
+        const unsupportedRecords: Array<{ index: number; message: string }> = [];
+        const cache = await inspectDockerBuildCache(
+          collectedScope,
+          this.runDocker,
+          (index, error) => {
+            unsupportedRecords.push({ index, message: error.message });
+          },
+        );
         const verifiedScope = await inspectDockerScope(
           this.runDocker,
           this.options.builderOverride,
@@ -227,6 +234,14 @@ export class DockerAuditAdapter implements AuditAdapter {
         }
         this.buildxScope = verifiedScope;
         resources.push(...cache.map((record) => this.toBuildCacheResource(context, record)));
+        diagnostics.push(
+          ...unsupportedRecords.map(({ index, message }) => ({
+            severity: "warning" as const,
+            code: "DOCKER_BUILD_CACHE_RECORD_UNSUPPORTED",
+            message: `Buildx cache record ${index + 1} was skipped: ${message}`,
+            adapter: this.id,
+          })),
+        );
       } catch (error) {
         diagnostics.push({
           severity: "warning",

--- a/src/adapters/docker/owner.ts
+++ b/src/adapters/docker/owner.ts
@@ -191,9 +191,19 @@ function parseSizeBytes(value: unknown): number {
 }
 
 function relativeAgeLowerBoundHours(value: string): number | undefined {
-  const normalized = value.trim().replace(/\s+ago$/u, "");
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "less than a second ago") {
+    return 0;
+  }
+  if (normalized === "about a minute ago") {
+    return 1 / 60;
+  }
+  if (normalized === "about an hour ago") {
+    return 1;
+  }
+  const withoutAgo = normalized.replace(/\s+ago$/u, "");
   const match = /^(\d+)\s+(seconds?|minutes?|hours?|days?|weeks?|months?|years?)$/u.exec(
-    normalized,
+    withoutAgo,
   );
   if (match === null) {
     return undefined;
@@ -236,13 +246,10 @@ function parseAgeEvidence(value: unknown): DockerBuildCacheAgeEvidence {
     };
   }
   const lowerBoundHours = relativeAgeLowerBoundHours(value);
-  if (lowerBoundHours === undefined) {
-    throw new DockerOwnerContractError("Docker cache last-used age is unsupported");
-  }
   return {
     kind: "relative",
     observed: value.trim(),
-    lowerBoundHours,
+    lowerBoundHours: lowerBoundHours ?? 0,
   };
 }
 
@@ -306,10 +313,9 @@ function parseBuilder(
   };
 }
 
-export async function inspectDockerScope(
+export async function inspectDockerContext(
   runDocker: DockerRunner = defaultDockerRunner,
-  builderOverride?: string,
-): Promise<DockerScopeIdentity> {
+): Promise<DockerContextIdentity> {
   const contextName = (await runDocker(["context", "show"])).trim();
   if (contextName === "") {
     throw new DockerOwnerContractError("Docker context is missing");
@@ -329,6 +335,19 @@ export async function inspectDockerScope(
   const daemon = JSON.parse(
     await runDocker(["--context", contextName, "info", "--format", "{{json .}}"]),
   ) as Record<string, unknown>;
+  return {
+    name: contextName,
+    endpoint: endpoint.trim(),
+    daemonId: requireString(daemon, "ID", "daemon ID"),
+    serverVersion: requireString(daemon, "ServerVersion", "server version"),
+  };
+}
+
+export async function inspectDockerScope(
+  runDocker: DockerRunner = defaultDockerRunner,
+  builderOverride?: string,
+): Promise<DockerScopeIdentity> {
+  const context = await inspectDockerContext(runDocker);
   const buildxVersion = parseBuildxVersion(await runDocker(["buildx", "version"]));
   if (!supportsDockerBuildxContract(buildxVersion)) {
     throw new DockerOwnerContractError(
@@ -336,31 +355,21 @@ export async function inspectDockerScope(
     );
   }
   const builders = parseJsonLines(
-    await runDocker(["--context", contextName, "buildx", "ls", "--format=json"]),
+    await runDocker(["--context", context.name, "buildx", "ls", "--format=json"]),
   );
 
   return {
     buildxVersion,
-    context: {
-      name: contextName,
-      endpoint: endpoint.trim(),
-      daemonId: requireString(daemon, "ID", "daemon ID"),
-      serverVersion: requireString(daemon, "ServerVersion", "server version"),
-    },
+    context,
     builder: parseBuilder(builders, builderOverride),
   };
 }
 
-export function exactDockerBuildCacheFilter(cacheId: string): string {
-  if (!CACHE_ID_PATTERN.test(cacheId)) {
-    throw new DockerOwnerContractError("Docker build-cache ID is unsupported");
-  }
-  return `id=^${cacheId}$`;
-}
-
 function parseCacheRecord(value: Record<string, unknown>): DockerBuildCacheRecord {
   const id = requireString(value, "ID", "cache ID");
-  exactDockerBuildCacheFilter(id);
+  if (!CACHE_ID_PATTERN.test(id)) {
+    throw new DockerOwnerContractError("Docker build-cache ID is unsupported");
+  }
   const stable = {
     id,
     createdAt: parseDate(requireString(value, "CreatedAt"), "cache creation time"),
@@ -371,32 +380,34 @@ function parseCacheRecord(value: Record<string, unknown>): DockerBuildCacheRecor
     usageCount: requireNonnegativeInteger(value, "UsageCount"),
     parents: parseStringArray(value["Parents"] ?? [], "cache parents"),
     recordType: requireString(value, "Type", "cache record type"),
-    ageEvidence: parseAgeEvidence(value["LastUsedAt"]),
+  };
+  const ageEvidence = parseAgeEvidence(value["LastUsedAt"]);
+  const fingerprintFacts = {
+    ...stable,
+    ...(ageEvidence.kind === "timestamp" ? { lastUsedAt: ageEvidence.lastUsedAt } : {}),
   };
   return {
     ...stable,
-    fingerprint: sha256Json(stable),
+    ageEvidence,
+    fingerprint: sha256Json(fingerprintFacts),
   };
 }
 
 export async function inspectDockerBuildCache(
   scope: DockerScopeIdentity,
   runDocker: DockerRunner = defaultDockerRunner,
-  cacheId?: string,
 ): Promise<DockerBuildCacheRecord[]> {
-  const args = [
-    "--context",
-    scope.context.name,
-    "buildx",
-    "du",
-    "--builder",
-    scope.builder.name,
-    "--format=json",
-  ];
-  if (cacheId !== undefined) {
-    args.push("--filter", exactDockerBuildCacheFilter(cacheId));
-  }
-  return parseJsonLines(await runDocker(args)).map(parseCacheRecord);
+  return parseJsonLines(
+    await runDocker([
+      "--context",
+      scope.context.name,
+      "buildx",
+      "du",
+      "--builder",
+      scope.builder.name,
+      "--format=json",
+    ]),
+  ).map(parseCacheRecord);
 }
 
 export function dockerBuildCacheIsOldEnough(

--- a/src/adapters/docker/owner.ts
+++ b/src/adapters/docker/owner.ts
@@ -322,10 +322,16 @@ function parseBuilder(
   if (!Array.isArray(nodesValue) || nodesValue.length === 0) {
     throw new DockerOwnerContractError("Docker Buildx builder has no nodes");
   }
+  const dynamic = requireBoolean(record, "Dynamic");
+  if (dynamic) {
+    throw new DockerOwnerContractError(
+      "Docker Buildx dynamic builders cannot bind cache records to an inspected worker",
+    );
+  }
   const identity = {
     name: requireString(record, "Name", "Buildx builder name"),
     driver: requireString(record, "Driver", "Buildx builder driver"),
-    dynamic: requireBoolean(record, "Dynamic"),
+    dynamic,
     nodes: nodesValue
       .map(parseBuilderNode)
       .sort((left, right) => left.name.localeCompare(right.name)),

--- a/src/adapters/docker/owner.ts
+++ b/src/adapters/docker/owner.ts
@@ -74,7 +74,7 @@ export type DockerBuildCacheRecord = {
       };
   usageCount: number;
   parents: string[];
-  recordType: string;
+  recordType?: string;
   ageEvidence: DockerBuildCacheAgeEvidence;
   fingerprint: string;
 };
@@ -197,11 +197,13 @@ function parseSizeEvidence(value: unknown): DockerBuildCacheRecord["sizeEvidence
       return { kind: "exact", bytes };
     }
   }
-  const match = /^(\d+(?:\.\d+)?)\s*(B|KB|MB|GB|TB)$/iu.exec(trimmed);
+  const match = /^(\d+(?:\.\d+)?)\s*(B|KB|MB|GB|TB|PB|EB|ZB|YB)$/iu.exec(trimmed);
   if (match === null) {
     throw new DockerOwnerContractError("Docker cache size is not a supported byte value");
   }
-  const exponent = ["B", "KB", "MB", "GB", "TB"].indexOf(match[2]!.toUpperCase());
+  const exponent = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"].indexOf(
+    match[2]!.toUpperCase(),
+  );
   const bytes = Math.round(Number(match[1]) * 1000 ** exponent);
   if (!Number.isSafeInteger(bytes) || bytes < 0) {
     throw new DockerOwnerContractError("Docker cache size exceeds the supported range");
@@ -418,6 +420,7 @@ function parseCacheRecord(value: Record<string, unknown>): DockerBuildCacheRecor
   if (!CACHE_ID_PATTERN.test(id)) {
     throw new DockerOwnerContractError("Docker build-cache ID is unsupported");
   }
+  const recordType = optionalString(value, "Type");
   const stable = {
     id,
     createdAt: parseDate(requireString(value, "CreatedAt"), "cache creation time"),
@@ -427,7 +430,7 @@ function parseCacheRecord(value: Record<string, unknown>): DockerBuildCacheRecor
     sizeEvidence: parseSizeEvidence(value["Size"]),
     usageCount: requireNonnegativeInteger(value, "UsageCount"),
     parents: parseStringArray(value["Parents"] ?? [], "cache parents"),
-    recordType: requireString(value, "Type", "cache record type"),
+    ...(recordType === undefined ? {} : { recordType }),
   };
   const ageEvidence = parseAgeEvidence(value["LastUsedAt"]);
   const fingerprintFacts = {

--- a/src/adapters/docker/owner.ts
+++ b/src/adapters/docker/owner.ts
@@ -294,11 +294,15 @@ function parseBuilderNode(value: unknown): DockerBuilderNodeIdentity {
     throw new DockerOwnerContractError("Docker Buildx node is not healthy and running");
   }
   const version = optionalString(record, "Version");
+  const workerIds = parseStringArray(record["IDs"] ?? [], "Buildx worker IDs");
+  if (workerIds.length === 0 || workerIds.some((id) => id.trim() === "")) {
+    throw new DockerOwnerContractError("Docker Buildx node has no stable worker IDs");
+  }
   return {
     name: requireString(record, "Name", "Buildx node name"),
     endpoint: requireString(record, "Endpoint", "Buildx node endpoint"),
     ...(version === undefined ? {} : { version }),
-    workerIds: parseStringArray(record["IDs"] ?? [], "Buildx worker IDs"),
+    workerIds,
   };
 }
 

--- a/src/adapters/docker/owner.ts
+++ b/src/adapters/docker/owner.ts
@@ -53,7 +53,7 @@ export type DockerBuildCacheAgeEvidence =
       lowerBoundHours: number;
     }
   | {
-      kind: "never-used";
+      kind: "unknown";
     };
 
 export type DockerBuildCacheRecord = {
@@ -243,7 +243,7 @@ function relativeAgeLowerBoundHours(value: string): number | undefined {
 
 function parseAgeEvidence(value: unknown): DockerBuildCacheAgeEvidence {
   if (value === undefined || value === null || value === "") {
-    return { kind: "never-used" };
+    return { kind: "unknown" };
   }
   if (typeof value !== "string") {
     throw new DockerOwnerContractError("Docker cache last-used value is unsupported");
@@ -421,17 +421,37 @@ function parseCacheRecord(value: Record<string, unknown>): DockerBuildCacheRecor
 export async function inspectDockerBuildCache(
   scope: DockerScopeIdentity,
   runDocker: DockerRunner = defaultDockerRunner,
+  onUnsupportedRecord?: (index: number, error: DockerOwnerContractError) => void,
 ): Promise<DockerBuildCacheRecord[]> {
-  return parseJsonLines(
-    await runDocker([
-      ...scope.context.commandPrefix,
-      "buildx",
-      "du",
-      "--builder",
-      scope.builder.name,
-      "--format=json",
-    ]),
-  ).map(parseCacheRecord);
+  const output = await runDocker([
+    ...scope.context.commandPrefix,
+    "buildx",
+    "du",
+    "--builder",
+    scope.builder.name,
+    "--format=json",
+  ]);
+  const records: DockerBuildCacheRecord[] = [];
+  for (const [index, line] of output
+    .split("\n")
+    .map((value) => value.trim())
+    .filter((value) => value !== "")
+    .entries()) {
+    try {
+      records.push(parseCacheRecord(JSON.parse(line) as Record<string, unknown>));
+    } catch (error) {
+      const ownerError =
+        error instanceof DockerOwnerContractError
+          ? error
+          : new DockerOwnerContractError(
+              `Docker build-cache record is malformed: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            );
+      onUnsupportedRecord?.(index, ownerError);
+    }
+  }
+  return records;
 }
 
 export function dockerBuildCacheIsOldEnough(
@@ -442,9 +462,9 @@ export function dockerBuildCacheIsOldEnough(
   if (record.ageEvidence.kind === "relative") {
     return record.ageEvidence.lowerBoundHours >= minimumAgeHours;
   }
-  const relevantTimestamp =
-    record.ageEvidence.kind === "timestamp"
-      ? Date.parse(record.ageEvidence.lastUsedAt)
-      : Date.parse(record.createdAt);
+  if (record.ageEvidence.kind === "unknown") {
+    return false;
+  }
+  const relevantTimestamp = Date.parse(record.ageEvidence.lastUsedAt);
   return now.getTime() - relevantTimestamp >= minimumAgeHours * 60 * 60 * 1000;
 }

--- a/src/adapters/docker/owner.ts
+++ b/src/adapters/docker/owner.ts
@@ -18,6 +18,7 @@ export type DockerContextIdentity = {
   endpoint: string;
   daemonId: string;
   serverVersion: string;
+  commandPrefix: string[];
 };
 
 export type DockerBuilderNodeIdentity = {
@@ -74,12 +75,19 @@ export class DockerOwnerContractError extends Error {
 }
 
 export async function defaultDockerRunner(args: string[]): Promise<string> {
-  const result = await execFileAsync("docker", args, {
-    encoding: "utf8",
-    maxBuffer: 16 * 1024 * 1024,
-    timeout: 20_000,
-  });
-  return result.stdout;
+  return createDockerRunner()(args);
+}
+
+export function createDockerRunner(environment: NodeJS.ProcessEnv = process.env): DockerRunner {
+  return async (args) => {
+    const result = await execFileAsync("docker", args, {
+      encoding: "utf8",
+      env: environment,
+      maxBuffer: 16 * 1024 * 1024,
+      timeout: 20_000,
+    });
+    return result.stdout;
+  };
 }
 
 function parseJsonLines(input: string): Record<string, unknown>[] {
@@ -315,39 +323,54 @@ function parseBuilder(
 
 export async function inspectDockerContext(
   runDocker: DockerRunner = defaultDockerRunner,
+  environment: NodeJS.ProcessEnv = process.env,
 ): Promise<DockerContextIdentity> {
   const contextName = (await runDocker(["context", "show"])).trim();
   if (contextName === "") {
     throw new DockerOwnerContractError("Docker context is missing");
   }
-  const endpointOutput = await runDocker([
-    "context",
-    "inspect",
-    contextName,
-    "--format",
-    "{{json .Endpoints.docker.Host}}",
-  ]);
-  const endpoint = JSON.parse(endpointOutput.trim()) as unknown;
-  if (typeof endpoint !== "string" || endpoint.trim() === "") {
-    throw new DockerOwnerContractError("Docker context endpoint is missing");
+  const dockerContext = environment["DOCKER_CONTEXT"]?.trim();
+  const dockerHost = environment["DOCKER_HOST"]?.trim();
+  const usesEnvironmentHost =
+    (dockerContext === undefined || dockerContext === "") &&
+    dockerHost !== undefined &&
+    dockerHost !== "";
+  const commandPrefix = usesEnvironmentHost ? [] : ["--context", contextName];
+  let endpoint = dockerHost;
+  if (!usesEnvironmentHost) {
+    const endpointOutput = await runDocker([
+      "context",
+      "inspect",
+      contextName,
+      "--format",
+      "{{json .Endpoints.docker.Host}}",
+    ]);
+    const inspectedEndpoint = JSON.parse(endpointOutput.trim()) as unknown;
+    if (typeof inspectedEndpoint !== "string" || inspectedEndpoint.trim() === "") {
+      throw new DockerOwnerContractError("Docker context endpoint is missing");
+    }
+    endpoint = inspectedEndpoint.trim();
   }
 
   const daemon = JSON.parse(
-    await runDocker(["--context", contextName, "info", "--format", "{{json .}}"]),
+    await runDocker([...commandPrefix, "info", "--format", "{{json .}}"]),
   ) as Record<string, unknown>;
   return {
     name: contextName,
-    endpoint: endpoint.trim(),
+    endpoint: endpoint!,
     daemonId: requireString(daemon, "ID", "daemon ID"),
     serverVersion: requireString(daemon, "ServerVersion", "server version"),
+    commandPrefix,
   };
 }
 
 export async function inspectDockerScope(
   runDocker: DockerRunner = defaultDockerRunner,
   builderOverride?: string,
+  environment: NodeJS.ProcessEnv = process.env,
 ): Promise<DockerScopeIdentity> {
-  const context = await inspectDockerContext(runDocker);
+  const context = await inspectDockerContext(runDocker, environment);
+  const selectedBuilder = builderOverride?.trim() || undefined;
   const buildxVersion = parseBuildxVersion(await runDocker(["buildx", "version"]));
   if (!supportsDockerBuildxContract(buildxVersion)) {
     throw new DockerOwnerContractError(
@@ -355,13 +378,13 @@ export async function inspectDockerScope(
     );
   }
   const builders = parseJsonLines(
-    await runDocker(["--context", context.name, "buildx", "ls", "--format=json"]),
+    await runDocker([...context.commandPrefix, "buildx", "ls", "--format=json"]),
   );
 
   return {
     buildxVersion,
     context,
-    builder: parseBuilder(builders, builderOverride),
+    builder: parseBuilder(builders, selectedBuilder),
   };
 }
 
@@ -399,8 +422,7 @@ export async function inspectDockerBuildCache(
 ): Promise<DockerBuildCacheRecord[]> {
   return parseJsonLines(
     await runDocker([
-      "--context",
-      scope.context.name,
+      ...scope.context.commandPrefix,
       "buildx",
       "du",
       "--builder",

--- a/src/adapters/docker/owner.ts
+++ b/src/adapters/docker/owner.ts
@@ -128,8 +128,8 @@ function requireNonnegativeInteger(record: Record<string, unknown>, key: string)
 }
 
 function parseSemver(version: string): [number, number, number] | undefined {
-  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/u.exec(version);
-  if (match === null) {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/u.exec(version);
+  if (match === null || match[4] !== undefined) {
     return undefined;
   }
   return [Number(match[1]), Number(match[2]), Number(match[3])];
@@ -157,7 +157,9 @@ export function supportsDockerBuildxContract(version: string): boolean {
 }
 
 function parseBuildxVersion(output: string): string {
-  const match = /\bv?(\d+\.\d+\.\d+)(?:[-+][^\s]+)?\b/u.exec(output);
+  const match = /\bv?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)(?=\s|$)/u.exec(
+    output,
+  );
   if (match?.[1] === undefined) {
     throw new DockerOwnerContractError("Docker Buildx version is unrecognized");
   }

--- a/src/adapters/docker/owner.ts
+++ b/src/adapters/docker/owner.ts
@@ -62,7 +62,16 @@ export type DockerBuildCacheRecord = {
   mutable: boolean;
   reclaimable: boolean;
   shared: boolean;
-  sizeBytes: number;
+  sizeEvidence:
+    | {
+        kind: "exact";
+        bytes: number;
+      }
+    | {
+        kind: "humanized";
+        observed: string;
+        approximateBytes: number;
+      };
   usageCount: number;
   parents: string[];
   recordType: string;
@@ -174,9 +183,9 @@ function parseDate(value: string, description: string): string {
   return new Date(timestamp).toISOString();
 }
 
-function parseSizeBytes(value: unknown): number {
+function parseSizeEvidence(value: unknown): DockerBuildCacheRecord["sizeEvidence"] {
   if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) {
-    return value;
+    return { kind: "exact", bytes: value };
   }
   if (typeof value !== "string") {
     throw new DockerOwnerContractError("Docker cache size is not numeric");
@@ -185,7 +194,7 @@ function parseSizeBytes(value: unknown): number {
   if (/^\d+$/u.test(trimmed)) {
     const bytes = Number(trimmed);
     if (Number.isSafeInteger(bytes)) {
-      return bytes;
+      return { kind: "exact", bytes };
     }
   }
   const match = /^(\d+(?:\.\d+)?)\s*(B|KB|MB|GB|TB)$/iu.exec(trimmed);
@@ -197,7 +206,11 @@ function parseSizeBytes(value: unknown): number {
   if (!Number.isSafeInteger(bytes) || bytes < 0) {
     throw new DockerOwnerContractError("Docker cache size exceeds the supported range");
   }
-  return bytes;
+  return {
+    kind: "humanized",
+    observed: trimmed,
+    approximateBytes: bytes,
+  };
 }
 
 function relativeAgeLowerBoundHours(value: string): number | undefined {
@@ -401,7 +414,7 @@ function parseCacheRecord(value: Record<string, unknown>): DockerBuildCacheRecor
     mutable: requireBoolean(value, "Mutable"),
     reclaimable: requireBoolean(value, "Reclaimable"),
     shared: requireBoolean(value, "Shared"),
-    sizeBytes: parseSizeBytes(value["Size"]),
+    sizeEvidence: parseSizeEvidence(value["Size"]),
     usageCount: requireNonnegativeInteger(value, "UsageCount"),
     parents: parseStringArray(value["Parents"] ?? [], "cache parents"),
     recordType: requireString(value, "Type", "cache record type"),

--- a/src/adapters/docker/owner.ts
+++ b/src/adapters/docker/owner.ts
@@ -1,0 +1,415 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import { sha256Json } from "../../core/digest.js";
+
+const execFileAsync = promisify(execFile);
+
+export const DOCKER_BUILD_CACHE_MINIMUM_AGE_HOURS = 168;
+export const DOCKER_BUILDX_CONTRACT_MIN_VERSION = "0.33.0";
+export const DOCKER_BUILDX_CONTRACT_MAX_VERSION = "0.35.99";
+
+const CACHE_ID_PATTERN = /^[a-z0-9]{20,128}$/u;
+
+export type DockerRunner = (args: string[]) => Promise<string>;
+
+export type DockerContextIdentity = {
+  name: string;
+  endpoint: string;
+  daemonId: string;
+  serverVersion: string;
+};
+
+export type DockerBuilderNodeIdentity = {
+  name: string;
+  endpoint: string;
+  version?: string;
+  workerIds: string[];
+};
+
+export type DockerBuilderIdentity = {
+  name: string;
+  driver: string;
+  dynamic: boolean;
+  nodes: DockerBuilderNodeIdentity[];
+  fingerprint: string;
+};
+
+export type DockerScopeIdentity = {
+  buildxVersion: string;
+  context: DockerContextIdentity;
+  builder: DockerBuilderIdentity;
+};
+
+export type DockerBuildCacheAgeEvidence =
+  | {
+      kind: "timestamp";
+      lastUsedAt: string;
+    }
+  | {
+      kind: "relative";
+      observed: string;
+      lowerBoundHours: number;
+    }
+  | {
+      kind: "never-used";
+    };
+
+export type DockerBuildCacheRecord = {
+  id: string;
+  createdAt: string;
+  mutable: boolean;
+  reclaimable: boolean;
+  shared: boolean;
+  sizeBytes: number;
+  usageCount: number;
+  parents: string[];
+  recordType: string;
+  ageEvidence: DockerBuildCacheAgeEvidence;
+  fingerprint: string;
+};
+
+export class DockerOwnerContractError extends Error {
+  override readonly name = "DockerOwnerContractError";
+}
+
+export async function defaultDockerRunner(args: string[]): Promise<string> {
+  const result = await execFileAsync("docker", args, {
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+    timeout: 20_000,
+  });
+  return result.stdout;
+}
+
+function parseJsonLines(input: string): Record<string, unknown>[] {
+  return input
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "")
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+function requireString(record: Record<string, unknown>, key: string, description = key): string {
+  const value = record[key];
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new DockerOwnerContractError(`Docker ${description} is missing`);
+  }
+  return value.trim();
+}
+
+function optionalString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.trim() !== "" ? value.trim() : undefined;
+}
+
+function requireBoolean(record: Record<string, unknown>, key: string): boolean {
+  const value = record[key];
+  if (typeof value !== "boolean") {
+    throw new DockerOwnerContractError(`Docker ${key} is not boolean`);
+  }
+  return value;
+}
+
+function requireNonnegativeInteger(record: Record<string, unknown>, key: string): number {
+  const value = record[key];
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new DockerOwnerContractError(`Docker ${key} is not a nonnegative integer`);
+  }
+  return value;
+}
+
+function parseSemver(version: string): [number, number, number] | undefined {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/u.exec(version);
+  if (match === null) {
+    return undefined;
+  }
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function compareSemver(left: [number, number, number], right: [number, number, number]): number {
+  for (let index = 0; index < 3; index += 1) {
+    const difference = left[index]! - right[index]!;
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+  return 0;
+}
+
+export function supportsDockerBuildxContract(version: string): boolean {
+  const parsed = parseSemver(version);
+  const minimum = parseSemver(DOCKER_BUILDX_CONTRACT_MIN_VERSION)!;
+  const maximum = parseSemver(DOCKER_BUILDX_CONTRACT_MAX_VERSION)!;
+  return (
+    parsed !== undefined &&
+    compareSemver(parsed, minimum) >= 0 &&
+    compareSemver(parsed, maximum) <= 0
+  );
+}
+
+function parseBuildxVersion(output: string): string {
+  const match = /\bv?(\d+\.\d+\.\d+)(?:[-+][^\s]+)?\b/u.exec(output);
+  if (match?.[1] === undefined) {
+    throw new DockerOwnerContractError("Docker Buildx version is unrecognized");
+  }
+  return match[1];
+}
+
+function parseDate(value: string, description: string): string {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) {
+    throw new DockerOwnerContractError(`Docker ${description} is not a supported timestamp`);
+  }
+  return new Date(timestamp).toISOString();
+}
+
+function parseSizeBytes(value: unknown): number {
+  if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) {
+    return value;
+  }
+  if (typeof value !== "string") {
+    throw new DockerOwnerContractError("Docker cache size is not numeric");
+  }
+  const trimmed = value.trim();
+  if (/^\d+$/u.test(trimmed)) {
+    const bytes = Number(trimmed);
+    if (Number.isSafeInteger(bytes)) {
+      return bytes;
+    }
+  }
+  const match = /^(\d+(?:\.\d+)?)\s*(B|KB|MB|GB|TB)$/iu.exec(trimmed);
+  if (match === null) {
+    throw new DockerOwnerContractError("Docker cache size is not a supported byte value");
+  }
+  const exponent = ["B", "KB", "MB", "GB", "TB"].indexOf(match[2]!.toUpperCase());
+  const bytes = Math.round(Number(match[1]) * 1000 ** exponent);
+  if (!Number.isSafeInteger(bytes) || bytes < 0) {
+    throw new DockerOwnerContractError("Docker cache size exceeds the supported range");
+  }
+  return bytes;
+}
+
+function relativeAgeLowerBoundHours(value: string): number | undefined {
+  const normalized = value.trim().replace(/\s+ago$/u, "");
+  const match = /^(\d+)\s+(seconds?|minutes?|hours?|days?|weeks?|months?|years?)$/u.exec(
+    normalized,
+  );
+  if (match === null) {
+    return undefined;
+  }
+  const count = Number(match[1]);
+  const unit = match[2]!;
+  if (unit.startsWith("second")) {
+    return count / 3600;
+  }
+  if (unit.startsWith("minute")) {
+    return count / 60;
+  }
+  if (unit.startsWith("hour")) {
+    return Math.max(0, count - 0.5);
+  }
+  if (unit.startsWith("day")) {
+    return Math.max(0, count * 24 - 0.5);
+  }
+  if (unit.startsWith("week")) {
+    return Math.max(0, count * 7 * 24 - 0.5);
+  }
+  if (unit.startsWith("month")) {
+    return Math.max(0, count * 30 * 24 - 0.5);
+  }
+  return Math.max(0, count * 365 * 24);
+}
+
+function parseAgeEvidence(value: unknown): DockerBuildCacheAgeEvidence {
+  if (value === undefined || value === null || value === "") {
+    return { kind: "never-used" };
+  }
+  if (typeof value !== "string") {
+    throw new DockerOwnerContractError("Docker cache last-used value is unsupported");
+  }
+  const parsed = Date.parse(value);
+  if (Number.isFinite(parsed)) {
+    return {
+      kind: "timestamp",
+      lastUsedAt: new Date(parsed).toISOString(),
+    };
+  }
+  const lowerBoundHours = relativeAgeLowerBoundHours(value);
+  if (lowerBoundHours === undefined) {
+    throw new DockerOwnerContractError("Docker cache last-used age is unsupported");
+  }
+  return {
+    kind: "relative",
+    observed: value.trim(),
+    lowerBoundHours,
+  };
+}
+
+function parseStringArray(value: unknown, description: string): string[] {
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    throw new DockerOwnerContractError(`Docker ${description} is not a string array`);
+  }
+  return [...new Set(value)].sort();
+}
+
+function parseBuilderNode(value: unknown): DockerBuilderNodeIdentity {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new DockerOwnerContractError("Docker Buildx node is malformed");
+  }
+  const record = value as Record<string, unknown>;
+  const error = optionalString(record, "Err");
+  const status = optionalString(record, "Status");
+  if (error !== undefined || status !== "running") {
+    throw new DockerOwnerContractError("Docker Buildx node is not healthy and running");
+  }
+  const version = optionalString(record, "Version");
+  return {
+    name: requireString(record, "Name", "Buildx node name"),
+    endpoint: requireString(record, "Endpoint", "Buildx node endpoint"),
+    ...(version === undefined ? {} : { version }),
+    workerIds: parseStringArray(record["IDs"] ?? [], "Buildx worker IDs"),
+  };
+}
+
+function parseBuilder(
+  records: Record<string, unknown>[],
+  builderOverride?: string,
+): DockerBuilderIdentity {
+  const selected =
+    builderOverride === undefined
+      ? records.filter((record) => record["Current"] === true)
+      : records.filter((record) => record["Name"] === builderOverride);
+  if (selected.length !== 1) {
+    throw new DockerOwnerContractError("Docker Buildx selected builder is ambiguous");
+  }
+  const record = selected[0]!;
+  const error = optionalString(record, "Err");
+  if (error !== undefined) {
+    throw new DockerOwnerContractError(`Docker Buildx builder is unavailable: ${error}`);
+  }
+  const nodesValue = record["Nodes"];
+  if (!Array.isArray(nodesValue) || nodesValue.length === 0) {
+    throw new DockerOwnerContractError("Docker Buildx builder has no nodes");
+  }
+  const identity = {
+    name: requireString(record, "Name", "Buildx builder name"),
+    driver: requireString(record, "Driver", "Buildx builder driver"),
+    dynamic: requireBoolean(record, "Dynamic"),
+    nodes: nodesValue
+      .map(parseBuilderNode)
+      .sort((left, right) => left.name.localeCompare(right.name)),
+  };
+  return {
+    ...identity,
+    fingerprint: sha256Json(identity),
+  };
+}
+
+export async function inspectDockerScope(
+  runDocker: DockerRunner = defaultDockerRunner,
+  builderOverride?: string,
+): Promise<DockerScopeIdentity> {
+  const contextName = (await runDocker(["context", "show"])).trim();
+  if (contextName === "") {
+    throw new DockerOwnerContractError("Docker context is missing");
+  }
+  const endpointOutput = await runDocker([
+    "context",
+    "inspect",
+    contextName,
+    "--format",
+    "{{json .Endpoints.docker.Host}}",
+  ]);
+  const endpoint = JSON.parse(endpointOutput.trim()) as unknown;
+  if (typeof endpoint !== "string" || endpoint.trim() === "") {
+    throw new DockerOwnerContractError("Docker context endpoint is missing");
+  }
+
+  const daemon = JSON.parse(
+    await runDocker(["--context", contextName, "info", "--format", "{{json .}}"]),
+  ) as Record<string, unknown>;
+  const buildxVersion = parseBuildxVersion(await runDocker(["buildx", "version"]));
+  if (!supportsDockerBuildxContract(buildxVersion)) {
+    throw new DockerOwnerContractError(
+      `Docker Buildx ${buildxVersion} is outside the inspected ${DOCKER_BUILDX_CONTRACT_MIN_VERSION}-${DOCKER_BUILDX_CONTRACT_MAX_VERSION} contract`,
+    );
+  }
+  const builders = parseJsonLines(
+    await runDocker(["--context", contextName, "buildx", "ls", "--format=json"]),
+  );
+
+  return {
+    buildxVersion,
+    context: {
+      name: contextName,
+      endpoint: endpoint.trim(),
+      daemonId: requireString(daemon, "ID", "daemon ID"),
+      serverVersion: requireString(daemon, "ServerVersion", "server version"),
+    },
+    builder: parseBuilder(builders, builderOverride),
+  };
+}
+
+export function exactDockerBuildCacheFilter(cacheId: string): string {
+  if (!CACHE_ID_PATTERN.test(cacheId)) {
+    throw new DockerOwnerContractError("Docker build-cache ID is unsupported");
+  }
+  return `id=^${cacheId}$`;
+}
+
+function parseCacheRecord(value: Record<string, unknown>): DockerBuildCacheRecord {
+  const id = requireString(value, "ID", "cache ID");
+  exactDockerBuildCacheFilter(id);
+  const stable = {
+    id,
+    createdAt: parseDate(requireString(value, "CreatedAt"), "cache creation time"),
+    mutable: requireBoolean(value, "Mutable"),
+    reclaimable: requireBoolean(value, "Reclaimable"),
+    shared: requireBoolean(value, "Shared"),
+    sizeBytes: parseSizeBytes(value["Size"]),
+    usageCount: requireNonnegativeInteger(value, "UsageCount"),
+    parents: parseStringArray(value["Parents"] ?? [], "cache parents"),
+    recordType: requireString(value, "Type", "cache record type"),
+    ageEvidence: parseAgeEvidence(value["LastUsedAt"]),
+  };
+  return {
+    ...stable,
+    fingerprint: sha256Json(stable),
+  };
+}
+
+export async function inspectDockerBuildCache(
+  scope: DockerScopeIdentity,
+  runDocker: DockerRunner = defaultDockerRunner,
+  cacheId?: string,
+): Promise<DockerBuildCacheRecord[]> {
+  const args = [
+    "--context",
+    scope.context.name,
+    "buildx",
+    "du",
+    "--builder",
+    scope.builder.name,
+    "--format=json",
+  ];
+  if (cacheId !== undefined) {
+    args.push("--filter", exactDockerBuildCacheFilter(cacheId));
+  }
+  return parseJsonLines(await runDocker(args)).map(parseCacheRecord);
+}
+
+export function dockerBuildCacheIsOldEnough(
+  record: DockerBuildCacheRecord,
+  now: Date,
+  minimumAgeHours = DOCKER_BUILD_CACHE_MINIMUM_AGE_HOURS,
+): boolean {
+  if (record.ageEvidence.kind === "relative") {
+    return record.ageEvidence.lowerBoundHours >= minimumAgeHours;
+  }
+  const relevantTimestamp =
+    record.ageEvidence.kind === "timestamp"
+      ? Date.parse(record.ageEvidence.lastUsedAt)
+      : Date.parse(record.createdAt);
+  return now.getTime() - relevantTimestamp >= minimumAgeHours * 60 * 60 * 1000;
+}

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -107,7 +107,11 @@ export function createAuditAdapters(
   }
 
   if (config.adapters.docker?.enabled === true) {
-    adapters.push(new DockerAuditAdapter());
+    adapters.push(
+      new DockerAuditAdapter(undefined, {
+        builderOverride: (options.environment ?? process.env)["BUILDX_BUILDER"],
+      }),
+    );
   }
 
   return adapters;

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -107,9 +107,12 @@ export function createAuditAdapters(
   }
 
   if (config.adapters.docker?.enabled === true) {
+    const environment = options.environment ?? process.env;
+    const builderOverride = environment["BUILDX_BUILDER"]?.trim() || undefined;
     adapters.push(
       new DockerAuditAdapter(undefined, {
-        builderOverride: (options.environment ?? process.env)["BUILDX_BUILDER"],
+        builderOverride,
+        environment,
       }),
     );
   }

--- a/src/commands/adapters.ts
+++ b/src/commands/adapters.ts
@@ -14,7 +14,7 @@ export function renderAdapters(): string {
     "",
     "git        audit-only  Git worktrees (explicit root)",
     "runtime    audit-only  Installed agent runtimes",
-    "docker     audit-only  Docker images and containers (opt-in)",
+    "docker     audit-only  Docker images, containers, and Buildx cache (opt-in)",
     "artifacts  safe-clean  Explicit rebuildable project directories",
     "",
   ];

--- a/test/adapters/docker-adapter.test.ts
+++ b/test/adapters/docker-adapter.test.ts
@@ -1,13 +1,87 @@
 import { describe, expect, it } from "vitest";
 
 import { DockerAuditAdapter } from "../../src/adapters/docker/adapter.js";
+import type { DockerRunner } from "../../src/adapters/docker/owner.js";
 import type { AuditContext } from "../../src/contracts/adapter.js";
 
 const CONTEXT: AuditContext = {
   home: "/tmp/agentrinse-docker-fixture",
-  now: new Date("2026-07-23T00:00:00.000Z"),
+  now: new Date("2026-07-29T00:00:00.000Z"),
   auditId: "audit-docker",
 };
+
+const BASE_CACHE = {
+  CreatedAt: "2026-06-01T00:00:00Z",
+  ID: "abcdefghijklmnopqrstuvwx",
+  LastUsedAt: "2026-07-01T00:00:00Z",
+  Mutable: false,
+  Parents: [],
+  Reclaimable: true,
+  Shared: false,
+  Size: 4096,
+  Type: "regular",
+  UsageCount: 1,
+};
+
+function dockerRunner(
+  options: {
+    buildxError?: Error;
+    cache?: Record<string, unknown>;
+  } = {},
+): DockerRunner {
+  return async (args) => {
+    const command = args.join(" ");
+    if (command === "context show") {
+      return "fixture\n";
+    }
+    if (command === "context inspect fixture --format {{json .Endpoints.docker.Host}}") {
+      return '"unix:///fixture/docker.sock"\n';
+    }
+    if (command === "--context fixture info --format {{json .}}") {
+      return JSON.stringify({ ID: "daemon-fixture", ServerVersion: "29.0.0" });
+    }
+    if (command === "buildx version") {
+      if (options.buildxError !== undefined) {
+        throw options.buildxError;
+      }
+      return "github.com/docker/buildx v0.35.0 fixture\n";
+    }
+    if (command === "--context fixture buildx ls --format=json") {
+      return `${JSON.stringify({
+        Current: true,
+        Driver: "docker-container",
+        Dynamic: false,
+        Name: "fixture-builder",
+        Nodes: [
+          {
+            Endpoint: "fixture",
+            IDs: ["worker-fixture"],
+            Name: "fixture-builder0",
+            Status: "running",
+          },
+        ],
+      })}\n`;
+    }
+    if (command === "--context fixture image ls --no-trunc --format {{json .}}") {
+      return `${JSON.stringify({
+        ID: "sha256:image",
+        Repository: "fixture/image",
+        Tag: "latest",
+      })}\n`;
+    }
+    if (command === "--context fixture container ls -a --no-trunc --format {{json .}}") {
+      return `${JSON.stringify({
+        ID: "container-id",
+        Names: "fixture-container",
+        State: "exited",
+      })}\n`;
+    }
+    if (command === "--context fixture buildx du --builder fixture-builder --format=json") {
+      return `${JSON.stringify(options.cache ?? BASE_CACHE)}\n`;
+    }
+    throw new Error(`unexpected Docker command: ${command}`);
+  };
+}
 
 describe("DockerAuditAdapter", () => {
   it("degrades cleanly when the daemon is unavailable", async () => {
@@ -25,40 +99,92 @@ describe("DockerAuditAdapter", () => {
     });
   });
 
-  it("inventories images and containers through structured output", async () => {
-    const runner = async (args: string[]) => {
-      if (args[0] === "context") {
-        return "fixture\n";
-      }
-      if (args[0] === "version") {
-        return "29.0.0\n";
-      }
-      if (args[0] === "image") {
-        return `${JSON.stringify({
-          ID: "sha256:image",
-          Repository: "fixture/image",
-          Tag: "latest",
-        })}\n`;
-      }
-      return `${JSON.stringify({
-        ID: "container-id",
-        Names: "fixture-container",
-        State: "exited",
-      })}\n`;
-    };
-    const adapter = new DockerAuditAdapter(runner);
+  it("preserves image and container inventory when Buildx is unavailable", async () => {
+    const adapter = new DockerAuditAdapter(
+      dockerRunner({ buildxError: new Error("buildx missing") }),
+    );
 
     const probe = await adapter.probe(CONTEXT);
     const collection = await adapter.collect(CONTEXT, probe);
-    const findings = await Promise.all(
-      collection.resources.map((resource) => adapter.classify(CONTEXT, resource)),
-    );
 
     expect(probe.status).toBe("available");
+    expect(probe.diagnostics[0]?.code).toBe("DOCKER_BUILD_CACHE_UNAVAILABLE");
     expect(collection.resources.map((resource) => resource.resource.kind)).toEqual([
       "docker-image",
       "docker-container",
     ]);
-    expect(findings.every((finding) => finding.state === "protected")).toBe(true);
+  });
+
+  it("inventories Buildx cache with pinned owner facts but emits no action", async () => {
+    const adapter = new DockerAuditAdapter(dockerRunner());
+
+    const probe = await adapter.probe(CONTEXT);
+    const collection = await adapter.collect(CONTEXT, probe);
+    const cache = collection.resources.find(
+      (resource) => resource.resource.kind === "docker-build-cache",
+    )!;
+    const finding = await adapter.classify(CONTEXT, cache);
+
+    expect(collection.resources.map((resource) => resource.resource.kind)).toEqual([
+      "docker-image",
+      "docker-container",
+      "docker-build-cache",
+    ]);
+    expect(cache).toMatchObject({
+      measuredBytes: 4096,
+      facts: {
+        mutationStatus: "unbound-owner-identity",
+        reportOnly: true,
+        dockerScope: {
+          buildxVersion: "0.35.0",
+          context: { daemonId: "daemon-fixture", name: "fixture" },
+          builder: { name: "fixture-builder" },
+        },
+      },
+    });
+    expect(finding).toMatchObject({
+      state: "protected",
+      confidence: "certain",
+      measuredBytes: 4096,
+      estimatedReclaimBytes: 4096,
+      roots: [{ code: "docker-build-cache-mutation-unbound" }],
+      candidateActions: [],
+    });
+  });
+
+  it.each([
+    [{ Mutable: true }, "docker-build-cache-mutable"],
+    [{ Reclaimable: false }, "docker-build-cache-in-use"],
+    [{ Type: "internal" }, "docker-build-cache-internal"],
+    [{ LastUsedAt: "About an hour ago" }, "docker-build-cache-recent"],
+  ])("protects cache evidence %# with its specific root", async (override, expectedCode) => {
+    const adapter = new DockerAuditAdapter(dockerRunner({ cache: { ...BASE_CACHE, ...override } }));
+    const probe = await adapter.probe(CONTEXT);
+    const collection = await adapter.collect(CONTEXT, probe);
+    const cache = collection.resources.find(
+      (resource) => resource.resource.kind === "docker-build-cache",
+    )!;
+
+    const finding = await adapter.classify(CONTEXT, cache);
+
+    expect(finding.state).toBe("protected");
+    expect(finding.roots[0]?.code).toBe(expectedCode);
+    expect(finding.candidateActions).toEqual([]);
+  });
+
+  it("reports shared cache bytes without claiming they are reclaimable", async () => {
+    const adapter = new DockerAuditAdapter(
+      dockerRunner({ cache: { ...BASE_CACHE, Shared: true } }),
+    );
+    const probe = await adapter.probe(CONTEXT);
+    const collection = await adapter.collect(CONTEXT, probe);
+    const cache = collection.resources.find(
+      (resource) => resource.resource.kind === "docker-build-cache",
+    )!;
+
+    const finding = await adapter.classify(CONTEXT, cache);
+
+    expect(finding.estimatedReclaimBytes).toBe(0);
+    expect(finding.warnings[0]?.code).toBe("DOCKER_BUILD_CACHE_SHARED");
   });
 });

--- a/test/adapters/docker-adapter.test.ts
+++ b/test/adapters/docker-adapter.test.ts
@@ -232,6 +232,32 @@ describe("DockerAuditAdapter", () => {
     expect(finding.warnings[0]?.code).toBe("DOCKER_BUILD_CACHE_SHARED");
   });
 
+  it("does not publish humanized Buildx sizes as exact byte measurements", async () => {
+    const adapter = new DockerAuditAdapter(
+      dockerRunner({ cache: { ...BASE_CACHE, Size: "829.9MB" } }),
+    );
+    const probe = await adapter.probe(CONTEXT);
+    const collection = await adapter.collect(CONTEXT, probe);
+    const cache = collection.resources.find(
+      (resource) => resource.resource.kind === "docker-build-cache",
+    )!;
+
+    const finding = await adapter.classify(CONTEXT, cache);
+
+    expect(cache.measuredBytes).toBeUndefined();
+    expect(cache.facts).toMatchObject({
+      cache: {
+        sizeEvidence: {
+          kind: "humanized",
+          observed: "829.9MB",
+          approximateBytes: 829_900_000,
+        },
+      },
+    });
+    expect(finding.measuredBytes).toBeUndefined();
+    expect(finding.estimatedReclaimBytes).toBeUndefined();
+  });
+
   it("discards cache records when the selected builder changes during collection", async () => {
     let builderCalls = 0;
     const baseRunner = dockerRunner();

--- a/test/adapters/docker-adapter.test.ts
+++ b/test/adapters/docker-adapter.test.ts
@@ -27,6 +27,7 @@ function dockerRunner(
   options: {
     buildxError?: Error;
     cache?: Record<string, unknown>;
+    cacheOutput?: string;
   } = {},
 ): DockerRunner {
   return async (args) => {
@@ -77,7 +78,7 @@ function dockerRunner(
       })}\n`;
     }
     if (command === "--context fixture buildx du --builder fixture-builder --format=json") {
-      return `${JSON.stringify(options.cache ?? BASE_CACHE)}\n`;
+      return options.cacheOutput ?? `${JSON.stringify(options.cache ?? BASE_CACHE)}\n`;
     }
     throw new Error(`unexpected Docker command: ${command}`);
   };
@@ -171,6 +172,25 @@ describe("DockerAuditAdapter", () => {
       roots: [{ code: "docker-build-cache-mutation-unbound" }],
       candidateActions: [],
     });
+  });
+
+  it("keeps valid cache records when a sibling record is unsupported", async () => {
+    const adapter = new DockerAuditAdapter(
+      dockerRunner({
+        cacheOutput: [
+          JSON.stringify({ ...BASE_CACHE, ID: "cache.*" }),
+          JSON.stringify(BASE_CACHE),
+        ].join("\n"),
+      }),
+    );
+
+    const probe = await adapter.probe(CONTEXT);
+    const collection = await adapter.collect(CONTEXT, probe);
+
+    expect(
+      collection.resources.filter((resource) => resource.resource.kind === "docker-build-cache"),
+    ).toHaveLength(1);
+    expect(collection.diagnostics[0]?.code).toBe("DOCKER_BUILD_CACHE_RECORD_UNSUPPORTED");
   });
 
   it.each([

--- a/test/adapters/docker-adapter.test.ts
+++ b/test/adapters/docker-adapter.test.ts
@@ -197,6 +197,7 @@ describe("DockerAuditAdapter", () => {
     [{ Mutable: true }, "docker-build-cache-mutable"],
     [{ Reclaimable: false }, "docker-build-cache-in-use"],
     [{ Type: "internal" }, "docker-build-cache-internal"],
+    [{ Type: "" }, "docker-build-cache-type-unknown"],
     [{ LastUsedAt: "About an hour ago" }, "docker-build-cache-recent"],
   ])("protects cache evidence %# with its specific root", async (override, expectedCode) => {
     const adapter = new DockerAuditAdapter(dockerRunner({ cache: { ...BASE_CACHE, ...override } }));

--- a/test/adapters/docker-adapter.test.ts
+++ b/test/adapters/docker-adapter.test.ts
@@ -190,6 +190,9 @@ describe("DockerAuditAdapter", () => {
 
     expect(finding.state).toBe("protected");
     expect(finding.roots[0]?.code).toBe(expectedCode);
+    if ("Reclaimable" in override && override.Reclaimable === false) {
+      expect(finding.estimatedReclaimBytes).toBe(0);
+    }
     expect(finding.candidateActions).toEqual([]);
   });
 

--- a/test/adapters/docker-adapter.test.ts
+++ b/test/adapters/docker-adapter.test.ts
@@ -115,6 +115,27 @@ describe("DockerAuditAdapter", () => {
     ]);
   });
 
+  it("discards daemon inventory when owner identity changes during collection", async () => {
+    let infoCalls = 0;
+    const baseRunner = dockerRunner({ buildxError: new Error("buildx missing") });
+    const adapter = new DockerAuditAdapter(async (args) => {
+      if (args.join(" ") === "--context fixture info --format {{json .}}") {
+        infoCalls += 1;
+        return JSON.stringify({
+          ID: infoCalls >= 4 ? "replacement-daemon" : "daemon-fixture",
+          ServerVersion: "29.0.0",
+        });
+      }
+      return baseRunner(args);
+    });
+
+    const probe = await adapter.probe(CONTEXT);
+    const collection = await adapter.collect(CONTEXT, probe);
+
+    expect(collection.resources).toEqual([]);
+    expect(collection.diagnostics[0]?.code).toBe("DOCKER_OWNER_CHANGED");
+  });
+
   it("inventories Buildx cache with pinned owner facts but emits no action", async () => {
     const adapter = new DockerAuditAdapter(dockerRunner());
 
@@ -186,5 +207,33 @@ describe("DockerAuditAdapter", () => {
 
     expect(finding.estimatedReclaimBytes).toBe(0);
     expect(finding.warnings[0]?.code).toBe("DOCKER_BUILD_CACHE_SHARED");
+  });
+
+  it("discards cache records when the selected builder changes during collection", async () => {
+    let builderCalls = 0;
+    const baseRunner = dockerRunner();
+    const adapter = new DockerAuditAdapter(async (args) => {
+      if (args.join(" ") === "--context fixture buildx ls --format=json") {
+        builderCalls += 1;
+        const output = await baseRunner(args);
+        if (builderCalls >= 3) {
+          return output.replace("worker-fixture", "replacement-worker");
+        }
+        return output;
+      }
+      return baseRunner(args);
+    });
+
+    const probe = await adapter.probe(CONTEXT);
+    const collection = await adapter.collect(CONTEXT, probe);
+
+    expect(
+      collection.resources.some((resource) => resource.resource.kind === "docker-build-cache"),
+    ).toBe(false);
+    expect(collection.diagnostics[0]?.code).toBe("DOCKER_BUILD_CACHE_COLLECTION_FAILED");
+    expect(collection.resources.map((resource) => resource.resource.kind)).toEqual([
+      "docker-image",
+      "docker-container",
+    ]);
   });
 });

--- a/test/adapters/docker-owner.test.ts
+++ b/test/adapters/docker-owner.test.ts
@@ -307,22 +307,60 @@ describe("Docker owner contract", () => {
     ).toBe(true);
   });
 
-  it("rejects malformed cache IDs without suppressing valid record parsing", async () => {
+  it("treats a missing last-use value as unknown instead of inferring age", async () => {
     const scope = await inspectDockerScope(scopeRunner());
-    await expect(
-      inspectDockerBuildCache(scope, async () =>
-        JSON.stringify({
-          CreatedAt: "2026-06-01T00:00:00Z",
-          ID: "cache.*",
-          LastUsedAt: "8 days ago",
-          Mutable: false,
-          Reclaimable: true,
-          Shared: false,
-          Size: 100,
-          Type: "regular",
-          UsageCount: 0,
-        }),
-      ),
-    ).rejects.toThrow("unsupported");
+    const [record] = await inspectDockerBuildCache(scope, async () =>
+      JSON.stringify({
+        CreatedAt: "2026-06-01T00:00:00Z",
+        ID: "abcdefghijklmnopqrstuvwx",
+        Mutable: false,
+        Reclaimable: true,
+        Shared: false,
+        Size: 100,
+        Type: "regular",
+        UsageCount: 0,
+      }),
+    );
+
+    expect(record?.ageEvidence).toEqual({ kind: "unknown" });
+    expect(dockerBuildCacheIsOldEnough(record!, new Date("2026-07-29"))).toBe(false);
+  });
+
+  it("skips malformed cache records without suppressing valid records", async () => {
+    const scope = await inspectDockerScope(scopeRunner());
+    const problems: Array<{ index: number; message: string }> = [];
+    const records = await inspectDockerBuildCache(
+      scope,
+      async () =>
+        [
+          JSON.stringify({
+            CreatedAt: "2026-06-01T00:00:00Z",
+            ID: "cache.*",
+            LastUsedAt: "8 days ago",
+            Mutable: false,
+            Reclaimable: true,
+            Shared: false,
+            Size: 100,
+            Type: "regular",
+            UsageCount: 0,
+          }),
+          JSON.stringify({
+            CreatedAt: "2026-06-01T00:00:00Z",
+            ID: "abcdefghijklmnopqrstuvwx",
+            LastUsedAt: "8 days ago",
+            Mutable: false,
+            Reclaimable: true,
+            Shared: false,
+            Size: 200,
+            Type: "regular",
+            UsageCount: 0,
+          }),
+        ].join("\n"),
+      (index, error) => problems.push({ index, message: error.message }),
+    );
+
+    expect(records).toHaveLength(1);
+    expect(records[0]?.id).toBe("abcdefghijklmnopqrstuvwx");
+    expect(problems).toEqual([{ index: 0, message: "Docker build-cache ID is unsupported" }]);
   });
 });

--- a/test/adapters/docker-owner.test.ts
+++ b/test/adapters/docker-owner.test.ts
@@ -233,7 +233,10 @@ describe("Docker owner contract", () => {
     expect(records[0]).toMatchObject({
       id: "abcdefghijklmnopqrstuvwx",
       createdAt: "2026-07-01T00:00:00.000Z",
-      sizeBytes: 829_889_526,
+      sizeEvidence: {
+        kind: "exact",
+        bytes: 829_889_526,
+      },
       parents: ["parent-a", "parent-b"],
       ageEvidence: {
         kind: "timestamp",
@@ -268,7 +271,11 @@ describe("Docker owner contract", () => {
 
     expect(dockerBuildCacheIsOldEnough(sevenDays, new Date("2026-07-29T00:00:00Z"))).toBe(false);
     expect(dockerBuildCacheIsOldEnough(eightDays, new Date("2026-07-29T00:00:00Z"))).toBe(true);
-    expect(eightDays.sizeBytes).toBe(1_653_000_000);
+    expect(eightDays.sizeEvidence).toEqual({
+      kind: "humanized",
+      observed: "1.653GB",
+      approximateBytes: 1_653_000_000,
+    });
   });
 
   it("treats approximate and unknown human ages as recent evidence", async () => {

--- a/test/adapters/docker-owner.test.ts
+++ b/test/adapters/docker-owner.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  dockerBuildCacheIsOldEnough,
+  exactDockerBuildCacheFilter,
+  inspectDockerBuildCache,
+  inspectDockerScope,
+  supportsDockerBuildxContract,
+  type DockerRunner,
+} from "../../src/adapters/docker/owner.js";
+
+function scopeRunner(overrides: Record<string, string> = {}): DockerRunner {
+  const outputs: Record<string, string> = {
+    "context show": "fixture\n",
+    "context inspect fixture --format {{json .Endpoints.docker.Host}}":
+      '"unix:///fixture/docker.sock"\n',
+    "--context fixture info --format {{json .}}": JSON.stringify({
+      ID: "daemon-fixture",
+      ServerVersion: "29.0.0",
+    }),
+    "buildx version": "github.com/docker/buildx v0.35.0 fixture\n",
+    "--context fixture buildx ls --format=json": `${JSON.stringify({
+      Current: true,
+      Driver: "docker-container",
+      Dynamic: false,
+      Name: "fixture-builder",
+      Nodes: [
+        {
+          Endpoint: "fixture",
+          IDs: ["worker-b", "worker-a"],
+          Name: "fixture-builder0",
+          Status: "running",
+          Version: "v0.24.0",
+        },
+      ],
+    })}\n`,
+    ...overrides,
+  };
+  return async (args) => {
+    const key = args.join(" ");
+    const output = outputs[key];
+    if (output === undefined) {
+      throw new Error(`unexpected Docker command: ${key}`);
+    }
+    return output;
+  };
+}
+
+describe("Docker owner contract", () => {
+  it("pins the context, daemon, selected builder, and stable worker identity", async () => {
+    const scope = await inspectDockerScope(scopeRunner());
+
+    expect(scope).toMatchObject({
+      buildxVersion: "0.35.0",
+      context: {
+        name: "fixture",
+        endpoint: "unix:///fixture/docker.sock",
+        daemonId: "daemon-fixture",
+        serverVersion: "29.0.0",
+      },
+      builder: {
+        name: "fixture-builder",
+        driver: "docker-container",
+        nodes: [
+          {
+            name: "fixture-builder0",
+            endpoint: "fixture",
+            workerIds: ["worker-a", "worker-b"],
+          },
+        ],
+      },
+    });
+    expect(scope.builder.fingerprint).toMatch(/^[a-f0-9]{64}$/u);
+  });
+
+  it("honors an explicit Buildx builder override instead of the stored current builder", async () => {
+    const runner = scopeRunner({
+      "--context fixture buildx ls --format=json": [
+        JSON.stringify({
+          Current: true,
+          Driver: "docker",
+          Dynamic: false,
+          Name: "stored-current",
+          Nodes: [
+            {
+              Endpoint: "fixture",
+              IDs: ["stored-worker"],
+              Name: "stored-current0",
+              Status: "running",
+            },
+          ],
+        }),
+        JSON.stringify({
+          Current: false,
+          Driver: "remote",
+          Dynamic: false,
+          Name: "environment-builder",
+          Nodes: [
+            {
+              Endpoint: "tcp://builder.example.invalid:1234",
+              IDs: ["remote-worker"],
+              Name: "environment-builder0",
+              Status: "running",
+            },
+          ],
+        }),
+      ].join("\n"),
+    });
+
+    const scope = await inspectDockerScope(runner, "environment-builder");
+
+    expect(scope.builder).toMatchObject({
+      name: "environment-builder",
+      driver: "remote",
+    });
+  });
+
+  it("fails closed for uninspected Buildx versions and unhealthy builders", async () => {
+    expect(supportsDockerBuildxContract("0.32.1")).toBe(false);
+    expect(supportsDockerBuildxContract("0.33.0")).toBe(true);
+    expect(supportsDockerBuildxContract("0.35.0")).toBe(true);
+    expect(supportsDockerBuildxContract("0.36.0")).toBe(false);
+
+    await expect(
+      inspectDockerScope(
+        scopeRunner({
+          "buildx version": "github.com/docker/buildx v0.36.0 future\n",
+        }),
+      ),
+    ).rejects.toThrow("outside the inspected");
+    await expect(
+      inspectDockerScope(
+        scopeRunner({
+          "--context fixture buildx ls --format=json": `${JSON.stringify({
+            Current: true,
+            Driver: "docker-container",
+            Dynamic: false,
+            Name: "fixture-builder",
+            Nodes: [
+              {
+                Endpoint: "fixture",
+                Err: "connection failed",
+                Name: "fixture-builder0",
+                Status: "error",
+              },
+            ],
+          })}\n`,
+        }),
+      ),
+    ).rejects.toThrow("not healthy and running");
+  });
+
+  it("parses exact cache facts and uses an anchored ID filter", async () => {
+    const scope = await inspectDockerScope(scopeRunner());
+    const calls: string[][] = [];
+    const runner: DockerRunner = async (args) => {
+      calls.push(args);
+      return `${JSON.stringify({
+        CreatedAt: "2026-07-01T00:00:00Z",
+        ID: "abcdefghijklmnopqrstuvwx",
+        LastUsedAt: "2026-07-10T00:00:00Z",
+        Mutable: false,
+        Parents: ["parent-b", "parent-a"],
+        Reclaimable: true,
+        Shared: false,
+        Size: "829889526",
+        Type: "regular",
+        UsageCount: 1,
+      })}\n`;
+    };
+
+    const records = await inspectDockerBuildCache(scope, runner, "abcdefghijklmnopqrstuvwx");
+
+    expect(calls).toEqual([
+      [
+        "--context",
+        "fixture",
+        "buildx",
+        "du",
+        "--builder",
+        "fixture-builder",
+        "--format=json",
+        "--filter",
+        "id=^abcdefghijklmnopqrstuvwx$",
+      ],
+    ]);
+    expect(records[0]).toMatchObject({
+      id: "abcdefghijklmnopqrstuvwx",
+      createdAt: "2026-07-01T00:00:00.000Z",
+      sizeBytes: 829_889_526,
+      parents: ["parent-a", "parent-b"],
+      ageEvidence: {
+        kind: "timestamp",
+        lastUsedAt: "2026-07-10T00:00:00.000Z",
+      },
+    });
+  });
+
+  it("accepts Docker's humanized JSON fields only with a conservative age bound", async () => {
+    const scope = await inspectDockerScope(scopeRunner());
+    const recordFor = async (lastUsedAt: string) =>
+      (
+        await inspectDockerBuildCache(scope, async () =>
+          [
+            JSON.stringify({
+              CreatedAt: "2026-06-01 00:00:00 +0000 UTC",
+              ID: "abcdefghijklmnopqrstuvwx",
+              LastUsedAt: lastUsedAt,
+              Mutable: false,
+              Reclaimable: true,
+              Shared: true,
+              Size: "1.653GB",
+              Type: "regular",
+              UsageCount: 2,
+            }),
+          ].join("\n"),
+        )
+      )[0]!;
+
+    const sevenDays = await recordFor("7 days ago");
+    const eightDays = await recordFor("8 days ago");
+
+    expect(dockerBuildCacheIsOldEnough(sevenDays, new Date("2026-07-29T00:00:00Z"))).toBe(false);
+    expect(dockerBuildCacheIsOldEnough(eightDays, new Date("2026-07-29T00:00:00Z"))).toBe(true);
+    expect(eightDays.sizeBytes).toBe(1_653_000_000);
+  });
+
+  it("rejects regex-capable or malformed cache IDs", () => {
+    expect(exactDockerBuildCacheFilter("abcdefghijklmnopqrstuvwx")).toBe(
+      "id=^abcdefghijklmnopqrstuvwx$",
+    );
+    expect(() => exactDockerBuildCacheFilter("cache.*")).toThrow("unsupported");
+  });
+});

--- a/test/adapters/docker-owner.test.ts
+++ b/test/adapters/docker-owner.test.ts
@@ -165,8 +165,18 @@ describe("Docker owner contract", () => {
     expect(supportsDockerBuildxContract("0.32.1")).toBe(false);
     expect(supportsDockerBuildxContract("0.33.0")).toBe(true);
     expect(supportsDockerBuildxContract("0.35.0")).toBe(true);
+    expect(supportsDockerBuildxContract("0.35.0+vendor.1")).toBe(true);
+    expect(supportsDockerBuildxContract("0.33.0-rc1")).toBe(false);
+    expect(supportsDockerBuildxContract("0.35.0-desktop.1")).toBe(false);
     expect(supportsDockerBuildxContract("0.36.0")).toBe(false);
 
+    await expect(
+      inspectDockerScope(
+        scopeRunner({
+          "buildx version": "github.com/docker/buildx v0.33.0-rc1 future\n",
+        }),
+      ),
+    ).rejects.toThrow("outside the inspected");
     await expect(
       inspectDockerScope(
         scopeRunner({

--- a/test/adapters/docker-owner.test.ts
+++ b/test/adapters/docker-owner.test.ts
@@ -204,6 +204,26 @@ describe("Docker owner contract", () => {
         }),
       ),
     ).rejects.toThrow("not healthy and running");
+    await expect(
+      inspectDockerScope(
+        scopeRunner({
+          "--context fixture buildx ls --format=json": `${JSON.stringify({
+            Current: true,
+            Driver: "kubernetes",
+            Dynamic: true,
+            Name: "fixture-builder",
+            Nodes: [
+              {
+                Endpoint: "kubernetes:///fixture",
+                IDs: ["ephemeral-worker"],
+                Name: "fixture-builder0",
+                Status: "running",
+              },
+            ],
+          })}\n`,
+        }),
+      ),
+    ).rejects.toThrow("dynamic builders cannot bind");
   });
 
   it("parses exact cache facts from the selected builder", async () => {

--- a/test/adapters/docker-owner.test.ts
+++ b/test/adapters/docker-owner.test.ts
@@ -224,6 +224,25 @@ describe("Docker owner contract", () => {
         }),
       ),
     ).rejects.toThrow("dynamic builders cannot bind");
+    await expect(
+      inspectDockerScope(
+        scopeRunner({
+          "--context fixture buildx ls --format=json": `${JSON.stringify({
+            Current: true,
+            Driver: "docker-container",
+            Dynamic: false,
+            Name: "fixture-builder",
+            Nodes: [
+              {
+                Endpoint: "fixture",
+                Name: "fixture-builder0",
+                Status: "running",
+              },
+            ],
+          })}\n`,
+        }),
+      ),
+    ).rejects.toThrow("no stable worker IDs");
   });
 
   it("parses exact cache facts from the selected builder", async () => {

--- a/test/adapters/docker-owner.test.ts
+++ b/test/adapters/docker-owner.test.ts
@@ -55,7 +55,36 @@ describe("Docker owner contract", () => {
       endpoint: "unix:///fixture/docker.sock",
       daemonId: "daemon-fixture",
       serverVersion: "29.0.0",
+      commandPrefix: ["--context", "fixture"],
     });
+  });
+
+  it("preserves DOCKER_HOST instead of overriding it with the default context", async () => {
+    const calls: string[] = [];
+    const runner: DockerRunner = async (args) => {
+      const command = args.join(" ");
+      calls.push(command);
+      if (command === "context show") {
+        return "default\n";
+      }
+      if (command === "info --format {{json .}}") {
+        return JSON.stringify({ ID: "remote-daemon", ServerVersion: "29.0.0" });
+      }
+      throw new Error(`unexpected Docker command: ${command}`);
+    };
+
+    const context = await inspectDockerContext(runner, {
+      DOCKER_HOST: "tcp://docker.example.invalid:2376",
+    });
+
+    expect(context).toEqual({
+      name: "default",
+      endpoint: "tcp://docker.example.invalid:2376",
+      daemonId: "remote-daemon",
+      serverVersion: "29.0.0",
+      commandPrefix: [],
+    });
+    expect(calls).not.toContain("context inspect default --format {{json .Endpoints.docker.Host}}");
   });
 
   it("pins the context, daemon, selected builder, and stable worker identity", async () => {
@@ -124,6 +153,12 @@ describe("Docker owner contract", () => {
       name: "environment-builder",
       driver: "remote",
     });
+  });
+
+  it("treats an empty Buildx builder override as unset", async () => {
+    const scope = await inspectDockerScope(scopeRunner(), "");
+
+    expect(scope.builder.name).toBe("fixture-builder");
   });
 
   it("fails closed for uninspected Buildx versions and unhealthy builders", async () => {

--- a/test/adapters/docker-owner.test.ts
+++ b/test/adapters/docker-owner.test.ts
@@ -317,6 +317,29 @@ describe("Docker owner contract", () => {
     });
   });
 
+  it("accepts petabyte humanized sizes while preserving approximate precision", async () => {
+    const scope = await inspectDockerScope(scopeRunner());
+    const [record] = await inspectDockerBuildCache(scope, async () =>
+      JSON.stringify({
+        CreatedAt: "2026-06-01T00:00:00Z",
+        ID: "abcdefghijklmnopqrstuvwx",
+        LastUsedAt: "8 days ago",
+        Mutable: false,
+        Reclaimable: true,
+        Shared: false,
+        Size: "1PB",
+        Type: "regular",
+        UsageCount: 0,
+      }),
+    );
+
+    expect(record?.sizeEvidence).toEqual({
+      kind: "humanized",
+      observed: "1PB",
+      approximateBytes: 1_000_000_000_000_000,
+    });
+  });
+
   it("treats approximate and unknown human ages as recent evidence", async () => {
     const scope = await inspectDockerScope(scopeRunner());
     const records = await inspectDockerBuildCache(scope, async () =>
@@ -370,6 +393,26 @@ describe("Docker owner contract", () => {
 
     expect(record?.ageEvidence).toEqual({ kind: "unknown" });
     expect(dockerBuildCacheIsOldEnough(record!, new Date("2026-07-29"))).toBe(false);
+  });
+
+  it("preserves a cache record whose optional type is absent", async () => {
+    const scope = await inspectDockerScope(scopeRunner());
+    const [record] = await inspectDockerBuildCache(scope, async () =>
+      JSON.stringify({
+        CreatedAt: "2026-06-01T00:00:00Z",
+        ID: "abcdefghijklmnopqrstuvwx",
+        LastUsedAt: "8 days ago",
+        Mutable: false,
+        Reclaimable: true,
+        Shared: false,
+        Size: 100,
+        Type: "",
+        UsageCount: 0,
+      }),
+    );
+
+    expect(record).toBeDefined();
+    expect(record?.recordType).toBeUndefined();
   });
 
   it("skips malformed cache records without suppressing valid records", async () => {

--- a/test/adapters/docker-owner.test.ts
+++ b/test/adapters/docker-owner.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   dockerBuildCacheIsOldEnough,
-  exactDockerBuildCacheFilter,
   inspectDockerBuildCache,
+  inspectDockerContext,
   inspectDockerScope,
   supportsDockerBuildxContract,
   type DockerRunner,
@@ -47,6 +47,17 @@ function scopeRunner(overrides: Record<string, string> = {}): DockerRunner {
 }
 
 describe("Docker owner contract", () => {
+  it("inspects the daemon without requiring Buildx", async () => {
+    const context = await inspectDockerContext(scopeRunner());
+
+    expect(context).toEqual({
+      name: "fixture",
+      endpoint: "unix:///fixture/docker.sock",
+      daemonId: "daemon-fixture",
+      serverVersion: "29.0.0",
+    });
+  });
+
   it("pins the context, daemon, selected builder, and stable worker identity", async () => {
     const scope = await inspectDockerScope(scopeRunner());
 
@@ -150,7 +161,7 @@ describe("Docker owner contract", () => {
     ).rejects.toThrow("not healthy and running");
   });
 
-  it("parses exact cache facts and uses an anchored ID filter", async () => {
+  it("parses exact cache facts from the selected builder", async () => {
     const scope = await inspectDockerScope(scopeRunner());
     const calls: string[][] = [];
     const runner: DockerRunner = async (args) => {
@@ -169,20 +180,10 @@ describe("Docker owner contract", () => {
       })}\n`;
     };
 
-    const records = await inspectDockerBuildCache(scope, runner, "abcdefghijklmnopqrstuvwx");
+    const records = await inspectDockerBuildCache(scope, runner);
 
     expect(calls).toEqual([
-      [
-        "--context",
-        "fixture",
-        "buildx",
-        "du",
-        "--builder",
-        "fixture-builder",
-        "--format=json",
-        "--filter",
-        "id=^abcdefghijklmnopqrstuvwx$",
-      ],
+      ["--context", "fixture", "buildx", "du", "--builder", "fixture-builder", "--format=json"],
     ]);
     expect(records[0]).toMatchObject({
       id: "abcdefghijklmnopqrstuvwx",
@@ -225,10 +226,58 @@ describe("Docker owner contract", () => {
     expect(eightDays.sizeBytes).toBe(1_653_000_000);
   });
 
-  it("rejects regex-capable or malformed cache IDs", () => {
-    expect(exactDockerBuildCacheFilter("abcdefghijklmnopqrstuvwx")).toBe(
-      "id=^abcdefghijklmnopqrstuvwx$",
+  it("treats approximate and unknown human ages as recent evidence", async () => {
+    const scope = await inspectDockerScope(scopeRunner());
+    const records = await inspectDockerBuildCache(scope, async () =>
+      [
+        ["abcdefghijklmnopqrstuvwx", "Less than a second ago"],
+        ["bcdefghijklmnopqrstuvwxy", "About a minute ago"],
+        ["cdefghijklmnopqrstuvwxyz", "About an hour ago"],
+        ["defghijklmnopqrstuvwxyz0", "localized age text"],
+      ]
+        .map(([ID, LastUsedAt]) =>
+          JSON.stringify({
+            CreatedAt: "2026-06-01 00:00:00 +0000 UTC",
+            ID,
+            LastUsedAt,
+            Mutable: false,
+            Reclaimable: true,
+            Shared: false,
+            Size: 100,
+            Type: "regular",
+            UsageCount: 0,
+          }),
+        )
+        .join("\n"),
     );
-    expect(() => exactDockerBuildCacheFilter("cache.*")).toThrow("unsupported");
+
+    expect(records.map((record) => record.ageEvidence)).toEqual([
+      { kind: "relative", observed: "Less than a second ago", lowerBoundHours: 0 },
+      { kind: "relative", observed: "About a minute ago", lowerBoundHours: 1 / 60 },
+      { kind: "relative", observed: "About an hour ago", lowerBoundHours: 1 },
+      { kind: "relative", observed: "localized age text", lowerBoundHours: 0 },
+    ]);
+    expect(
+      records.every((record) => !dockerBuildCacheIsOldEnough(record, new Date("2026-07-29"))),
+    ).toBe(true);
+  });
+
+  it("rejects malformed cache IDs without suppressing valid record parsing", async () => {
+    const scope = await inspectDockerScope(scopeRunner());
+    await expect(
+      inspectDockerBuildCache(scope, async () =>
+        JSON.stringify({
+          CreatedAt: "2026-06-01T00:00:00Z",
+          ID: "cache.*",
+          LastUsedAt: "8 days ago",
+          Mutable: false,
+          Reclaimable: true,
+          Shared: false,
+          Size: 100,
+          Type: "regular",
+          UsageCount: 0,
+        }),
+      ),
+    ).rejects.toThrow("unsupported");
   });
 });


### PR DESCRIPTION
## Summary

- add a version-gated Docker Buildx owner contract for static builders with stable worker IDs
- inventory images, containers, and cache records while isolating Buildx capability failures
- keep every Docker resource protected because prune cannot bind mutation to revalidated daemon and worker identity
- preserve effective `DOCKER_HOST`, conservative age/type evidence, and exact versus humanized size precision

## Safety

- no Docker action, executor, prune, image removal, volume removal, or schema change
- before/after daemon and builder identity checks discard changed-owner inventory
- unsupported versions, prereleases, dynamic builders, missing worker IDs, and malformed records fail closed or degrade only cache inventory
- tests and smoke runs use synthetic fixtures only

## Verification

- `./node_modules/.bin/vitest run` (66 files, 498 passed, 1 skipped)
- `./node_modules/.bin/oxlint src test`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `./node_modules/.bin/oxfmt --check .`
- `./node_modules/.bin/tsc -p tsconfig.build.json`
- schema, package manifest, publint, npm pack dry-run, source smoke, packed-install smoke
- autoreview clean

Refs #16