### PR TITLE
feat(audit): add stateless provider-scoped mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The project follows semantic versioning after its first supported release.
 
 ## [Unreleased]
 
+### Added
+
+- stateless JSON and NDJSON audits for an exact provider allowlist, including
+  shell completion and configured-root support
+
+### Safety
+
+- `audit --no-state` rejects output and state paths before discovery and never
+  resolves or writes the AgentRinse state layout
+- provider-scoped audits suppress Git, Docker, runtime, and artifact discovery,
+  reject relative configured roots, and omit candidate actions so redirected
+  output cannot authorize cleanup
+
 ## [0.6.0] - 2026-07-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ rollback set is actually deleted.
 | Command                                   | Purpose                                                   | Mutation              |
 | ----------------------------------------- | --------------------------------------------------------- | --------------------- |
 | `agentrinse audit`                        | inventory a home and explain protection evidence          | none                  |
+| `agentrinse audit --no-state --providers` | stream selected provider evidence without persisted state | none                  |
 | `agentrinse audit --allow-offline-vacuum` | propose supported offline Codex DB actions                | none                  |
 | `agentrinse plan`                         | create a bounded plan from a saved audit                  | persisted plan only   |
 | `agentrinse clean --profile closeout`     | audit and plan the current repository                     | none                  |
@@ -329,6 +330,19 @@ long audits can stream versioned events:
 ```bash
 agentrinse audit --ndjson
 ```
+
+headless checks can select exact providers without creating AgentRinse state:
+
+```bash
+agentrinse audit --providers cursor,copilot,opencode --no-state --json
+```
+
+`--no-state` requires JSON or NDJSON and rejects `--output` and `--state-dir`.
+`--providers` accepts unique provider IDs only, honors configured provider
+roots when they are absolute, and is valid only with `--no-state`. Git, Docker,
+runtime, and artifact adapters are not instantiated for a provider-scoped
+audit. The transient report omits candidate actions, so redirecting it into a
+later plan cannot authorize cleanup.
 
 create a non-executable report for issue filing:
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -60,6 +60,32 @@ agentrinse audit --ndjson |
 
 Do not parse human output.
 
+## Stateless Provider Audits
+
+Headless checks can request only exact provider adapters and keep all evidence
+on stdout:
+
+```bash
+agentrinse audit --providers cursor,copilot,opencode --no-state --json
+agentrinse audit --providers cursor,copilot,opencode --no-state --ndjson
+```
+
+`--no-state` requires JSON or NDJSON and rejects `--output` and `--state-dir`
+before config or provider discovery. It neither resolves nor creates the
+AgentRinse state layout. `--providers` accepts a unique comma-separated list of
+known provider IDs, overrides each selected provider's `enabled` setting, and
+still honors its configured root when that root is absolute. Relative configured
+roots are rejected before provider discovery. The selector is valid only with
+`--no-state`. Transient provider reports omit every candidate action; if one is
+manually redirected and passed to `plan`, it produces no cleanup actions.
+
+Provider selection does not instantiate Git, Docker, runtime, or artifact
+adapters even when configuration enables them. Node permission mode can deny
+filesystem writes, child processes, and native addons. Node runtimes that do
+not expose network and FFI permission controls still require OS containment:
+use `sandbox-exec` on macOS or `bwrap` with seccomp on Linux and WSL. The
+launcher owns that containment; AgentRinse does not weaken or emulate it.
+
 ## Redacted Reports
 
 Redaction is available only with audit JSON or NDJSON:

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -1339,6 +1339,7 @@ Read-only discovery and classification.
 agentrinse audit
 agentrinse audit --adapter git --adapter codex
 agentrinse audit --json
+agentrinse audit --providers cursor,copilot,opencode --no-state --json
 agentrinse audit --save
 agentrinse audit --paths "$HOME/src/project"
 ```
@@ -1350,8 +1351,17 @@ Key flags:
 --paths <path>          repeatable
 --include-protected
 --min-size <bytes>
+--no-state              machine output only; never persist audit state
+--providers <ids>       exact provider list; requires --no-state
 --state <state>         repeatable
 ```
+
+Provider-scoped audits are transient read-only evidence. They honor configured
+roots only when those roots are absolute and override the selected providers'
+enabled settings, but instantiate no Git, Docker, runtime, or artifact adapters.
+They omit every candidate action, so saving one and passing it to `plan` cannot
+authorize cleanup. A future machine-output schema would be required before
+provider-scoped evidence could participate in plan/apply.
 
 Default human summary:
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "pack:check": "pnpm build && pnpm schemas:check && node scripts/check-package-manifest.mjs && publint && npm pack --dry-run",
     "schemas:check": "pnpm build && node scripts/generate-schemas.mjs --check",
     "schemas:generate": "pnpm build && node scripts/generate-schemas.mjs",
-    "smoke": "pnpm build && node scripts/smoke.mjs",
+    "smoke": "pnpm build && node scripts/stateless-audit-smoke.mjs && node scripts/smoke.mjs",
     "smoke:package": "pnpm build && node scripts/smoke-package.mjs",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/stateless-audit-smoke.mjs
