### PR TITLE
chore(release): prepare 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The project follows semantic versioning after its first supported release.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-29
+
 ### Added
 
 - recoverable quarantine for the exact Zed `Zed.log.old` rotated application

--- a/README.md
+++ b/README.md
@@ -15,18 +15,15 @@ protected or eligible, creates a content-addressed plan, and revalidates the
 same facts immediately before mutation.
 
 agentrinse is not audit-only. audit establishes the evidence; apply performs
-the approved filesystem, Git metadata, and offline database changes. `0.5.0`
+the approved filesystem, Git metadata, and offline database changes. `0.6.0`
 removes exact configured rebuildable artifacts, quarantines proven inactive
 linked worktrees, repairs and locks their Git registrations, restores
 quarantined worktrees, permanently purges explicitly selected quarantine
 entries, and compacts supported Codex SQLite state with a retained rollback
 copy. It also quarantines exact stale Claude debug logs and changelog cache
-files with a seven-day undo window.
-
-current main extends that recoverable boundary to Zed's exact stale
-`Zed.log.old` rotated application log. it also reports OpenCode, Cursor,
-version-gated Docker Buildx, and version-gated Grok owner-maintenance facts.
-the latest published release remains `0.5.0`.
+files plus Zed's exact stale `Zed.log.old` rotated application log with a
+seven-day undo window. OpenCode, Cursor, version-gated Docker Buildx, and
+version-gated Grok owner maintenance remain report-only.
 
 the point is confidence: make real cleanup changes without deleting the
 session, branch, worktree, database content, or cache that another agent still
@@ -52,7 +49,7 @@ optional external handoff for broader macOS and project debris.
 | 🔒 lock recovery       | operational  | removes only a stale AgentRinse lock after proving its process is gone         | rerun the interrupted command           |
 
 provider sessions, transcripts, credentials, configuration, and logical
-database records remain report-only. `0.5.0` supports explicit offline
+database records remain report-only. `0.6.0` supports explicit offline
 compaction for the exact current Codex `state_5`, `logs_2`, `goals_1`, and
 `memories_1` SQLite contracts. Claude cleanup is limited to exact old debug
 text files and its rebuildable changelog cache. AgentRinse also reports
@@ -115,7 +112,7 @@ brew install vincentkoc/tap/agentrinse
 one-off use:
 
 ```bash
-npx agentrinse@0.5.0 doctor
+npx agentrinse@0.6.0 doctor
 ```
 
 then:
@@ -235,7 +232,7 @@ agentrinse is built around refusal:
 
 there is no generic `--force` escape hatch.
 
-agentrinse `0.5.0` never removes:
+agentrinse `0.6.0` never removes:
 
 - provider sessions, transcripts, logical database rows, credentials, or configuration
 - unsupported provider databases or Codex databases with unknown migrations
@@ -345,12 +342,12 @@ it can be verified before apply.
 
 ## platform support
 
-| Platform       | `0.5.0` support                                                 |
-| -------------- | --------------------------------------------------------------- |
-| macOS          | audit, artifact/worktree/Claude cleanup, DB vacuum, undo, purge |
-| Linux          | audit, artifact/worktree/Claude cleanup, DB vacuum, undo, purge |
-| WSL            | Linux contract inside the WSL filesystem                        |
-| native Windows | audit-only; mutation remains blocked before `1.0.0`             |
+| Platform       | `0.6.0` support                                                     |
+| -------------- | ------------------------------------------------------------------- |
+| macOS          | audit, artifact/worktree/Claude/Zed cleanup, DB vacuum, undo, purge |
+| Linux          | audit, artifact/worktree/Claude/Zed cleanup, DB vacuum, undo, purge |
+| WSL            | Linux contract inside the WSL filesystem                            |
+| native Windows | audit-only; mutation remains blocked before `1.0.0`                 |
 
 Git and `lsof` are required for the complete diagnostic and process-ownership
 contract. Codex DB maintenance additionally requires `sqlite3`. Docker is
@@ -385,12 +382,12 @@ unreleased build at real developer state.
 
 ## status
 
