### PR TITLE
chore(release): prepare 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The project follows semantic versioning after its first supported release.
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-07
+
 ### Added
 
 - stateless JSON and NDJSON audits for an exact provider allowlist, including

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ protected or eligible, creates a content-addressed plan, and revalidates the
 same facts immediately before mutation.
 
 agentrinse is not audit-only. audit establishes the evidence; apply performs
-the approved filesystem, Git metadata, and offline database changes. `0.6.0`
+the approved filesystem, Git metadata, and offline database changes. `0.7.0`
 removes exact configured rebuildable artifacts, quarantines proven inactive
 linked worktrees, repairs and locks their Git registrations, restores
 quarantined worktrees, permanently purges explicitly selected quarantine
@@ -49,7 +49,7 @@ optional external handoff for broader macOS and project debris.
 | 🔒 lock recovery       | operational  | removes only a stale AgentRinse lock after proving its process is gone         | rerun the interrupted command           |
 
 provider sessions, transcripts, credentials, configuration, and logical
-database records remain report-only. `0.6.0` supports explicit offline
+database records remain report-only. `0.7.0` supports explicit offline
 compaction for the exact current Codex `state_5`, `logs_2`, `goals_1`, and
 `memories_1` SQLite contracts. Claude cleanup is limited to exact old debug
 text files and its rebuildable changelog cache. AgentRinse also reports
@@ -112,7 +112,7 @@ brew install vincentkoc/tap/agentrinse
 one-off use:
 
 ```bash
-npx agentrinse@0.6.0 doctor
+npx agentrinse@0.7.0 doctor
 ```
 
 then:
@@ -233,7 +233,7 @@ agentrinse is built around refusal:
 
 there is no generic `--force` escape hatch.
 
-agentrinse `0.6.0` never removes:
+agentrinse `0.7.0` never removes:
 
 - provider sessions, transcripts, logical database rows, credentials, or configuration
 - unsupported provider databases or Codex databases with unknown migrations
@@ -356,7 +356,7 @@ it can be verified before apply.
 
 ## platform support
 
-| Platform       | `0.6.0` support                                                     |
+| Platform       | `0.7.0` support                                                     |
 | -------------- | ------------------------------------------------------------------- |
 | macOS          | audit, artifact/worktree/Claude/Zed cleanup, DB vacuum, undo, purge |
 | Linux          | audit, artifact/worktree/Claude/Zed cleanup, DB vacuum, undo, purge |
@@ -396,12 +396,13 @@ unreleased build at real developer state.
 
 ## status
 
-`0.6.0` ships the complete audit → plan → revalidate → apply loop, safe
+`0.7.0` ships the complete audit → plan → revalidate → apply loop, safe
 configured artifact cleanup, recoverable Git worktree, Claude file, and exact
 Zed rotated-log quarantine, plus recoverable offline Codex database
 compaction. It reports OpenCode's native maintenance contract, Cursor's owner
 database commands, Docker Buildx cache facts, and Grok's version-gated