+++ b/scripts/stateless-audit-smoke.mjs
@@ -1,0 +1,252 @@
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
+import {
+  access,
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { delimiter, dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const repositoryRoot = await realpath(
+  dirname(fileURLToPath(new URL("../package.json", import.meta.url))),
+);
+const dependenciesRoot = await realpath(join(repositoryRoot, "node_modules"));
+const cli = join(repositoryRoot, "dist", "cli.js");
+const fixtureRoot = await realpath(await mkdtemp(join(tmpdir(), "agentrinse-stateless-smoke-")));
+const home = join(fixtureRoot, "home");
+const trapBin = join(fixtureRoot, "trap-bin");
+const trapMarker = join(fixtureRoot, "trap-invocations.log");
+const stateRoot = join(home, "forbidden-state");
+const configPath = join(home, "config.json");
+const cursorRoot = join(home, "selected", "cursor");
+const copilotRoot = join(home, "selected", "copilot");
+const opencodeRoot = join(home, "selected", "opencode");
+const artifactRoot = join(home, "project");
+
+async function expectMissing(path, label) {
+  try {
+    await access(path);
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+  throw new Error(`${label} was created`);
+}
+
+async function snapshotTree(root) {
+  const entries = [];
+  const visit = async (path) => {
+    const stats = await lstat(path, { bigint: true });
+    const kind = stats.isDirectory()
+      ? "directory"
+      : stats.isFile()
+        ? "file"
+        : stats.isSymbolicLink()
+          ? "symlink"
+          : "other";
+    entries.push({
+      path: relative(root, path) || ".",
+      kind,
+      mode: stats.mode.toString(),
+      size: stats.size.toString(),
+      modified: stats.mtimeNs.toString(),
+      changed: stats.ctimeNs.toString(),
+      created: stats.birthtimeNs.toString(),
+      inode: stats.ino.toString(),
+      uid: stats.uid.toString(),
+      gid: stats.gid.toString(),
+      ...(kind === "file"
+        ? {
+            content: createHash("sha256")
+              .update(await readFile(path))
+              .digest("hex"),
+          }
+        : {}),
+    });
+    if (kind === "directory") {
+      for (const name of (await readdir(path)).sort()) {
+        await visit(join(path, name));
+      }
+    }
+  };
+  await visit(root);
+  return entries;
+}
+
+await mkdir(trapBin, { recursive: true });
+for (const binary of ["mo", "grok", "codex", "git", "docker", "sqlite3", "lsof"]) {
+  const path = join(trapBin, process.platform === "win32" ? `${binary}.cmd` : binary);
+  await writeFile(
+    path,
+    process.platform === "win32"
+      ? `@echo ${binary}>>"%TRAP_MARKER%"\r\n@exit /b 97\r\n`
+      : `#!/bin/sh\nprintf '%s\\n' '${binary}' >> "$TRAP_MARKER"\nexit 97\n`,
+  );
+  if (process.platform !== "win32") {
+    await chmod(path, 0o755);
+  }
+}
+
+await mkdir(join(cursorRoot, "User", "workspaceStorage", "workspace"), {
+  recursive: true,
+});
+await mkdir(join(cursorRoot, "User", "globalStorage"), { recursive: true });
+await mkdir(join(cursorRoot, "logs"), { recursive: true });
+await writeFile(join(cursorRoot, "User", "workspaceStorage", "workspace", "state.json"), "{}");
+await writeFile(join(cursorRoot, "User", "globalStorage", "state.vscdb"), "cursor");
+await mkdir(join(copilotRoot, "session-state"), { recursive: true });
+await mkdir(join(copilotRoot, "logs"), { recursive: true });
+await writeFile(join(copilotRoot, "session-state", "session.json"), "{}");
+await mkdir(join(opencodeRoot, "log"), { recursive: true });
+await mkdir(join(opencodeRoot, "snapshot"), { recursive: true });
+await writeFile(join(opencodeRoot, "opencode.db"), "opencode");
+await writeFile(join(opencodeRoot, "snapshot", "object"), "snapshot");
+
+await mkdir(join(home, "excluded-codex", "sessions"), { recursive: true });
+await writeFile(join(home, "excluded-codex", "sessions", "thread.jsonl"), "keep");
+await mkdir(join(home, "excluded-grok", "logs"), { recursive: true });
+await writeFile(join(home, "excluded-grok", "logs", "grok.log"), "keep");
+await mkdir(join(artifactRoot, "node_modules"), { recursive: true });
+await writeFile(join(artifactRoot, "node_modules", "cache"), "keep");
+await writeFile(
+  configPath,
+  `${JSON.stringify(
+    {
+      schemaVersion: 1,
+      adapters: {
+        codex: { enabled: true, root: join(home, "excluded-codex") },
+        claude: { enabled: true, root: join(home, "excluded-claude") },
+        cursor: { enabled: true, root: cursorRoot },
+        copilot: { enabled: true, root: copilotRoot },
+        zed: { enabled: true, root: join(home, "excluded-zed") },
+        opencode: { enabled: true, root: opencodeRoot },
+        grok: { enabled: true, root: join(home, "excluded-grok") },
+        runtime: { enabled: true },
+        git: { enabled: true, root: artifactRoot },
+        docker: { enabled: true },
+      },
+      audit: {
+        maxEntries: 1000,
+        measureBytes: false,
+      },
+      artifacts: {
+        projects: [{ root: artifactRoot, names: ["node_modules"] }],
+        minAgeMinutes: 0,
+        minBytes: 0,
+        processCheck: "required",
+      },
+    },
+    null,
+    2,
+  )}\n`,
+);
+
+const before = await snapshotTree(home);
+const permissionFlags = process.allowedNodeEnvironmentFlags;
+const runtimeDenied = ["fs-write", "child-process", "addons"];
+const externalSandboxRequired = [];
+if (permissionFlags.has("--allow-net")) {
+  runtimeDenied.push("net");
+} else {
+  externalSandboxRequired.push("net");
+}
+if (permissionFlags.has("--allow-ffi")) {
+  runtimeDenied.push("ffi");
+} else {
+  externalSandboxRequired.push("ffi");
+}
+const environment = {
+  ...process.env,
+  HOME: home,
+  USERPROFILE: home,
+  XDG_STATE_HOME: stateRoot,
+  PATH: `${trapBin}${delimiter}${process.env.PATH ?? ""}`,
+  TRAP_MARKER: trapMarker,
+};
+for (const name of [
+  "BUILDX_BUILDER",
+  "CLAUDE_CONFIG_DIR",
+  "CODEX_HOME",
+  "COPILOT_HOME",
+  "DOCKER_HOST",
+  "FLATPAK_XDG_DATA_HOME",
+  "GROK_HOME",
+  "NODE_OPTIONS",
+  "XDG_DATA_HOME",
+]) {
+  delete environment[name];
+}
+
+const permissionArguments = [
+  "--permission",
+  `--allow-fs-read=${repositoryRoot}`,
+  `--allow-fs-read=${dependenciesRoot}`,
+  `--allow-fs-read=${fixtureRoot}`,
+  cli,
+  "audit",
+  "--home",
+  home,
+  "--config",
+  configPath,
+  "--providers",
+  "cursor,copilot,opencode",
+  "--no-state",
+  "--json",
+];
+const completed = await execFileAsync(process.execPath, permissionArguments, {
+  cwd: fixtureRoot,
+  env: environment,
+  maxBuffer: 16 * 1024 * 1024,
+});
+if (completed.stderr !== "") {
+  throw new Error(`stateless audit wrote stderr: ${completed.stderr}`);
+}
+
+const envelope = JSON.parse(completed.stdout);
+const probes = envelope.data?.probes?.map((probe) => probe.adapter);
+if (JSON.stringify(probes) !== JSON.stringify(["copilot", "cursor", "opencode"])) {
+  throw new Error(`stateless audit probed unexpected adapters: ${JSON.stringify(probes)}`);
+}
+const findingAdapters = new Set(
+  envelope.data?.findings?.map((finding) => finding.resource?.adapter),
+);
+if (
+  findingAdapters.size !== 3 ||
+  !["copilot", "cursor", "opencode"].every((provider) => findingAdapters.has(provider))
+) {
+  throw new Error("stateless audit returned findings outside the selected providers");
+}
+for (const excluded of ["excluded-codex", "excluded-grok", "node_modules"]) {
+  if (completed.stdout.includes(excluded)) {
+    throw new Error(`stateless audit exposed excluded root: ${excluded}`);
+  }
+}
+
+const after = await snapshotTree(home);
+if (JSON.stringify(after) !== JSON.stringify(before)) {
+  throw new Error("stateless audit changed synthetic HOME metadata or content");
+}
+await expectMissing(stateRoot, "AgentRinse state");
+await expectMissing(trapMarker, "trap invocation log");
+
+process.stdout.write(
+  `${JSON.stringify({
+    statelessAudit: true,
+    providers: probes,
+    runtimeDenied,
+    externalSandboxRequired,
+    trapBinaries: ["mo", "grok", "codex", "git", "docker", "sqlite3", "lsof"],
+  })}\n`,
+);

--- a/src/adapters/provider-specs.ts
+++ b/src/adapters/provider-specs.ts
@@ -224,3 +224,5 @@ export const PROVIDER_SPECS: Record<ProviderAdapterId, ProviderSpec> = {
     ],
   },
 };
+
+export const PROVIDER_IDS = Object.freeze(Object.keys(PROVIDER_SPECS) as ProviderAdapterId[]);

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -6,12 +6,13 @@ import { ArtifactAuditAdapter } from "./artifacts/adapter.js";
 import { DockerAuditAdapter } from "./docker/adapter.js";
 import { GitWorktreeAuditAdapter } from "./git/adapter.js";
 import { ProviderAuditAdapter } from "./provider-adapter.js";
-import { PROVIDER_SPECS, type ProviderAdapterId } from "./provider-specs.js";
+import { PROVIDER_IDS, PROVIDER_SPECS, type ProviderAdapterId } from "./provider-specs.js";
 import { RuntimeAuditAdapter } from "./runtime/adapter.js";
 
-const PROVIDER_IDS = Object.keys(PROVIDER_SPECS) as ProviderAdapterId[];
+const PROVIDER_ID_SET = new Set<string>(PROVIDER_IDS);
 
 export type AuditAdapterRegistryOptions = {
+  providers?: readonly ProviderAdapterId[];
   providerInventory?: boolean;
   roots?: ReachabilityRoot[];
   environment?: NodeJS.ProcessEnv;
@@ -19,13 +20,35 @@ export type AuditAdapterRegistryOptions = {
   allowOfflineVacuum?: boolean;
 };
 
+function validateProviderSelection(providers: readonly ProviderAdapterId[]): ProviderAdapterId[] {
+  if (providers.length === 0) {
+    throw new Error("provider selection must not be empty");
+  }
+  const selected: ProviderAdapterId[] = [];
+  const seen = new Set<string>();
+  for (const id of providers) {
+    if (!PROVIDER_ID_SET.has(id)) {
+      throw new Error(`unknown provider ID: ${String(id)}`);
+    }
+    if (seen.has(id)) {
+      throw new Error(`duplicate provider ID: ${id}`);
+    }
+    seen.add(id);
+    selected.push(id);
+  }
+  return selected;
+}
+
 export function createAuditAdapters(
   config: AgentRinseConfig,
   platform: NodeJS.Platform = process.platform,
   options: AuditAdapterRegistryOptions = {},
 ): AuditAdapter[] {
   const reachability = options.reachability ?? new ReachabilityIndex();
-  const gitEnabled = config.adapters.git?.enabled === true;
+  const providerSelection =
+    options.providers === undefined ? undefined : validateProviderSelection(options.providers);
+  const exclusiveProviders = providerSelection !== undefined;
+  const gitEnabled = !exclusiveProviders && config.adapters.git?.enabled === true;
   for (const root of options.roots ?? []) {
     reachability.add(root);
   }
@@ -50,9 +73,9 @@ export function createAuditAdapters(
       });
     }
   }