-`0.5.0` ships the complete audit → plan → revalidate → apply loop, safe
-configured artifact cleanup, recoverable Git worktree and Claude file
-quarantine, and recoverable offline Codex database compaction. Current main
-also quarantines the exact stale Zed `Zed.log.old` file and reports OpenCode's
-native maintenance contract, Cursor's owner database commands, Docker Buildx
-cache facts, and Grok's version-gated session-start memory GC. Grok Build,
-Docker, and all other Cursor, Zed, and OpenCode state remain non-mutating.
+`0.6.0` ships the complete audit → plan → revalidate → apply loop, safe
+configured artifact cleanup, recoverable Git worktree, Claude file, and exact
+Zed rotated-log quarantine, plus recoverable offline Codex database
+compaction. It reports OpenCode's native maintenance contract, Cursor's owner
+database commands, Docker Buildx cache facts, and Grok's version-gated
+session-start memory GC. Grok Build, Docker, and all other Cursor, Zed, and
+OpenCode state remain non-mutating.
 
 MIT licensed. built by [Vincent Koc](https://github.com/vincentkoc).

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -25,7 +25,7 @@ schemas.
 {
   "schemaVersion": 1,
   "command": "audit",
-  "agentrinseVersion": "0.5.0",
+  "agentrinseVersion": "0.6.0",
   "startedAt": "2026-07-24T00:00:00.000Z",
   "completedAt": "2026-07-24T00:00:01.000Z",
   "status": "ok",
@@ -95,7 +95,7 @@ resource is skipped rather than substituted.
 
 ## Exit Status
 
-Current `0.5.0` behavior:
+Current `0.6.0` behavior:
 
 | Code  | Meaning                                      |
 | ----- | -------------------------------------------- |

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -20,13 +20,14 @@ Run `agentrinse doctor` to verify the current machine without mutating it.
 
 ## macOS
 
-macOS is Tier 1 for `0.5.0`.
+macOS is Tier 1 for `0.6.0`.
 
 - provider, Git, Docker, and configured artifact inventory
 - `lsof` process ownership proof
 - safe configured artifact apply
 - recoverable linked-worktree quarantine, undo, and purge
 - recoverable exact Claude debug-log and changelog-cache quarantine
+- recoverable exact Zed `Zed.log.old` quarantine after 30 days
 - experimental recoverable offline Codex database compaction
 - optional Mole detection through `mo --version`
 - external `mo purge --dry-run` and `mo clean --dry-run` suggestions from the
@@ -35,12 +36,9 @@ macOS is Tier 1 for `0.5.0`.
 Mole remains external. AgentRinse does not embed, invoke, or parse Mole
 cleanup.
 
-Current main after `0.5.0` also supports recoverable quarantine for the exact
-native Zed `$HOME/Library/Logs/Zed/Zed.log.old` file after 30 days.
-
 ## Linux
 
-Linux is Tier 2 for `0.5.0`.
+Linux is Tier 2 for `0.6.0`.
 
 - provider, Git, Docker, and configured artifact inventory
 - same-user `/proc` process ownership inspection
@@ -48,12 +46,10 @@ Linux is Tier 2 for `0.5.0`.
 - safe configured artifact apply
 - recoverable linked-worktree quarantine, undo, and purge
 - recoverable exact Claude debug-log and changelog-cache quarantine
+- recoverable exact Zed `Zed.log.old` quarantine after 30 days
 - experimental recoverable offline Codex database compaction
 
 If neither `/proc` nor `lsof` can prove a target idle, apply skips it.
-
-Current main after `0.5.0` also supports recoverable quarantine for the exact
-`Zed.log.old` file under the resolved Zed data root's `logs` directory.
 
 Stale-lock recovery uses the kernel-held `lockf` utility on macOS and `flock`
 from `util-linux` on Linux. A crashed recovery process releases the mutex
@@ -62,7 +58,7 @@ automatically.
 ## WSL
 
 WSL follows the Linux contract for paths and processes inside the WSL
-filesystem. Do not use `0.5.0` to mutate Windows-mounted project trees unless
+filesystem. Do not use `0.6.0` to mutate Windows-mounted project trees unless
 doctor and a disposable canary prove path identity, ownership, rename, and
 mount behavior for that exact setup.
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -6,7 +6,7 @@ Target version: 0.6.0
 
 Created: 2026-07-23
 
-Updated: 2026-07-28
+Updated: 2026-07-29
 
 Owner: Vincent Koc
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentrinse",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": false,
   "description": "Safe, local-first cleanup for agentic development.",
   "keywords": [

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.5.0";
+export const VERSION = "0.6.0";


### PR DESCRIPTION
## Summary

- release recoverable quarantine for the exact stale Zed `Zed.log.old` file
- ship report-only OpenCode, Cursor, Grok, and Docker Buildx maintenance diagnostics
- bump package, CLI, changelog, and release documentation to 0.6.0

## Safety

Zed mutation remains limited to one exact rotated application log after 30 days, with process, descriptor, path, inode, content, and age revalidation plus a seven-day undo window. Active logs, ACP logs, databases, threads, settings, credentials, extensions, crash reports, neighboring files, symlinks, and all OpenCode, Cursor, Grok, and Docker state remain protected or report-only.

## Validation

- formatting, lint, typecheck, and schema checks passed
- 67 test files passed: 509 tests passed, 1 skipped
- source smoke passed, including Zed apply, undo, and purge
- package manifest and `publint` checks passed
- packed `agentrinse-0.6.0.tgz` installed successfully and passed synthetic audit, plan, apply, undo, and purge smoke

## Release

After merge, create `v0.6.0`, verify GitHub/npm artifacts and checksum, then update the Homebrew formula to the exact release asset SHA-256.