-session-start memory GC. Grok Build, Docker, and all other Cursor, Zed, and
-OpenCode state remain non-mutating.
+session-start memory GC. Exact-provider JSON and NDJSON audits can run without
+creating AgentRinse state and omit candidate actions. Grok Build, Docker, and
+all other Cursor, Zed, and OpenCode state remain non-mutating.
 
 MIT licensed. built by [Vincent Koc](https://github.com/vincentkoc).

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -25,7 +25,7 @@ schemas.
 {
   "schemaVersion": 1,
   "command": "audit",
-  "agentrinseVersion": "0.6.0",
+  "agentrinseVersion": "0.7.0",
   "startedAt": "2026-07-24T00:00:00.000Z",
   "completedAt": "2026-07-24T00:00:01.000Z",
   "status": "ok",
@@ -121,7 +121,7 @@ resource is skipped rather than substituted.
 
 ## Exit Status
 
-Current `0.6.0` behavior:
+Current `0.7.0` behavior:
 
 | Code  | Meaning                                      |
 | ----- | -------------------------------------------- |

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -20,7 +20,7 @@ Run `agentrinse doctor` to verify the current machine without mutating it.
 
 ## macOS
 
-macOS is Tier 1 for `0.6.0`.
+macOS is Tier 1 for `0.7.0`.
 
 - provider, Git, Docker, and configured artifact inventory
 - `lsof` process ownership proof
@@ -38,7 +38,7 @@ cleanup.
 
 ## Linux
 
-Linux is Tier 2 for `0.6.0`.
+Linux is Tier 2 for `0.7.0`.
 
 - provider, Git, Docker, and configured artifact inventory
 - same-user `/proc` process ownership inspection
@@ -58,7 +58,7 @@ automatically.
 ## WSL
 
 WSL follows the Linux contract for paths and processes inside the WSL
-filesystem. Do not use `0.6.0` to mutate Windows-mounted project trees unless
+filesystem. Do not use `0.7.0` to mutate Windows-mounted project trees unless
 doctor and a disposable canary prove path identity, ownership, rename, and
 mount behavior for that exact setup.
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -2,11 +2,11 @@
 
 Status: active implementation
 
-Target version: 0.6.0
+Target version: 0.7.0
 
 Created: 2026-07-23
 
-Updated: 2026-07-29
+Updated: 2026-08-07
 
 Owner: Vincent Koc
 
@@ -3167,6 +3167,27 @@ Exit criteria:
 - no active log, ACP log, database, thread, configuration, credential,
   extension, crash report, neighboring file, or symlink can match
 - active Zed processes and open descriptors block mutation
+
+### `0.7.0`: stateless exact-provider audits
+
+Deliver:
+
+- `audit --no-state --providers <exact-list>` emits JSON or NDJSON only
+- no AgentRinse state is resolved, created, or written
+- output, state-directory, provider-selector, and relative selected-provider
+  root misuse is rejected before discovery
+- only the exact selected providers are instantiated; Git, Docker, runtime,
+  and artifact adapters remain suppressed
+- transient reports omit every candidate action
+
+Exit criteria:
+
+- parser and provider-registry refusal tests pass
+- an all-enabled configuration still probes only the exact selected providers
+- synthetic home metadata remains unchanged and trap binaries remain untouched
+- repository synthetic permission smoke verifies the denials supported by the
+  active Node runtime; unsupported network and FFI controls require the
+  documented external sandbox
 
 ### `1.0.0`: stable contracts
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -64,7 +64,7 @@ Shipped:
 
 ## 0.6: Additional Provider Policies
 
-Current:
+Shipped:
 
 - exact stale Zed `Zed.log.old` quarantine
 - native macOS, explicit-root, Flatpak, and XDG log-root resolution
@@ -81,7 +81,22 @@ Current:
 - explicit Docker mutation refusal while Buildx cannot condition prune on the
   revalidated owner identity
 
-Remaining:
+## 0.7: Stateless Exact-Provider Audits
+
+Current:
+
+- `audit --no-state --providers <exact-list>` emits JSON or NDJSON only
+- no AgentRinse state is resolved, created, or written
+- invalid output, state-directory, provider, and relative-root combinations
+  fail before discovery
+- only the exact selected providers are instantiated; Git, Docker, runtime,
+  and artifact adapters remain suppressed
+- transient reports omit every candidate action
+- repository synthetic permission smoke verifies the denials supported by the
+  active Node runtime; unsupported network and FFI controls require the
+  documented external sandbox
+
+## Later
 
 - owner-managed old agent runtime removal
 - Docker mutation only after the owner command exposes conditional daemon and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentrinse",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": false,
   "description": "Safe, local-first cleanup for agentic development.",
   "keywords": [

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.6.0";
+export const VERSION = "0.7.0";


### PR DESCRIPTION
## Summary

- bump the package and CLI version to `0.7.0`
- add the stateless exact-provider audit notes under the August 7 release
- refresh current-version docs, the product milestone, and the roadmap
- leave dependencies, lockfiles, workflows, schemas, tests, and runtime behavior unchanged

## Verification

- Node 24 frozen install
- format, lint, typecheck, and schema drift checks
- synthetic smoke and installed-package smoke
- package manifest, publint, and dry-run pack checks
- exact `agentrinse-0.7.0.tgz` smoke; SHA-256 `ce32af63f511c1c1c3d7950992245cb518eb50970699943868ad2ff2ce0a5d67`
- fresh Crabbox Node 24 proof of the exact source commit, lockfile, tarball, installed CLI, and five synthetic run journals
- Node 24 and Node 26 repository synthetic permission smoke verified the denials supported by each runtime and the documented external-sandbox fallback

The local full test run passed 518 tests with one skipped. One unchanged real-SQLite fixture exceeded its 10-second timeout while the host was heavily contended; the isolated diagnostic completed successfully in 29.01 seconds. Clean PR CI remains the release gate.

## Not Included

- dependency PRs #38, #40, and #41
- merge, tag, release, npm publish, or Homebrew changes