-  const adapters: AuditAdapter[] = PROVIDER_IDS.filter(
-    (id) => config.adapters[id]?.enabled !== false,
-  ).map(
+  const providerIds =
+    providerSelection ?? PROVIDER_IDS.filter((id) => config.adapters[id]?.enabled !== false);
+  const adapters: AuditAdapter[] = providerIds.map(
     (id) =>
       new ProviderAuditAdapter(PROVIDER_SPECS[id], {
         ...(config.adapters[id]?.root === undefined ? {} : { root: config.adapters[id].root }),
@@ -65,6 +88,10 @@ export function createAuditAdapters(
         environment: options.environment ?? process.env,
       }),
   );
+
+  if (exclusiveProviders) {
+    return adapters;
+  }
 
   if (gitEnabled) {
     adapters.push(

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -1,8 +1,10 @@
 import { randomUUID } from "node:crypto";
-import { resolve } from "node:path";
+import { isAbsolute, resolve } from "node:path";
 
 import { createAuditAdapters } from "../adapters/registry.js";
+import { PROVIDER_IDS, type ProviderAdapterId } from "../adapters/provider-specs.js";
 import { loadConfigForHome } from "../config/load.js";
+import type { AgentRinseConfig } from "../config/schema.js";
 import type { AuditReport } from "../contracts/report.js";
 import { runAudit, type AuditProgressEvent } from "../core/audit.js";
 import { redactAuditReport, redactAuditValue } from "../core/redaction.js";
@@ -24,6 +26,8 @@ export type AuditCommandOptions = {
   redact?: boolean;
   output?: string;
   stateDir?: string;
+  noState?: boolean;
+  providers?: string;
   allowOfflineVacuum?: boolean;
   now?: () => Date;
   emit?: (output: string) => void;
@@ -31,9 +35,66 @@ export type AuditCommandOptions = {
 
 export type AuditCommandResult = {
   report: AuditReport;
-  statePath: string;
+  statePath?: string;
   output: string;
 };
+
+const PROVIDER_ID_SET = new Set<string>(PROVIDER_IDS);
+const NON_PROVIDER_IDS = new Set(["artifacts", "docker", "git", "runtime"]);
+
+export function parseAuditProviders(value?: string): ProviderAdapterId[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value.length === 0) {
+    throw new Error("audit --providers requires a non-empty comma-separated provider list");
+  }
+
+  const providers: ProviderAdapterId[] = [];
+  const seen = new Set<string>();
+  for (const id of value.split(",")) {
+    if (id.length === 0) {
+      throw new Error("audit --providers contains an empty provider ID");
+    }
+    if (id.trim() !== id) {
+      throw new Error("audit --providers accepts exact provider IDs without whitespace");
+    }
+    if (NON_PROVIDER_IDS.has(id)) {
+      throw new Error(`audit --providers accepts provider IDs only; got ${id}`);
+    }
+    if (!PROVIDER_ID_SET.has(id)) {
+      throw new Error(`audit --providers contains unknown provider: ${id}`);
+    }
+    if (seen.has(id)) {
+      throw new Error(`audit --providers contains duplicate provider: ${id}`);
+    }
+    seen.add(id);
+    providers.push(id as ProviderAdapterId);
+  }
+  return providers;
+}
+
+function assertAbsoluteSelectedProviderRoots(
+  config: AgentRinseConfig,
+  providers: readonly ProviderAdapterId[],
+): void {
+  for (const id of providers) {
+    const root = config.adapters[id]?.root;
+    if (root !== undefined && !isAbsolute(root)) {
+      throw new Error(`audit --providers requires an absolute configured root for ${id}`);
+    }
+  }
+}
+
+function withoutCandidateActions(report: AuditReport): AuditReport {
+  return {
+    ...report,
+    findings: report.findings.map((finding) => ({
+      ...finding,
+      candidateActions: [],
+    })),
+  };
+}
 
 export async function executeAuditCommand(
   options: AuditCommandOptions,
@@ -43,6 +104,19 @@ export async function executeAuditCommand(
   }
   if (options.redact === true && options.json !== true && options.ndjson !== true) {
     throw new Error("audit --redact requires --json or --ndjson");
+  }
+  if (options.noState === true && options.output !== undefined) {
+    throw new Error("audit --no-state does not accept --output");
+  }
+  if (options.noState === true && options.stateDir !== undefined) {
+    throw new Error("audit --no-state does not accept --state-dir");
+  }
+  if (options.noState === true && options.json !== true && options.ndjson !== true) {
+    throw new Error("audit --no-state requires --json or --ndjson");
+  }
+  const providers = parseAuditProviders(options.providers);
+  if (providers !== undefined && options.noState !== true) {
+    throw new Error("audit --providers requires --no-state");
   }
 
   const clock = options.now ?? (() => new Date());
@@ -69,35 +143,48 @@ export async function executeAuditCommand(
 
   const home = resolve(options.home);
   const { config } = await loadConfigForHome(home, options.config);
+  if (providers !== undefined) {
+    assertAbsoluteSelectedProviderRoots(config, providers);
+  }
   const startedAt = clock().toISOString();
   if (options.ndjson === true) {
     emitEvent("command.started", startedAt, options.redact === true ? { home: "$HOME" } : { home });
   }
   try {
-    const report = await runAudit({
+    const discoveredReport = await runAudit({
       home,
       config,
       adapters: createAuditAdapters(config, process.platform, {
         allowOfflineVacuum: options.allowOfflineVacuum ?? false,
+        ...(providers === undefined ? {} : { providers }),
       }),
       now: clock,
       ...(options.ndjson === true
         ? {
             onEvent: (event: AuditProgressEvent) => {
+              const eventData =
+                providers !== undefined && event.type === "finding.completed"
+                  ? { ...event.data, candidateActions: [] }
+                  : event.data;
               emitEvent(
                 event.type,
                 event.timestamp,
-                options.redact === true ? redactAuditValue(event.data, home, salt) : event.data,
+                options.redact === true ? redactAuditValue(eventData, home, salt) : eventData,
               );
             },
           }
         : {}),
     });
-    const layout = stateLayout(resolveStateRoot(home, options.stateDir));
-    const statePath = resolve(layout.audits, `${report.auditId}.json`);
-    await writeJsonAtomic(statePath, report, {
-      privateDirectories: [layout.root, layout.audits],
-    });
+    const report =
+      providers === undefined ? discoveredReport : withoutCandidateActions(discoveredReport);
+    let statePath: string | undefined;
+    if (options.noState !== true) {
+      const layout = stateLayout(resolveStateRoot(home, options.stateDir));
+      statePath = resolve(layout.audits, `${report.auditId}.json`);
+      await writeJsonAtomic(statePath, report, {
+        privateDirectories: [layout.root, layout.audits],
+      });
+    }
 
     if (options.output !== undefined) {
       await writeJsonAtomic(resolve(options.output), report);
@@ -125,7 +212,7 @@ export async function executeAuditCommand(
         : "ok";
     return {
       report,
-      statePath,
+      ...(statePath === undefined ? {} : { statePath }),
       output:
         options.ndjson === true
           ? ndjson.join("")

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -1,3 +1,5 @@
+import { PROVIDER_IDS } from "../adapters/provider-specs.js";
+
 export const completionShells = ["bash", "zsh", "fish"] as const;
 export type CompletionShell = (typeof completionShells)[number];
 
@@ -27,16 +29,23 @@ const SUBCOMMANDS = {
 function bashCompletion(): string {
   return `# bash completion for AgentRinse
 _agentrinse_completion() {
-  local current command
+  local current command previous
   current="\${COMP_WORDS[COMP_CWORD]}"
   command="\${COMP_WORDS[1]}"
+  previous="\${COMP_WORDS[COMP_CWORD-1]}"
 
   if [[ "\${COMP_CWORD}" -eq 1 ]]; then
     COMPREPLY=( $(compgen -W "${COMMANDS.join(" ")}" -- "\${current}") )
     return
   fi
 
+  if [[ "\${command}" == "audit" && "\${previous}" == "--providers" ]]; then
+    COMPREPLY=( $(compgen -W "${PROVIDER_IDS.join(" ")}" -- "\${current}") )
+    return
+  fi
+
   case "\${command}" in
+    audit) COMPREPLY=( $(compgen -W "--help --home --config --json --ndjson --redact --output --state-dir --no-state --providers --allow-offline-vacuum" -- "\${current}") ) ;;
     completion) COMPREPLY=( $(compgen -W "${SUBCOMMANDS.completion.join(" ")}" -- "\${current}") ) ;;
     config) COMPREPLY=( $(compgen -W "${SUBCOMMANDS.config.join(" ")}" -- "\${current}") ) ;;
     lock) COMPREPLY=( $(compgen -W "${SUBCOMMANDS.lock.join(" ")}" -- "\${current}") ) ;;
@@ -63,6 +72,7 @@ ${COMMANDS.map((command) => `    '${command}:${command}'`).join("\n")}
   fi
 
   case "\${words[2]}" in
+    audit) _arguments '--no-state[do not persist audit state]' '--providers[comma-separated provider IDs]:providers:(${PROVIDER_IDS.join(" ")})' '*:argument:_files' ;;
     completion) _values 'shell' ${SUBCOMMANDS.completion.join(" ")} ;;
     config) _values 'config command' ${SUBCOMMANDS.config.join(" ")} ;;
     lock) _values 'lock command' ${SUBCOMMANDS.lock.join(" ")} ;;
@@ -91,6 +101,12 @@ function fishCompletion(): string {
       );
     }
   }
+  lines.push(
+    "complete -c agentrinse -n '__fish_seen_subcommand_from audit' -l no-state -d 'Do not persist audit state'",
+  );
+  lines.push(
+    `complete -c agentrinse -n '__fish_seen_subcommand_from audit' -l providers -r -a '${PROVIDER_IDS.join(" ")}' -d 'Audit only selected providers'`,
+  );
   return `${lines.join("\n")}\n`;
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,6 +40,8 @@ export function buildProgram(): Command {
     .option("--json", "emit the versioned JSON report", false)
     .option("--ndjson", "stream versioned NDJSON events", false)
     .option("--redact", "redact paths and identifiers in machine output", false)
+    .option("--providers <ids>", "audit only comma-separated provider IDs; requires --no-state")
+    .option("--no-state", "do not persist audit state; requires JSON or NDJSON")
     .option("--output <path>", "write the JSON report atomically")
     .option("--state-dir <path>", "override the AgentRinse state directory")
     .option(
@@ -54,6 +56,8 @@ export function buildProgram(): Command {
         json: boolean;
         ndjson: boolean;
         redact: boolean;
+        providers?: string;
+        state: boolean;
         output?: string;
         stateDir?: string;
         allowOfflineVacuum: boolean;
@@ -61,6 +65,7 @@ export function buildProgram(): Command {
         const result = await executeAuditCommand({
           ...options,
           home: options.home ?? homedir(),
+          noState: options.state === false,
           ...(options.ndjson ? { emit: (output) => process.stdout.write(output) } : {}),
         });
         if (result.output !== "") {

--- a/test/commands/audit-no-state.test.ts
+++ b/test/commands/audit-no-state.test.ts
@@ -1,0 +1,349 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  access,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { executeAuditCommand, parseAuditProviders } from "../../src/commands/audit.js";
+import { executePlanCommand } from "../../src/commands/plan.js";
+import { commandEnvelopeSchema, commandEventSchema } from "../../src/contracts/output.js";
+import { auditReportSchema } from "../../src/contracts/report.js";
+
+type TreeEntry = {
+  path: string;
+  kind: "directory" | "file" | "symlink" | "other";
+  mode: number;
+  size: string;
+  modified: string;
+  changed: string;
+  inode: string;
+  content?: string;
+};
+
+async function snapshotTree(root: string): Promise<TreeEntry[]> {
+  const entries: TreeEntry[] = [];
+  const visit = async (path: string): Promise<void> => {
+    const stats = await lstat(path, { bigint: true });
+    const kind = stats.isDirectory()
+      ? "directory"
+      : stats.isFile()
+        ? "file"
+        : stats.isSymbolicLink()
+          ? "symlink"
+          : "other";
+    entries.push({
+      path: relative(root, path) || ".",
+      kind,
+      mode: Number(stats.mode),
+      size: stats.size.toString(),
+      modified: stats.mtimeNs.toString(),
+      changed: stats.ctimeNs.toString(),
+      inode: stats.ino.toString(),
+      ...(kind === "file"
+        ? {
+            content: createHash("sha256")
+              .update(await readFile(path))
+              .digest("hex"),
+          }
+        : {}),
+    });
+    if (kind === "directory") {
+      for (const name of (await readdir(path)).sort()) {
+        await visit(join(path, name));
+      }
+    }
+  };
+  await visit(root);
+  return entries;
+}
+
+async function expectMissing(path: string): Promise<void> {
+  await expect(access(path)).rejects.toMatchObject({ code: "ENOENT" });
+}
+
+describe("stateless provider audit", () => {
+  it("rejects persistence options and non-machine output before discovery", async () => {
+    const missingHome = join(tmpdir(), `agentrinse-missing-${randomUUID()}`);
+    const missingConfig = join(missingHome, "missing-config.json");
+    const emitted: string[] = [];
+
+    await expect(
+      executeAuditCommand({
+        home: missingHome,
+        config: missingConfig,
+        noState: true,
+        ndjson: true,
+        output: join(missingHome, "audit.json"),
+        emit: (record) => emitted.push(record),
+      }),
+    ).rejects.toThrow("does not accept --output");
+    await expect(
+      executeAuditCommand({
+        home: missingHome,
+        config: missingConfig,
+        noState: true,
+        json: true,
+        stateDir: join(missingHome, "state"),
+      }),
+    ).rejects.toThrow("does not accept --state-dir");
+    await expect(
+      executeAuditCommand({
+        home: missingHome,
+        noState: true,
+      }),
+    ).rejects.toThrow("requires --json or --ndjson");
+    await expect(
+      executeAuditCommand({
+        home: missingHome,
+        config: missingConfig,
+        json: true,
+        providers: "cursor",
+      }),
+    ).rejects.toThrow("--providers requires --no-state");
+    expect(emitted).toEqual([]);
+  });
+
+  it("rejects empty, duplicate, unknown, and non-provider selections", () => {
+    expect(() => parseAuditProviders("")).toThrow("non-empty");
+    expect(() => parseAuditProviders("cursor,")).toThrow("empty provider ID");
+    expect(() => parseAuditProviders("cursor,cursor")).toThrow("duplicate provider");
+    expect(() => parseAuditProviders("cursor, copilot")).toThrow("without whitespace");
+    expect(() => parseAuditProviders("git")).toThrow("provider IDs only");
+    expect(() => parseAuditProviders("not-a-provider")).toThrow("unknown provider");
+  });
+
+  it("rejects a selected disabled provider with a relative configured root", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-relative-provider-root-"));
+    const configPath = join(home, "config.json");
+    await writeFile(
+      configPath,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        adapters: {
+          cursor: {
+            enabled: false,
+            root: "relative/cursor",
+          },
+        },
+      })}\n`,
+    );
+
+    await expect(
+      executeAuditCommand({
+        home,
+        config: configPath,
+        noState: true,
+        json: true,
+        providers: "cursor",
+      }),
+    ).rejects.toThrow("requires an absolute configured root for cursor");
+    await expectMissing(join(home, "relative", "cursor"));
+    await expectMissing(join(home, ".local", "state", "agentrinse"));
+  });
+
+  it("emits NDJSON without resolving a state path", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-stateless-ndjson-"));
+    const result = await executeAuditCommand({
+      home,
+      noState: true,
+      ndjson: true,
+      providers: "cursor",
+    });
+    const events = result.output
+      .trim()
+      .split("\n")
+      .map((line) => commandEventSchema.parse(JSON.parse(line)));
+
+    expect(Object.hasOwn(result, "statePath")).toBe(false);
+    expect(events[0]?.event).toBe("command.started");
+    expect(events.at(-1)?.event).toBe("command.completed");
+    await expectMissing(join(home, ".local", "state", "agentrinse"));
+  });
+
+  it("omits candidate actions from JSON, NDJSON, and extracted plans", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-stateless-actions-"));
+    const claudeRoot = join(home, "claude");
+    const debugRoot = join(claudeRoot, "debug");
+    const configPath = join(home, "config.json");
+    const extractedAuditPath = join(home, "extracted-audit.json");
+    const now = () => new Date("2026-08-07T00:00:00.000Z");
+    await mkdir(debugRoot, { recursive: true });
+    const debugLog = join(debugRoot, "old-session.txt");
+    await writeFile(debugLog, "synthetic old debug output\n");
+    await utimes(
+      debugLog,
+      new Date("2026-06-01T00:00:00.000Z"),
+      new Date("2026-06-01T00:00:00.000Z"),
+    );
+    await writeFile(
+      configPath,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        adapters: {
+          claude: {
+            enabled: false,
+            root: claudeRoot,
+          },
+        },
+        plan: {
+          ttlMinutes: 30,
+          maxRisk: "recoverable",
+        },
+      })}\n`,
+    );
+
+    const json = await executeAuditCommand({
+      home,
+      config: configPath,
+      noState: true,
+      json: true,
+      providers: "claude",
+      now,
+    });
+    const envelope = commandEnvelopeSchema.parse(JSON.parse(json.output));
+    const envelopeReport = auditReportSchema.parse(envelope.data);
+    const eligible = json.report.findings.find((finding) => finding.state === "eligible");
+
+    expect(Object.hasOwn(json, "statePath")).toBe(false);
+    expect(eligible).toBeDefined();
+    expect(eligible?.candidateActions).toEqual([]);
+    expect(envelopeReport.findings.every((finding) => finding.candidateActions.length === 0)).toBe(
+      true,
+    );
+
+    const ndjson = await executeAuditCommand({
+      home,
+      config: configPath,
+      noState: true,
+      ndjson: true,
+      providers: "claude",
+      now,
+    });
+    const findingEvents = ndjson.output
+      .trim()
+      .split("\n")
+      .map((line) => commandEventSchema.parse(JSON.parse(line)))
+      .filter((event) => event.event === "finding.completed");
+    expect(
+      findingEvents.every(
+        (event) =>
+          typeof event.data === "object" &&
+          event.data !== null &&
+          "candidateActions" in event.data &&
+          Array.isArray(event.data.candidateActions) &&
+          event.data.candidateActions.length === 0,
+      ),
+    ).toBe(true);
+
+    await writeFile(extractedAuditPath, `${JSON.stringify(json.report)}\n`);
+    const plan = await executePlanCommand({
+      audit: extractedAuditPath,
+      config: configPath,
+      stateDir: join(home, "plan-state"),
+      maxRisk: "recoverable",
+    });
+    expect(plan.plan.actions).toEqual([]);
+  });
+
+  it("audits only selected providers without changing the synthetic home", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-stateless-home-"));
+    const cursorRoot = join(home, "selected", "cursor");
+    const copilotRoot = join(home, "selected", "copilot");
+    const opencodeRoot = join(home, "selected", "opencode");
+    const artifactRoot = join(home, "project");
+    const configPath = join(home, "config.json");
+
+    await mkdir(join(cursorRoot, "User", "workspaceStorage", "workspace"), {
+      recursive: true,
+    });
+    await mkdir(join(cursorRoot, "User", "globalStorage"), { recursive: true });
+    await mkdir(join(cursorRoot, "logs"), { recursive: true });
+    await writeFile(join(cursorRoot, "User", "workspaceStorage", "workspace", "state.json"), "{}");
+    await writeFile(join(cursorRoot, "User", "globalStorage", "state.vscdb"), "cursor");
+    await mkdir(join(copilotRoot, "session-state"), { recursive: true });
+    await mkdir(join(copilotRoot, "logs"), { recursive: true });
+    await writeFile(join(copilotRoot, "session-state", "session.json"), "{}");
+    await mkdir(join(opencodeRoot, "log"), { recursive: true });
+    await mkdir(join(opencodeRoot, "snapshot"), { recursive: true });
+    await writeFile(join(opencodeRoot, "opencode.db"), "opencode");
+    await writeFile(join(opencodeRoot, "snapshot", "object"), "snapshot");
+
+    await mkdir(join(home, "excluded-codex", "sessions"), { recursive: true });
+    await writeFile(join(home, "excluded-codex", "sessions", "thread.jsonl"), "keep");
+    await mkdir(join(home, "excluded-grok", "logs"), { recursive: true });
+    await writeFile(join(home, "excluded-grok", "logs", "grok.log"), "keep");
+    await mkdir(join(artifactRoot, "node_modules"), { recursive: true });
+    await writeFile(join(artifactRoot, "node_modules", "cache"), "keep");
+
+    await writeFile(
+      configPath,
+      `${JSON.stringify(
+        {
+          schemaVersion: 1,
+          adapters: {
+            codex: { enabled: true, root: join(home, "excluded-codex") },
+            claude: { enabled: true, root: join(home, "excluded-claude") },
+            cursor: { enabled: true, root: cursorRoot },
+            copilot: { enabled: true, root: copilotRoot },
+            zed: { enabled: true, root: join(home, "excluded-zed") },
+            opencode: { enabled: true, root: opencodeRoot },
+            grok: { enabled: true, root: join(home, "excluded-grok") },
+            runtime: { enabled: true },
+            git: { enabled: true, root: artifactRoot },
+            docker: { enabled: true },
+          },
+          audit: {
+            maxEntries: 1000,
+            measureBytes: false,
+          },
+          artifacts: {
+            projects: [{ root: artifactRoot, names: ["node_modules"] }],
+            minAgeMinutes: 0,
+            minBytes: 0,
+            processCheck: "required",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const before = await snapshotTree(home);
+    const result = await executeAuditCommand({
+      home,
+      config: configPath,
+      noState: true,
+      json: true,
+      providers: "cursor,copilot,opencode",
+    });
+    const after = await snapshotTree(home);
+
+    expect(Object.hasOwn(result, "statePath")).toBe(false);
+    expect(result.report.probes.map((probe) => probe.adapter)).toEqual([
+      "copilot",
+      "cursor",
+      "opencode",
+    ]);
+    expect(new Set(result.report.findings.map((finding) => finding.resource.adapter))).toEqual(
+      new Set(["copilot", "cursor", "opencode"]),
+    );
+    expect(result.output).toContain(cursorRoot);
+    expect(result.output).toContain(copilotRoot);
+    expect(result.output).toContain(opencodeRoot);
+    expect(result.output).not.toContain("excluded-codex");
+    expect(result.output).not.toContain("excluded-grok");
+    expect(result.output).not.toContain("node_modules");
+    expect(after).toEqual(before);
+    await expectMissing(join(home, ".local", "state", "agentrinse"));
+  });
+});

--- a/test/commands/audit-output.test.ts
+++ b/test/commands/audit-output.test.ts
@@ -19,7 +19,8 @@ describe("audit machine output", () => {
       now: () => new Date("2026-07-24T00:00:00.000Z"),
     });
     const envelope = commandEnvelopeSchema.parse(JSON.parse(result.output));
-    const stored = auditReportSchema.parse(JSON.parse(await readFile(result.statePath, "utf8")));
+    expect(result.statePath).toBeTypeOf("string");
+    const stored = auditReportSchema.parse(JSON.parse(await readFile(result.statePath!, "utf8")));
 
     expect(envelope.command).toBe("audit");
     expect(envelope.data).toEqual(result.report);
@@ -58,7 +59,8 @@ describe("audit machine output", () => {
     });
 
     expect(result.output).not.toContain(home);
-    expect(await readFile(result.statePath, "utf8")).toContain(home);
+    expect(result.statePath).toBeTypeOf("string");
+    expect(await readFile(result.statePath!, "utf8")).toContain(home);
   });
 
   it("emits a failed terminal NDJSON event when persistence fails", async () => {

--- a/test/commands/audit-plan-state.test.ts
+++ b/test/commands/audit-plan-state.test.ts
@@ -20,7 +20,8 @@ describe("audit and plan state persistence", () => {
       output: auditOutput,
       stateDir,
     });
-    await access(audit.statePath);
+    expect(audit.statePath).toBeTypeOf("string");
+    await access(audit.statePath!);
 
     const plan = await executePlanCommand({
       audit: auditOutput,

--- a/test/commands/completion.test.ts
+++ b/test/commands/completion.test.ts
@@ -4,10 +4,10 @@ import { renderCompletion } from "../../src/commands/completion.js";
 
 describe("completion command", () => {
   it.each([
-    ["bash", "complete -F _agentrinse_completion agentrinse"],
-    ["zsh", "#compdef agentrinse"],
-    ["fish", "complete -c agentrinse"],
-  ])("generates %s completion", (shell, marker) => {
+    ["bash", "complete -F _agentrinse_completion agentrinse", "--no-state", "--providers"],
+    ["zsh", "#compdef agentrinse", "--no-state", "--providers"],
+    ["fish", "complete -c agentrinse", "-l no-state", "-l providers"],
+  ])("generates %s completion", (shell, marker, noState, providers) => {
     const output = renderCompletion(shell);
 
     expect(output).toContain(marker);
@@ -16,9 +16,24 @@ describe("completion command", () => {
     expect(output).toContain("doctor");
     expect(output).toContain("recover");
     expect(output).toContain("resource");
+    expect(output).toContain(noState);
+    expect(output).toContain(providers);
+    expect(output).toContain("cursor");
+    expect(output).toContain("copilot");
+    expect(output).toContain("opencode");
   });
 
   it("rejects unsupported shells", () => {
     expect(() => renderCompletion("powershell")).toThrow("expected bash, zsh, or fish");
+  });
+
+  it("keeps stateful bash audit flags and scopes provider values to their option", () => {
+    const output = renderCompletion("bash");
+    const auditCase = output.split("\n").find((line) => line.trimStart().startsWith("audit)"));
+
+    expect(auditCase).toContain("--output");
+    expect(auditCase).toContain("--state-dir");
+    expect(auditCase).not.toContain("cursor");
+    expect(output).toContain('"${previous}" == "--providers"');
   });
 });

--- a/test/core/audit.test.ts
+++ b/test/core/audit.test.ts
@@ -39,6 +39,62 @@ describe("runAudit", () => {
     expect(createAuditAdapters(config).map((adapter) => adapter.id)).not.toContain("grok");
   });
 
+  it("instantiates only explicitly selected providers", () => {
+    const config = structuredClone(DEFAULT_CONFIG);
+    config.adapters.git = { enabled: true, root: "/tmp/agentrinse-git-fixture" };
+    config.adapters.docker = { enabled: true };
+    config.adapters.runtime = { enabled: true };
+    config.artifacts.projects = [
+      {
+        root: "/tmp/agentrinse-artifact-project",
+        names: ["node_modules"],
+      },
+    ];
+
+    expect(
+      createAuditAdapters(config, "linux", {
+        providers: ["cursor", "copilot", "opencode"],
+      }).map((adapter) => adapter.id),
+    ).toEqual(["cursor", "copilot", "opencode"]);
+  });
+
+  it("rejects invalid direct provider selections", () => {
+    expect(() => createAuditAdapters(DEFAULT_CONFIG, "linux", { providers: [] })).toThrow(
+      "must not be empty",
+    );
+    expect(() =>
+      createAuditAdapters(DEFAULT_CONFIG, "linux", {
+        providers: ["cursor", "cursor"],
+      }),
+    ).toThrow("duplicate provider ID");
+    expect(() =>
+      createAuditAdapters(DEFAULT_CONFIG, "linux", {
+        providers: ["git" as never],
+      }),
+    ).toThrow("unknown provider ID");
+  });
+
+  it("honors configured roots when selection overrides a disabled provider", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-provider-select-home-"));
+    const cursorRoot = await mkdtemp(join(tmpdir(), "agentrinse-provider-select-cursor-"));
+    const config = structuredClone(DEFAULT_CONFIG);
+    config.adapters.cursor = { enabled: false, root: cursorRoot };
+
+    const report = await runAudit({
+      home,
+      config,
+      adapters: createAuditAdapters(config, "darwin", { providers: ["cursor"] }),
+    });
+
+    expect(report.probes).toEqual([
+      expect.objectContaining({
+        adapter: "cursor",
+        root: cursorRoot,
+        status: "available",
+      }),
+    ]);
+  });
+
   it("adds Git only when explicitly enabled", () => {
     const config = structuredClone(DEFAULT_CONFIG);
     config.adapters.git = {

--- a/test/state/json-file.test.ts
+++ b/test/state/json-file.test.ts
@@ -103,22 +103,26 @@ describe("atomic JSON files", () => {
     await expectPosixMode(join(root, "config.json"), 0o600);
   });
 
-  it("repairs and verifies AgentRinse-owned state directories", async () => {
-    const root = await mkdtemp(join(tmpdir(), "agentrinse-private-state-"));
-    const plans = join(root, "plans");
-    await chmod(root, 0o777);
+  it(
+    "repairs and verifies AgentRinse-owned state directories",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "agentrinse-private-state-"));
+      const plans = join(root, "plans");
+      await chmod(root, 0o777);
 
-    await writeJsonAtomic(
-      join(plans, "plan.json"),
-      { planId: "plan-1" },
-      {
-        privateDirectories: [root, plans],
-      },
-    );
+      await writeJsonAtomic(
+        join(plans, "plan.json"),
+        { planId: "plan-1" },
+        {
+          privateDirectories: [root, plans],
+        },
+      );
 
-    await expectPosixMode(root, 0o700);
-    await expectPosixMode(plans, 0o700);
-  });
+      await expectPosixMode(root, 0o700);
+      await expectPosixMode(plans, 0o700);
+    },
+    process.platform === "win32" ? 30_000 : 10_000,
+  );
 
   it.runIf(process.platform === "win32")(
     "removes inherited access from private state directories",


### PR DESCRIPTION
## Summary

- add `audit --no-state` for JSON/NDJSON audits that never resolve, create, or write AgentRinse state
- add exact provider selection through `--providers <comma-list>`, requiring `--no-state`
- validate provider IDs, duplicates, empty selections, and configured roots before provider inventory
- add completion support, operator documentation, and a built-CLI permission smoke test

## Safety contract

- `--no-state` rejects `--output` and `--state-dir` before config, home, provider, or state discovery
- provider-scoped audits instantiate only the selected provider adapters and suppress Git, Docker, runtime, and artifact adapters
- selected providers may override `enabled: false`, but configured roots must be absolute
- JSON reports and NDJSON finding events omit `candidateActions`, so redirected output cannot produce plan actions
- the smoke test proves no AgentRinse state is created and excluded Codex, Grok, Git, Docker, runtime, and artifact surfaces are not probed
- no release, version, schema, lockfile, doctor, or production state changes

## Verification

- independent implementation and CI-blocker reviews: clean
- focused audit/completion coverage: 29 passed
- TypeScript typecheck and diff checks: passed
- `pnpm --config.manage-package-manager-versions=false smoke`: passed
- `pnpm --config.manage-package-manager-versions=false pack:check`: passed, including 9 schemas, package manifest, publint, and dry pack
- affected state-file test after the CI fix: 5 passed, 1 Windows-only skipped locally
- privacy scan: clean

Two full `pnpm check` runs passed before the final action-stripping patch. After that patch, formatting, lint, typecheck, schemas, and all assertions remained clean, but six unchanged filesystem-heavy tests exceeded Vitest's 10-second default under Node 26. The worktree cases passed in exact serial retries under the repo-pinned Node 24.16 runtime. The remaining unchanged real-SQLite test passed diagnostically in 23.764 seconds with a 30-second CLI timeout, confirming a baseline timing flake.

Windows CI then reproduced the same timeout class in the unchanged private-directory ACL test at 10.010 and 10.014 seconds. A separate test-only commit gives exactly that test a 30-second budget on Windows while preserving the shared 10-second default on macOS and Linux. No production behavior or shared timeout was changed.
