### PR TITLE
docs(readme): replace remaining cleanup surface emoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ logical memory records.
 | <img width="48px" src="docs/client-opencode.png" alt="OpenCode" />          | OpenCode native maintenance          | report-only        | hourly snapshot GC and the append-only server-log contract              |
 | <img width="48px" src="docs/client-cursor.jpg" alt="Cursor" />              | Cursor database maintenance          | report-only        | exact DB companions, orphan KV GC, and destructive chat cleanup         |
 | <img width="48px" src="docs/client-grok-build.svg" alt="Grok Build" />      | Grok native memory GC                | report-only        | session-start orphan cleanup, source version, and explicit refusal      |
-| ⚡                                                                          | Agent runtimes                       | audit-only, opt-in | installed agent executables and versions                                |
+| <img width="48px" src="docs/icon-terminal.svg" alt="Terminal runtime" />    | Agent runtimes                       | audit-only, opt-in | installed agent executables and versions                                |
 | <img width="48px" src="docs/client-docker-agent.svg" alt="Docker" />        | [Docker](https://docs.docker.com/)   | audit-only, opt-in | images, containers, and versioned Buildx cache                          |
-| 🕳️                                                                          | [Mole](https://github.com/tw93/Mole) | suggestions only   | external dry-run cleanup opportunities on macOS                         |
+| <img width="48px" src="docs/icon-search.svg" alt="Cleanup search" />        | [Mole](https://github.com/tw93/Mole) | suggestions only   | external dry-run cleanup opportunities on macOS                         |
 
 ## install
 

--- a/docs/icon-search.svg
+++ b/docs/icon-search.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96" role="img" aria-labelledby="title">
+  <title id="title">Cleanup opportunity search</title>
+  <rect width="96" height="96" rx="18" fill="#eefbf3"/>
+  <path transform="translate(18 18) scale(2.5)" fill="#20884a" d="M10.25 2a8.25 8.25 0 0 1 6.34 13.53l5.69 5.69a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215l-5.69-5.69A8.25 8.25 0 1 1 10.25 2ZM3.5 10.25a6.75 6.75 0 1 0 13.5 0 6.75 6.75 0 0 0-13.5 0Z"/>
+</svg>

--- a/docs/icon-terminal.svg
+++ b/docs/icon-terminal.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96" role="img" aria-labelledby="title">
+  <title id="title">Terminal runtime</title>
+  <rect width="96" height="96" rx="18" fill="#e9f7ff"/>
+  <g transform="translate(18 18) scale(2.5)" fill="#087ea4">
+    <path d="M9.25 12a.75.75 0 0 1-.22.53l-2.75 2.75a.75.75 0 0 1-1.06-1.06L7.44 12 5.22 9.78a.75.75 0 1 1 1.06-1.06l2.75 2.75c.141.14.22.331.22.53Zm2 2a.75.75 0 0 0 0 1.5h5a.75.75 0 0 0 0-1.5h-5Z"/>
+    <path d="M0 4.75C0 3.784.784 3 1.75 3h20.5c.966 0 1.75.784 1.75 1.75v14.5A1.75 1.75 0 0 1 22.25 21H1.75A1.75 1.75 0 0 1 0 19.25Zm1.75-.25a.25.25 0 0 0-.25.25v14.5c0 .138.112.25.25.25h20.5a.25.25 0 0 0 .25-.25V4.75a.25.25 0 0 0-.25-.25Z"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

- add a generic terminal icon for installed agent runtimes
- add a generic search icon for Mole dry-run discovery
- replace the final emoji in the cleanup surface table

## Verification

- `./node_modules/.bin/oxfmt --check .`
- `xmllint --noout docs/icon-terminal.svg docs/icon-search.svg`
- verified every local README image reference resolves
- rendered both SVGs with macOS Quick Look