### PR TITLE
feat(clean): add explicit fleet cleanup campaigns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The project follows semantic versioning after its first supported release.
 
 ## [Unreleased]
 
+### Added
+
+- Added explicit multi-repository cleanup campaigns with
+  `clean --profile fleet --repo <root>... --max-risk safe|recoverable`,
+  deterministic Git common-directory deduplication, and fleet-specific action,
+  quarantine-byte, blocker, unknown-state, and diagnostic summaries.
+
+### Safety
+
+- Git worktree reachability now uses bounded upstream, remote, and configured
+  pin checks instead of enumerating every containing ref. Current-worktree
+  protection is exact for worktrees and subtree-scoped for artifacts, ignored
+  content has its own hard blocker, failed fleet repositories remain isolated,
+  and empty applies create no lock or journal.
+
 ## [0.7.0] - 2026-08-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -155,6 +155,20 @@ agentrinse clean --profile closeout --max-risk recoverable
 agentrinse clean --profile closeout --max-risk recoverable --apply --yes
 ```
 
+for an explicit repository fleet, repeat `--repo` and choose the risk ceiling:
+
+```bash
+agentrinse clean --profile fleet \
+  --repo /path/to/repo-a \
+  --repo /path/to/repo-b \
+  --max-risk recoverable
+```
+
+fleet mode requires absolute `--repo` paths and never crawls the current
+directory or home for repositories. linked-worktree aliases are deduplicated
+by their physical Git common directory. add `--apply --yes` only after
+reviewing the persisted plan.
+
 that moves a proven inactive linked worktree into quarantine. it does not
 reclaim disk immediately. restore it or inspect a later permanent purge:
 
@@ -198,6 +212,7 @@ rollback set is actually deleted.
 | `agentrinse audit --allow-offline-vacuum` | propose supported offline Codex DB actions                | none                  |
 | `agentrinse plan`                         | create a bounded plan from a saved audit                  | persisted plan only   |
 | `agentrinse clean --profile closeout`     | audit and plan the current repository                     | none                  |
+| `agentrinse clean --profile fleet`        | audit and plan explicit repository roots                  | none                  |
 | `agentrinse apply --plan <file>`          | revalidate and apply an authorized plan                   | selected actions      |
 | `agentrinse undo <run-id>`                | restore recoverable actions from a run                    | recovery restore      |
 | `agentrinse purge`                        | preview worktree and database recovery backups            | none                  |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,6 +36,19 @@ eligible configured directory. The Git adapter can emit one exact
 
 No adapter mutates directly.
 
+Fleet cleanup shares one reachability index across one provider pass, one Git
+adapter per deduplicated physical common directory, and one artifact adapter.
+Expected Git failures are contained by the owning Git adapter so another
+explicit repository can still produce evidence and actions. Provider
+reachability failure is intentionally not isolated because unknown provider
+ownership must protect all candidate worktrees.
+
+Git reachability avoids repository-wide containing-ref enumeration. Attached
+branches require zero upstream-ahead commits plus a targeted upstream ancestry
+check; branches without upstreams use a bounded `rev-list` proof against local
+remote-tracking refs. Configured branch and remote pins use targeted ancestry
+checks; configured tags require an exact commit target.
+
 ## Plan Engine
 
 The plan engine selects eligible actions within the configured risk ceiling,

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -166,6 +166,31 @@ agentrinse clean --profile closeout --apply --yes --max-risk safe --json
 The profile does not infer that work is complete. Call it only after the task
 has landed, been handed off, or otherwise reached a terminal state.
 
+## Fleet Profile
+
+Fleet cleanup requires every repository and the risk ceiling to be explicit:
+
+```bash
+agentrinse clean --profile fleet \
+  --repo /path/to/repo-a \
+  --repo /path/to/repo-b \
+  --max-risk safe \
+  --json
+```
+
+Use `recoverable` to select proven inactive worktree quarantine actions.
+`destructive` and `experimental` are refused. Fleet mode does not infer a
+repository from the current directory and does not crawl home. Every `--repo`
+must be absolute. Main and linked paths for the same repository are
+deduplicated by the physical Git common directory.
+
+The fleet summary reports repository count, risk ceiling, candidate and
+selected actions, exclusions by risk, candidates by risk, candidate and
+selected quarantine bytes, unknown findings, the five most frequent blockers,
+and diagnostics. `--apply --yes` uses the same persisted immutable plan,
+global lock, journal, revalidation, and executors as `agentrinse apply`. If no
+actions are selected, no apply lock or run journal is created.
+
 Recoverable worktree selection must be explicit:
 
 ```bash

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,6 +128,12 @@ inventory is disabled by default because it searches `PATH` and may execute
 selected binaries with `--version`. Docker is disabled by default and uses
 the active Docker context when enabled. Runtime and Docker remain report-only.
 
+`clean --profile fleet` does not add a configuration surface. Repeated
+absolute `--repo` values are ephemeral command scope, canonicalized by their
+physical Git common directory, and persisted only through the derived plan
+config needed for verification. Revalidation resolves each worktree
+repository from the planned action rather than `adapters.git.root`.
+
 ## Worktree Quarantine
 
 `worktrees.minAgeMinutes` defaults to 14 days and is measured from the newest

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -1487,6 +1487,34 @@ The profile does not infer that a task is finished. The caller remains
 responsible for invoking it only after its work has landed, been handed off, or
 otherwise reached a terminal state.
 
+### Fleet profile
+
+The built-in `fleet` profile audits only explicitly supplied repositories:
+
+```text
+agentrinse clean --profile fleet \
+  --repo /path/to/repo-a \
+  --repo /path/to/repo-b \
+  --max-risk safe
+```
+
+At least one absolute `--repo` and an explicit `safe` or `recoverable` risk
+ceiling are required. The profile never infers a repository from the current
+directory and never crawls home. Repository aliases are canonicalized and
+deduplicated by their physical Git common directory.
+
+Provider reachability collectors run once, Git collection runs once for each
+unique repository, and artifact collection runs once across configured
+projects inside the discovered worktrees. A failed Git repository emits
+diagnostics and no resources without suppressing healthy repositories.
+Unknown provider ownership remains global protection.
+
+The fleet machine summary adds repository count, risk ceiling, candidate and
+selected action counts, exclusions by risk, counts by risk, candidate and
+selected quarantine bytes, unknown findings, and the five most frequent
+blocker codes. Human output also prints diagnostics. An apply with zero
+selected actions does not acquire the lock or create a run journal.
+
 ### `agentrinse undo`
 
 Undo recoverable actions from a run.
@@ -1595,6 +1623,7 @@ Discover worktrees through repositories found from:
 - current working directory
 - provider-managed worktree roots
 - Git common directories referenced by discovered worktrees
+- explicit repeated `--repo` roots in the fleet profile
 
 Use:
 
@@ -1630,14 +1659,18 @@ A branch is not cleanable merely because the working tree is clean.
 
 Protection logic:
 
-1. If there is no upstream, protect unless HEAD is proven reachable from a
-   configured remote ref.
-2. If upstream exists and local is ahead, protect.
+1. If there is no upstream, protect unless bounded `rev-list` proves HEAD
+   reachable from local remote-tracking refs.
+2. If upstream exists, protect when local is ahead or targeted ancestry cannot
+   prove HEAD reachable from that upstream.
 3. If detached, protect unless HEAD is reachable from another durable local
    ref and the policy explicitly permits detached cleanup.
-4. Network fetch is not performed by default. The result is relative to local
+4. Configured branch and remote pins use targeted ancestry checks. Configured
+   tags match only when the tag resolves exactly to HEAD. A pin inspection
+   failure protects that repository.
+5. Network fetch is not performed by default. The result is relative to local
    remote-tracking refs and must say so.
-5. `--fetch` may be a future explicit read-only option.
+6. `--fetch` may be a future explicit read-only option.
 
 ### Artifact trimming
 

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -195,6 +195,8 @@ matches the pinned Codex schema contract.
 `recoverable`, excluded by the default `safe` risk ceiling, and requires:
 
 - a linked, branch-attached, unlocked, clean worktree
+- no ignored content; ignored files have a distinct hard blocker because
+  whole-worktree quarantine would move data outside the active checkout
 - configured remote reachability with no unpushed commit
 - no Git operation, submodule, provider/session root, user pin, or live process
 - complete filesystem measurement with no special entry or mount boundary
@@ -217,6 +219,19 @@ recorded recovery ref.
 Purge is a separate destructive command. It repeats the quarantine checks and
 uses `git worktree remove` without `--force`. Changed or dirty quarantine state
 is never purged.
+
+Repository campaigns remain fail-closed without becoming all-or-nothing.
+Each explicit Git repository probes and collects independently: a failed
+repository emits diagnostics and no resources, while healthy repositories
+continue. Provider metadata is collected once and still protects every
+matching worktree. A missing or malformed provider reachability source remains
+global protection.
+
+The worktree that starts a closeout is an exact `git-worktree` root, not an
+ancestor root for nested linked worktrees. Its rebuildable artifacts remain
+protected by a separate subtree-scoped `build-artifact` root. Provider roots
+retain overlap semantics, so a provider path inside a worktree protects the
+enclosing worktree.
 
 ## Authorization
 

--- a/src/adapters/git/adapter.ts
+++ b/src/adapters/git/adapter.ts
@@ -19,8 +19,8 @@ import {
   type ProcessOwnershipResult,
 } from "../../core/process-ownership.js";
 import type { ReachabilityIndex } from "../../core/reachability.js";
-import { parseWorktreePorcelain } from "./porcelain.js";
-import { listGitRefsForCommit } from "./refs.js";
+import { parseWorktreePorcelain, type GitWorktreeRecord } from "./porcelain.js";
+import { isPushedHead, matchingGitRefPins } from "./refs.js";
 import {
   countStatusSuppressedIndexEntries,
   parseGitStatusPorcelainV2,
@@ -38,6 +38,12 @@ export type GitWorktreeOptions = AgentRinseConfig["audit"] &
 export type GitWorktreeDependencies = {
   measure?: typeof measurePath;
   mountProbe?: (path: string) => Promise<MountBoundaryResult>;
+  inspect?: typeof lstat;
+  isolateRepositoryFailure?: boolean;
+  discovery?: {
+    records?: readonly GitWorktreeRecord[];
+    diagnostic?: Diagnostic;
+  };
 };
 
 const DEFAULT_OPTIONS: GitWorktreeOptions = {
@@ -127,6 +133,24 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
     }
 
     const requestedRoot = resolve(this.root);
+    if (this.dependencies.discovery?.diagnostic !== undefined) {
+      return {
+        adapter: this.id,
+        status: "degraded",
+        root: requestedRoot,
+        detail: "Git repository could not be inspected",
+        diagnostics: [this.dependencies.discovery.diagnostic],
+      };
+    }
+    if (this.dependencies.discovery?.records !== undefined) {
+      return {
+        adapter: this.id,
+        status: "available",
+        root: requestedRoot,
+        detail: "Git repository found",
+        diagnostics: [],
+      };
+    }
     try {
       const root = (
         await this.runGit(["-C", requestedRoot, "rev-parse", "--show-toplevel"])
@@ -158,12 +182,22 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
 
   async collect(context: AuditContext, probe: AdapterProbe): Promise<CollectionResult> {
     if (probe.status !== "available" || probe.root === undefined) {
-      this.reachability?.protectUnresolvedGitRefs(context.now.toISOString());
+      if (this.dependencies.isolateRepositoryFailure !== true) {
+        this.reachability?.protectUnresolvedGitRefs(context.now.toISOString());
+      }
       return { resources: [], diagnostics: [] };
     }
 
-    const output = await this.runGit(["-C", probe.root, "worktree", "list", "--porcelain", "-z"]);
-    const records = parseWorktreePorcelain(output);
+    let records: readonly GitWorktreeRecord[];
+    try {
+      records =
+        this.dependencies.discovery?.records ??
+        parseWorktreePorcelain(
+          await this.runGit(["-C", probe.root, "worktree", "list", "--porcelain", "-z"]),
+        );
+    } catch (error) {
+      return this.repositoryFailure(context, error);
+    }
     const mainWorktreePath = records[0] === undefined ? undefined : resolve(records[0].path);
     const resources: ResourceSnapshot[] = [];
     const diagnostics: Diagnostic[] = [];
@@ -171,10 +205,13 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
     for (const record of records) {
       let exists = true;
       try {
-        const stats = await lstat(record.path);
+        const stats = await (this.dependencies.inspect ?? lstat)(record.path);
         exists = stats.isDirectory() && !stats.isSymbolicLink();
       } catch (error) {
         if (!isMissing(error)) {
+          if (this.dependencies.isolateRepositoryFailure === true) {
+            return this.repositoryFailure(context, error, diagnostics);
+          }
           throw error;
         }
         exists = false;
@@ -184,10 +221,10 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
       const canonicalKey = `git:git-worktree:${worktreePath}`;
       let inspectionComplete = exists;
       let status: GitStatusFacts | undefined;
-      let containingRefs: string[] = [];
       let gitRefs: string[] = [];
-      let gitRefInspectionComplete = false;
+      let gitRefInspectionComplete = true;
       let remotes: string[] = [];
+      let remoteReachable = false;
       let repositoryCommonDir: string | undefined;
       let measurement: Measurement | undefined;
       let mountBoundaries: MountBoundaryResult = {
@@ -207,7 +244,7 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
 
       if (exists) {
         try {
-          stats = await lstat(worktreePath);
+          stats = await (this.dependencies.inspect ?? lstat)(worktreePath);
           await realpath(worktreePath);
           status = parseGitStatusPorcelainV2(
             await this.runGit([
@@ -250,21 +287,45 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
           );
           const head = status.head ?? record.head;
           if (head !== undefined) {
-            const refs = await listGitRefsForCommit(
-              (args) => this.runGit(["-C", worktreePath, ...args]),
-              head,
-            );
-            containingRefs = refs.containingRefs;
+            const configuredPins =
+              this.reachability?.activeGitRefs(context.now.toISOString()) ?? [];
+            let matchingPins: string[] = [];
+            try {
+              matchingPins = await matchingGitRefPins(
+                (args) => this.runGit(["-C", worktreePath, ...args]),
+                head,
+                configuredPins,
+              );
+            } catch (error) {
+              gitRefInspectionComplete = false;
+              diagnostics.push({
+                severity: "warning",
+                code: "GIT_REF_PIN_INSPECTION_FAILED",
+                message: error instanceof Error ? error.message : String(error),
+                adapter: this.id,
+              });
+            }
             gitRefs = [
               record.branch,
               branchRef(status.branch),
               upstreamRef(status.upstream),
-              ...refs.gitRefs,
+              ...matchingPins,
             ]
               .filter((value): value is string => value !== undefined)
               .filter((value, index, values) => values.indexOf(value) === index)
               .sort();
-            gitRefInspectionComplete = true;
+            remoteReachable = await isPushedHead(
+              (args) => this.runGit(["-C", worktreePath, ...args]),
+              {
+                head,
+                ...(status.upstream === undefined ? {} : { upstream: status.upstream }),
+                ahead: status.ahead,
+                remoteConfigured: remotes.length > 0,
+                detached: record.detached,
+              },
+            );
+          } else {
+            gitRefInspectionComplete = false;
           }
           for (const operation of await findGitOperations(
             worktreePath,
@@ -282,6 +343,9 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
             inspectionComplete = false;
           }
         } catch (error) {
+          if (this.dependencies.isolateRepositoryFailure === true) {
+            return this.repositoryFailure(context, error, diagnostics);
+          }
           inspectionComplete = false;
           diagnostics.push({
             severity: "warning",
@@ -298,8 +362,7 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
         gitRefInspectionComplete,
       );
 
-      const localReachable = containingRefs.some((ref) => ref.startsWith("refs/heads/"));
-      const remoteReachable = containingRefs.some((ref) => ref.startsWith("refs/remotes/"));
+      const localReachable = typeof status?.branch === "string" || record.branch !== undefined;
       const remoteConfigured = remotes.length > 0;
       const ahead = status?.ahead ?? 0;
       const staged = status?.staged ?? 0;
@@ -370,19 +433,45 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
           localReachable,
           remoteReachable,
           remoteConfigured,
-          unpushed: ahead > 0 || (remoteConfigured && localReachable && !remoteReachable),
-          remoteProof: remoteConfigured ? "local-remote-tracking-refs" : "unavailable",
+          unpushed:
+            status?.upstream !== undefined
+              ? ahead > 0
+              : remoteConfigured && !record.detached && !remoteReachable,
+          remoteProof:
+            status?.upstream !== undefined
+              ? "configured-upstream"
+              : remoteConfigured
+                ? "local-remote-tracking-refs"
+                : "unavailable",
           inspectionComplete,
           reportOnly: true,
         },
         ...(measurement === undefined ? {} : { measuredBytes: measurement.bytes }),
       });
     }
-    if (records.length === 0) {
+    return { resources, diagnostics };
+  }
+
+  private repositoryFailure(
+    context: AuditContext,
+    error: unknown,
+    diagnostics: readonly Diagnostic[] = [],
+  ): CollectionResult {
+    if (this.dependencies.isolateRepositoryFailure !== true) {
       this.reachability?.protectUnresolvedGitRefs(context.now.toISOString());
     }
-
-    return { resources, diagnostics };
+    return {
+      resources: [],
+      diagnostics: [
+        ...diagnostics,
+        {
+          severity: "warning",
+          code: "GIT_REPOSITORY_INSPECTION_FAILED",
+          message: error instanceof Error ? error.message : String(error),
+          adapter: this.id,
+        },
+      ],
+    };
   }
 
   async classify(context: AuditContext, resource: ResourceSnapshot): Promise<Finding> {
@@ -423,12 +512,26 @@ export class GitWorktreeAuditAdapter implements AuditAdapter {
       });
     }
 
-    if (resource.facts.dirty === true) {
+    if (
+      Number(resource.facts.staged ?? 0) +
+        Number(resource.facts.modified ?? 0) +
+        Number(resource.facts.untracked ?? 0) +
+        Number(resource.facts.conflicted ?? 0) >
+      0
+    ) {
       roots.push({
         code: "dirty-worktree",
         source: "git",
         observedAt,
-        detail: "Git reports staged, modified, conflicted, untracked, or ignored work.",
+        detail: "Git reports staged, modified, conflicted, or untracked work.",
+      });
+    }
+    if (typeof resource.facts.ignored === "number" && resource.facts.ignored > 0) {
+      roots.push({
+        code: "ignored-worktree-content",
+        source: "git",
+        observedAt,
+        detail: "Git reports ignored content that would be lost by whole-worktree cleanup.",
       });
     }
     if (

--- a/src/adapters/git/refs.ts
+++ b/src/adapters/git/refs.ts
@@ -1,29 +1,50 @@
 export type RepositoryGitRunner = (args: string[]) => Promise<string>;
 
-function lines(output: string): string[] {
-  return output
-    .split(/\r?\n/u)
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
-}
-
-export async function listGitRefsForCommit(
+async function gitRefContainsHead(
   runGit: RepositoryGitRunner,
   head: string,
-): Promise<{ containingRefs: string[]; gitRefs: string[] }> {
-  const [containingRefs, tagRefs] = await Promise.all([
-    runGit([
-      "for-each-ref",
-      "--contains",
-      head,
-      "--format=%(refname)",
-      "refs/heads",
-      "refs/remotes",
-    ]).then(lines),
-    runGit(["for-each-ref", "--points-at", head, "--format=%(refname)", "refs/tags"]).then(lines),
-  ]);
-  return {
-    containingRefs,
-    gitRefs: [...new Set([...containingRefs, ...tagRefs])].sort(),
-  };
+  gitRef: string,
+): Promise<boolean> {
+  if (gitRef.startsWith("refs/tags/")) {
+    return (await runGit(["rev-parse", `${gitRef}^{commit}`])).trim() === head;
+  }
+  return (await runGit(["rev-list", "--max-count=1", head, "--not", gitRef])).trim() === "";
+}
+
+export async function isPushedHead(
+  runGit: RepositoryGitRunner,
+  input: {
+    head: string;
+    upstream?: string;
+    ahead: number;
+    remoteConfigured: boolean;
+    detached: boolean;
+  },
+): Promise<boolean> {
+  if (!input.remoteConfigured || input.detached) {
+    return false;
+  }
+  if (input.upstream === undefined) {
+    return (
+      (await runGit(["rev-list", "--max-count=1", input.head, "--not", "--remotes"])).trim() === ""
+    );
+  }
+  const upstream = input.upstream.startsWith("refs/")
+    ? input.upstream
+    : `refs/remotes/${input.upstream}`;
+  return input.ahead === 0 && (await gitRefContainsHead(runGit, input.head, upstream));
+}
+
+export async function matchingGitRefPins(
+  runGit: RepositoryGitRunner,
+  head: string,
+  gitRefs: readonly string[],
+): Promise<string[]> {
+  const matches: string[] = [];
+  for (const gitRef of gitRefs) {
+    if (await gitRefContainsHead(runGit, head, gitRef)) {
+      matches.push(gitRef);
+    }
+  }
+  return matches;
 }

--- a/src/adapters/git/refs.ts
+++ b/src/adapters/git/refs.ts
@@ -1,10 +1,24 @@
 export type RepositoryGitRunner = (args: string[]) => Promise<string>;
 
+async function gitRefExists(runGit: RepositoryGitRunner, gitRef: string): Promise<boolean> {
+  const refs = (await runGit(["for-each-ref", "--format=%(refname)", "--", gitRef]))
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (refs.some((ref) => !ref.startsWith("refs/"))) {
+    throw new Error(`invalid Git ref inspection output for ${gitRef}`);
+  }
+  return refs.includes(gitRef);
+}
+
 async function gitRefContainsHead(
   runGit: RepositoryGitRunner,
   head: string,
   gitRef: string,
 ): Promise<boolean> {
+  if (!(await gitRefExists(runGit, gitRef))) {
+    return false;
+  }
   if (gitRef.startsWith("refs/tags/")) {
     return (await runGit(["rev-parse", `${gitRef}^{commit}`])).trim() === head;
   }

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -4,7 +4,7 @@ import { sha256 } from "../core/digest.js";
 import { ReachabilityIndex, type ReachabilityRoot } from "../core/reachability.js";
 import { ArtifactAuditAdapter } from "./artifacts/adapter.js";
 import { DockerAuditAdapter } from "./docker/adapter.js";
-import { GitWorktreeAuditAdapter } from "./git/adapter.js";
+import { GitWorktreeAuditAdapter, type GitWorktreeDependencies } from "./git/adapter.js";
 import { ProviderAuditAdapter } from "./provider-adapter.js";
 import { PROVIDER_IDS, PROVIDER_SPECS, type ProviderAdapterId } from "./provider-specs.js";
 import { RuntimeAuditAdapter } from "./runtime/adapter.js";
@@ -15,6 +15,10 @@ export type AuditAdapterRegistryOptions = {
   providers?: readonly ProviderAdapterId[];
   providerInventory?: boolean;
   roots?: ReachabilityRoot[];
+  gitRepositories?: readonly {
+    root: string | undefined;
+    discovery?: GitWorktreeDependencies["discovery"];
+  }[];
   environment?: NodeJS.ProcessEnv;
   reachability?: ReachabilityIndex;
   allowOfflineVacuum?: boolean;
@@ -94,20 +98,27 @@ export function createAuditAdapters(
   }
 
   if (gitEnabled) {
-    adapters.push(
-      new GitWorktreeAuditAdapter(
-        config.adapters.git?.root,
-        undefined,
-        undefined,
-        undefined,
-        reachability,
-        {
-          ...config.audit,
-          ...config.worktrees,
-          platform,
-        },
-      ),
-    );
+    const gitRepositories = options.gitRepositories ?? [{ root: config.adapters.git?.root }];
+    for (const repository of gitRepositories) {
+      adapters.push(
+        new GitWorktreeAuditAdapter(
+          repository.root,
+          undefined,
+          undefined,
+          undefined,
+          reachability,
+          {
+            ...config.audit,
+            ...config.worktrees,
+            platform,
+          },
+          {
+            isolateRepositoryFailure: options.gitRepositories !== undefined,
+            ...(repository.discovery === undefined ? {} : { discovery: repository.discovery }),
+          },
+        ),
+      );
+    }
   }
 
   if (config.artifacts.projects.length > 0) {

--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -1,13 +1,15 @@
 import { execFile } from "node:child_process";
+import { realpath } from "node:fs/promises";
 import { isAbsolute, relative, resolve } from "node:path";
 import { promisify } from "node:util";
 
 import { parseWorktreePorcelain } from "../adapters/git/porcelain.js";
-import { createAuditAdapters } from "../adapters/registry.js";
+import { createAuditAdapters, type AuditAdapterRegistryOptions } from "../adapters/registry.js";
 import { confirmApply } from "./apply.js";
 import { loadConfigForHome } from "../config/load.js";
 import type { AgentRinseConfig } from "../config/schema.js";
-import { actionRiskSchema, type ActionRisk } from "../contracts/action.js";
+import { actionRiskSchema, type ActionRisk, type PlannedAction } from "../contracts/action.js";
+import type { Diagnostic } from "../contracts/diagnostic.js";
 import type { CleanupPlan } from "../contracts/plan.js";
 import type { AuditReport } from "../contracts/report.js";
 import type { CleanupRun } from "../contracts/run.js";
@@ -20,13 +22,13 @@ import { writeJsonAtomic } from "../state/json-file.js";
 import { resolveStateRoot, stateLayout } from "../state/layout.js";
 
 const execFileAsync = promisify(execFile);
+const ACTION_RISKS = ["safe", "recoverable", "destructive", "experimental"] as const;
+type FleetRepository = NonNullable<AuditAdapterRegistryOptions["gitRepositories"]>[number];
 
-export type CleanCommandOptions = {
+type CleanCommandBaseOptions = {
   home: string;
   config?: string;
   stateDir?: string;
-  profile: "closeout";
-  cwd?: string;
   apply: boolean;
   yes: boolean;
   json: boolean;
@@ -39,41 +41,73 @@ export type CleanCommandOptions = {
   };
 };
 
+export type CloseoutCleanCommandOptions = CleanCommandBaseOptions & {
+  profile: "closeout";
+  cwd?: string;
+};
+
+export type FleetCleanCommandOptions = CleanCommandBaseOptions & {
+  profile: "fleet";
+  repos: string[];
+};
+
+export type CleanCommandOptions = CloseoutCleanCommandOptions | FleetCleanCommandOptions;
+
 export type MoleHandoff = {
   status: "available" | "absent" | "not-applicable";
   suggestions: string[];
 };
 
-export type CloseoutSummary = {
-  profile: "closeout";
-  repositoryRoot: string;
-  currentWorktree: string;
+type RunSummary = Pick<CleanupRun, "runId" | "status" | "reclaimedBytes"> & {
+  journalPath: string;
+  quarantinedBytes: number;
+};
+
+type SavedCleanSummary = {
   auditId: string;
   planId: string;
   auditPath: string;
   planPath: string;
   configPath: string;
+  run?: RunSummary;
+};
+
+export type CloseoutSummary = SavedCleanSummary & {
+  profile: "closeout";
+  repositoryRoot: string;
+  currentWorktree: string;
   worktrees: number;
   protectedWorktrees: number;
   eligibleActions: number;
   expectedReclaimBytes: number;
   pendingQuarantineBytes: number;
   mole: MoleHandoff;
-  run?: {
-    runId: string;
-    status: CleanupRun["status"];
-    journalPath: string;
-    reclaimedBytes: number;
-    quarantinedBytes: number;
-  };
 };
 
-export type CleanCommandResult = {
+export type FleetSummary = SavedCleanSummary & {
+  profile: "fleet";
+  repositoryCount: number;
+  riskCeiling: "safe" | "recoverable";
+  worktrees: number;
+  protectedWorktrees: number;
+  candidateActions: number;
+  selectedActions: number;
+  excludedByRisk: number;
+  candidatesByRisk: Record<ActionRisk, number>;
+  candidateQuarantineBytes: number;
+  selectedQuarantineBytes: number;
+  unknownFindings: number;
+  topBlockers: { code: string; count: number }[];
+};
+
+export type CleanSummary = CloseoutSummary | FleetSummary;
+
+export type CleanCommandResult<TSummary extends CleanSummary = CleanSummary> = {
   audit: AuditReport;
   plan: CleanupPlan;
   run?: CleanupRun;
   status: "ok" | "degraded" | "failed";
-  summary: CloseoutSummary;
+  summary: TSummary;
   output: string;
 };
 
@@ -120,7 +154,7 @@ function isInside(root: string, candidate: string): boolean {
 
 function scopedConfig(
   config: AgentRinseConfig,
-  currentWorktree: string,
+  gitRoot: string,
   worktrees: string[],
   maxRisk: ActionRisk | undefined,
 ): AgentRinseConfig {
@@ -128,7 +162,7 @@ function scopedConfig(
   for (const id of ["cursor", "copilot", "zed", "opencode", "grok", "runtime", "docker"] as const) {
     scoped.adapters[id] = { enabled: false };
   }
-  scoped.adapters.git = { enabled: true, root: currentWorktree };
+  scoped.adapters.git = { enabled: true, root: gitRoot };
   scoped.artifacts.projects = scoped.artifacts.projects.filter((project) =>
     worktrees.some((worktree) => isInside(worktree, project.root)),
   );
@@ -136,6 +170,95 @@ function scopedConfig(
     scoped.plan.maxRisk = maxRisk;
   }
   return scoped;
+}
+
+async function fleetRepositories(
+  repos: readonly string[],
+  runCommand: (command: string, args: string[]) => Promise<{ stdout: string; stderr: string }>,
+): Promise<{ repositories: FleetRepository[]; worktrees: string[] }> {
+  if (repos.some((repo) => !isAbsolute(repo))) {
+    throw new Error("clean --profile fleet requires absolute --repo paths");
+  }
+  const requested = [...new Set(repos)].sort();
+  const valid = new Map<string, FleetRepository>();
+  const invalid: FleetRepository[] = [];
+  const failed = (root: string, code: string, error: unknown): FleetRepository => ({
+    root,
+    discovery: {
+      diagnostic: {
+        severity: "warning",
+        code,
+        message: error instanceof Error ? error.message : String(error),
+        adapter: "git",
+      },
+    },
+  });
+
+  for (const repo of requested) {
+    let commonDir: string;
+    try {
+      const commonOutput = (
+        await runCommand("git", [
+          "-C",
+          repo,
+          "rev-parse",
+          "--path-format=absolute",
+          "--git-common-dir",
+        ])
+      ).stdout.trim();
+      commonDir = await realpath(commonOutput);
+    } catch (error) {
+      invalid.push(failed(repo, "GIT_PROBE_FAILED", error));
+      continue;
+    }
+    if (valid.has(commonDir)) {
+      continue;
+    }
+    try {
+      const output = (
+        await runCommand("git", ["-C", repo, "worktree", "list", "--porcelain", "-z"])
+      ).stdout;
+      valid.set(commonDir, {
+        root: repo,
+        discovery: { records: parseWorktreePorcelain(output) },
+      });
+    } catch (error) {
+      valid.set(commonDir, failed(repo, "GIT_REPOSITORY_INSPECTION_FAILED", error));
+    }
+  }
+
+  const repositories = [...valid.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([, repository]) => repository)
+    .concat(invalid.sort((left, right) => left.root!.localeCompare(right.root!)));
+  const worktrees = new Set<string>();
+  for (const repository of valid.values()) {
+    for (const record of repository.discovery?.records ?? []) {
+      worktrees.add(resolve(record.path));
+    }
+  }
+  return { repositories, worktrees: [...worktrees].sort() };
+}
+
+function quarantineBytes(actions: readonly PlannedAction[]): number {
+  return actions.reduce(
+    (total, action) =>
+      total + ("pendingQuarantineBytes" in action ? action.pendingQuarantineBytes : 0),
+    0,
+  );
+}
+
+function fleetBlockers(audit: AuditReport): { code: string; count: number }[] {
+  const counts = new Map<string, number>();
+  for (const { roots } of audit.findings) {
+    for (const { code } of roots) {
+      counts.set(code, (counts.get(code) ?? 0) + 1);
+    }
+  }
+  return [...counts]
+    .map(([code, count]) => ({ code, count }))
+    .sort((left, right) => right.count - left.count || left.code.localeCompare(right.code))
+    .slice(0, 5);
 }
 
 async function moleHandoff(
@@ -184,6 +307,49 @@ function renderCloseout(summary: CloseoutSummary): string {
   return `${lines.join("\n")}\n`;
 }
 
+function renderFleet(summary: FleetSummary, diagnostics: readonly Diagnostic[]): string {
+  const riskCounts = ACTION_RISKS.map((risk) => `${risk}=${summary.candidatesByRisk[risk]}`).join(
+    ", ",
+  );
+  const lines = [
+    "AgentRinse fleet cleanup",
+    "",
+    `Repositories: ${summary.repositoryCount}`,
+    `Worktrees: ${summary.worktrees} (${summary.protectedWorktrees} protected)`,
+    `Risk ceiling: ${summary.riskCeiling}`,
+    `Candidate actions: ${summary.candidateActions} (${riskCounts})`,
+    `Selected actions: ${summary.selectedActions} (${summary.excludedByRisk} excluded by risk)`,
+    `Candidate quarantine: ${summary.candidateQuarantineBytes} bytes`,
+    `Selected quarantine: ${summary.selectedQuarantineBytes} bytes`,
+    `Unknown findings: ${summary.unknownFindings}`,
+    `Audit: ${summary.auditPath}`,
+    `Plan: ${summary.planPath}`,
+    `Config: ${summary.configPath}`,
+  ];
+  if (summary.topBlockers.length > 0) {
+    lines.push(
+      "",
+      "Top blockers:",
+      ...summary.topBlockers.map((blocker) => `  ${blocker.code}: ${blocker.count}`),
+    );
+  }
+  if (diagnostics.length > 0) {
+    lines.push(
+      "",
+      "Diagnostics:",
+      ...diagnostics.map((diagnostic) => `  ${diagnostic.code}: ${diagnostic.message}`),
+    );
+  }
+  if (summary.run !== undefined) {
+    lines.push(
+      "",
+      `Run: ${summary.run.status} (${summary.run.reclaimedBytes} reclaimed, ${summary.run.quarantinedBytes} quarantined bytes)`,
+      `Journal: ${summary.run.journalPath}`,
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
 function interruptionFrom(signal?: AbortSignal): CommandInterruptedError | undefined {
   if (signal?.aborted !== true) {
     return undefined;
@@ -193,48 +359,91 @@ function interruptionFrom(signal?: AbortSignal): CommandInterruptedError | undef
     : new CommandInterruptedError("clean interrupted");
 }
 
+export function executeCleanCommand(
+  options: CloseoutCleanCommandOptions,
+): Promise<CleanCommandResult<CloseoutSummary>>;
+export function executeCleanCommand(
+  options: FleetCleanCommandOptions,
+): Promise<CleanCommandResult<FleetSummary>>;
 export async function executeCleanCommand(
   options: CleanCommandOptions,
 ): Promise<CleanCommandResult> {
-  if (options.profile !== "closeout") {
-    throw new Error(`unsupported clean profile: ${options.profile}`);
-  }
   if (options.json && options.apply && !options.yes) {
     throw new Error("clean --json --apply requires --yes");
+  }
+  if (options.profile === "fleet") {
+    const requirement =
+      options.repos.length === 0
+        ? "at least one --repo"
+        : options.maxRisk === undefined
+          ? "--max-risk safe or recoverable"
+          : undefined;
+    if (requirement !== undefined) {
+      throw new Error(`clean --profile fleet requires ${requirement}`);
+    }
+    if (options.maxRisk !== "safe" && options.maxRisk !== "recoverable") {
+      throw new Error("clean --profile fleet supports only --max-risk safe or recoverable");
+    }
   }
   const runCommand = options.dependencies?.runCommand ?? defaultRunCommand;
   const platform = options.dependencies?.platform ?? process.platform;
   const clock = options.dependencies?.now ?? (() => new Date());
-  const cwd = resolve(options.cwd ?? process.cwd());
   const home = resolve(options.home);
-  const currentWorktree = (
-    await runCommand("git", ["-C", cwd, "rev-parse", "--show-toplevel"])
-  ).stdout.trim();
-  if (currentWorktree === "") {
-    throw new Error("closeout requires a Git worktree");
+  let repositories: FleetRepository[];
+  let worktrees: string[];
+  let currentWorktree: string | undefined;
+  let repositoryRoot: string | undefined;
+  if (options.profile === "closeout") {
+    const cwd = resolve(options.cwd ?? process.cwd());
+    currentWorktree = (
+      await runCommand("git", ["-C", cwd, "rev-parse", "--show-toplevel"])
+    ).stdout.trim();
+    if (currentWorktree === "") {
+      throw new Error("closeout requires a Git worktree");
+    }
+    const worktreeOutput = (
+      await runCommand("git", ["-C", currentWorktree, "worktree", "list", "--porcelain", "-z"])
+    ).stdout;
+    worktrees = parseWorktreePorcelain(worktreeOutput).map((record) => resolve(record.path));
+    repositoryRoot = worktrees[0] ?? currentWorktree;
+    repositories = [{ root: currentWorktree }];
+  } else {
+    const fleet = await fleetRepositories(options.repos, runCommand);
+    repositories = fleet.repositories;
+    worktrees = fleet.worktrees;
   }
-  const worktreeOutput = (
-    await runCommand("git", ["-C", currentWorktree, "worktree", "list", "--porcelain", "-z"])
-  ).stdout;
-  const worktrees = parseWorktreePorcelain(worktreeOutput).map((record) => resolve(record.path));
-  const repositoryRoot = worktrees[0] ?? currentWorktree;
   const { config } = await loadConfigForHome(home, options.config);
   const maxRisk =
     options.maxRisk === undefined ? undefined : actionRiskSchema.parse(options.maxRisk);
-  const scoped = scopedConfig(config, currentWorktree, worktrees, maxRisk);
+  const scoped = scopedConfig(config, repositories[0]!.root!, worktrees, maxRisk);
+  const roots =
+    options.profile === "closeout"
+      ? [
+          {
+            path: currentWorktree!,
+            code: "current-worktree",
+            source: "closeout",
+            detail: "The worktree running the closeout profile is protected.",
+            scope: "exact" as const,
+            resourceKinds: ["git-worktree" as const],
+          },
+          {
+            path: currentWorktree!,
+            code: "current-worktree",
+            source: "closeout",
+            detail: "Artifacts inside the current worktree are protected.",
+            scope: "subtree" as const,
+            resourceKinds: ["build-artifact" as const],
+          },
+        ]
+      : [];
   const audit = await runAudit({
     home,
     config: scoped,
     adapters: createAuditAdapters(scoped, platform, {
       providerInventory: false,
-      roots: [
-        {
-          path: currentWorktree,
-          code: "current-worktree",
-          source: "closeout",
-          detail: "The worktree running the closeout profile is protected.",
-        },
-      ],
+      roots,
+      ...(options.profile === "fleet" ? { gitRepositories: repositories } : {}),
     }),
     now: clock,
     ...(options.signal === undefined ? {} : { signal: options.signal }),
@@ -256,7 +465,7 @@ export async function executeCleanCommand(
 
   let run: CleanupRun | undefined;
   let journalPath: string | undefined;
-  if (options.apply) {
+  if (options.apply && plan.actions.length > 0) {
     const interruption = interruptionFrom(options.signal);
     if (interruption !== undefined) {
       throw interruption;
@@ -271,7 +480,13 @@ export async function executeCleanCommand(
       ...(options.signal === undefined ? {} : { signal: options.signal }),
       dependencies: {
         clock,
-        loadCurrentConfig: async () => (await loadConfigForHome(home, options.config)).config,
+        loadCurrentConfig: async () =>
+          scopedConfig(
+            (await loadConfigForHome(home, options.config)).config,
+            repositories[0]!.root!,
+            worktrees,
+            maxRisk,
+          ),
       },
     });
     run = result.run;
@@ -279,22 +494,8 @@ export async function executeCleanCommand(
   }
 
   const gitFindings = audit.findings.filter((finding) => finding.resource.kind === "git-worktree");
-  const summary: CloseoutSummary = {
-    profile: "closeout",
-    repositoryRoot,
-    currentWorktree,
-    auditId: audit.auditId,
-    planId: plan.planId,
-    auditPath,
-    planPath,
-    configPath,
-    worktrees: gitFindings.length,
-    protectedWorktrees: gitFindings.filter((finding) => finding.state !== "eligible").length,
-    eligibleActions: plan.actions.length,
-    expectedReclaimBytes: plan.expectedReclaimBytes,
-    pendingQuarantineBytes: plan.pendingQuarantineBytes ?? 0,
-    mole: await moleHandoff(platform, runCommand),
-    ...(run === undefined || journalPath === undefined
+  const runSummary: { run?: RunSummary } =
+    run === undefined || journalPath === undefined
       ? {}
       : {
           run: {
@@ -304,8 +505,55 @@ export async function executeCleanCommand(
             reclaimedBytes: run.reclaimedBytes,
             quarantinedBytes: run.quarantinedBytes ?? 0,
           },
-        }),
+        };
+  const savedSummary: SavedCleanSummary = {
+    auditId: audit.auditId,
+    planId: plan.planId,
+    auditPath,
+    planPath,
+    configPath,
+    ...runSummary,
   };
+  const summary: CleanSummary =
+    options.profile === "closeout"
+      ? {
+          ...savedSummary,
+          profile: "closeout",
+          repositoryRoot: repositoryRoot!,
+          currentWorktree: currentWorktree!,
+          worktrees: gitFindings.length,
+          protectedWorktrees: gitFindings.filter((finding) => finding.state !== "eligible").length,
+          eligibleActions: plan.actions.length,
+          expectedReclaimBytes: plan.expectedReclaimBytes,
+          pendingQuarantineBytes: plan.pendingQuarantineBytes ?? 0,
+          mole: await moleHandoff(platform, runCommand),
+        }
+      : (() => {
+          const candidates = audit.findings.flatMap((finding) => finding.candidateActions);
+          const candidatesByRisk = Object.fromEntries(
+            ACTION_RISKS.map((risk) => [
+              risk,
+              candidates.filter((action) => action.risk === risk).length,
+            ]),
+          ) as Record<ActionRisk, number>;
+          return {
+            ...savedSummary,
+            profile: "fleet" as const,
+            repositoryCount: repositories.length,
+            riskCeiling: maxRisk as "safe" | "recoverable",
+            worktrees: gitFindings.length,
+            protectedWorktrees: gitFindings.filter((finding) => finding.state !== "eligible")
+              .length,
+            candidateActions: candidates.length,
+            selectedActions: plan.actions.length,
+            excludedByRisk: candidates.length - plan.actions.length,
+            candidatesByRisk,
+            candidateQuarantineBytes: quarantineBytes(candidates),
+            selectedQuarantineBytes: quarantineBytes(plan.actions),
+            unknownFindings: audit.findings.filter((finding) => finding.state === "unknown").length,
+            topBlockers: fleetBlockers(audit),
+          };
+        })();
   const startedAt = audit.startedAt;
   const completedAt = clock().toISOString();
   const status = cleanCommandStatus(audit, run);
@@ -326,6 +574,8 @@ export async function executeCleanCommand(
             diagnostics: audit.diagnostics,
           }),
         )
-      : renderCloseout(summary),
+      : summary.profile === "closeout"
+        ? renderCloseout(summary)
+        : renderFleet(summary, audit.diagnostics),
   };
 }

--- a/src/commands/purge.ts
+++ b/src/commands/purge.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import { resolve } from "node:path";
 import { promisify } from "node:util";
 
-import { listGitRefsForCommit } from "../adapters/git/refs.js";
+import { matchingGitRefPins } from "../adapters/git/refs.js";
 import { createAuditAdapters } from "../adapters/registry.js";
 import { PROVIDER_SPECS } from "../adapters/provider-specs.js";
 import { loadConfigForHome } from "../config/load.js";
@@ -113,18 +113,27 @@ async function currentProtectionRoots(
     path: entry.originalPath,
   };
   const observedAt = now.toISOString();
-  const currentRefs = config.pins.some((pin) => "gitRef" in pin)
-    ? await listGitRefsForCommit(
-        (args) => runGit(["--git-dir", entry.target.repositoryCommonDir, ...args]),
-        entry.target.head,
-      )
-    : { gitRefs: [] };
+  const configuredRefs = reachability.activeGitRefs(observedAt);
+  let matchingRefs: string[] = [];
+  let refInspectionComplete = true;
+  try {
+    matchingRefs = await matchingGitRefPins(
+      (args) => runGit(["--git-dir", entry.target.repositoryCommonDir, ...args]),
+      entry.target.head,
+      configuredRefs,
+    );
+  } catch {
+    refInspectionComplete = false;
+  }
+  reachability.bindGitRefsToPath(
+    entry.originalPath,
+    matchingRefs,
+    observedAt,
+    refInspectionComplete,
+  );
   const facts = {
     ...(entry.target.branch === undefined ? {} : { branch: entry.target.branch }),
-    gitRefs: [
-      ...(entry.target.branch === undefined ? [] : [entry.target.branch]),
-      ...currentRefs.gitRefs,
-    ],
+    gitRefs: [...(entry.target.branch === undefined ? [] : [entry.target.branch]), ...matchingRefs],
   };
   const roots = [
     ...reachability.rootsForResource(resource, facts, observedAt),

--- a/src/core/reachability.ts
+++ b/src/core/reachability.ts
@@ -1,7 +1,7 @@
 import { isAbsolute, relative, resolve } from "node:path";
 
 import type { RootEvidence } from "../contracts/finding.js";
-import type { ResourceRef } from "../contracts/resource.js";
+import type { ResourceKind, ResourceRef } from "../contracts/resource.js";
 
 type ReachabilityEvidence = Omit<RootEvidence, "observedAt"> & {
   expiresAt?: string;
@@ -9,7 +9,8 @@ type ReachabilityEvidence = Omit<RootEvidence, "observedAt"> & {
 
 export type ReachabilityRoot = ReachabilityEvidence & {
   path: string;
-  scope?: "overlap" | "subtree";
+  scope?: "exact" | "overlap" | "subtree";
+  resourceKinds?: readonly ResourceKind[];
 };
 
 function isInside(root: string, candidate: string): boolean {
@@ -25,7 +26,8 @@ export class ReachabilityIndex {
 
   add(root: ReachabilityRoot): void {
     const path = resolve(root.path);
-    const key = `${root.code}\0${root.source}\0${path}\0${root.scope ?? "overlap"}\0${root.evidenceRef ?? ""}`;
+    const resourceKinds = [...(root.resourceKinds ?? [])].sort();
+    const key = `${root.code}\0${root.source}\0${path}\0${root.scope ?? "overlap"}\0${resourceKinds.join(",")}\0${root.evidenceRef ?? ""}`;
     this.roots.set(key, { ...root, path });
   }
 
@@ -81,6 +83,13 @@ export class ReachabilityIndex {
     }
   }
 
+  activeGitRefs(observedAt: string): string[] {
+    return [...this.gitRefRoots]
+      .filter(([, root]) => this.isCurrent(root, observedAt))
+      .map(([key]) => key.slice(0, key.indexOf("\0")))
+      .sort();
+  }
+
   private isCurrent(root: ReachabilityEvidence, observedAt: string): boolean {
     return root.expiresAt === undefined || Date.parse(root.expiresAt) > Date.parse(observedAt);
   }
@@ -103,21 +112,34 @@ export class ReachabilityIndex {
     });
   }
 
-  rootsFor(path: string, observedAt: string): RootEvidence[] {
+  private pathRoots(path: string, observedAt: string, resourceKind?: ResourceKind): RootEvidence[] {
     const target = resolve(path);
     const matchingRoots = [...this.roots.values()]
       .filter((root) => this.isCurrent(root, observedAt))
-      .filter((root) =>
-        root.scope === "subtree"
-          ? isInside(root.path, target)
-          : isInside(root.path, target) || isInside(target, root.path),
+      .filter(
+        (root) =>
+          root.resourceKinds === undefined ||
+          (resourceKind !== undefined && root.resourceKinds.includes(resourceKind)),
       )
-      .map(({ path: _path, scope: _scope, ...root }) => this.evidence(root, observedAt));
+      .filter((root) =>
+        root.scope === "exact"
+          ? root.path === target
+          : root.scope === "subtree"
+            ? isInside(root.path, target)
+            : isInside(root.path, target) || isInside(target, root.path),
+      )
+      .map(({ path: _path, scope: _scope, resourceKinds: _resourceKinds, ...root }) =>
+        this.evidence(root, observedAt),
+      );
     const globalRoots = [...this.globalRoots.values()]
       .filter((root) => this.isCurrent(root, observedAt))
       .map((root) => this.evidence(root, observedAt));
 
     return this.sort([...matchingRoots, ...globalRoots]);
+  }
+
+  rootsFor(path: string, observedAt: string): RootEvidence[] {
+    return this.pathRoots(path, observedAt);
   }
 
   rootsForResource(
@@ -127,8 +149,8 @@ export class ReachabilityIndex {
   ): RootEvidence[] {
     const roots =
       resource.path === undefined
-        ? this.rootsFor("/", observedAt)
-        : this.rootsFor(resource.path, observedAt);
+        ? this.pathRoots("/", observedAt, resource.kind)
+        : this.pathRoots(resource.path, observedAt, resource.kind);
     for (const [key, root] of this.resourceRoots) {
       if (key.startsWith(`${resource.id}\0`) && this.isCurrent(root, observedAt)) {
         roots.push(this.evidence(root, observedAt));

--- a/src/core/worktree-executor.ts
+++ b/src/core/worktree-executor.ts
@@ -10,7 +10,7 @@ import {
   countStatusSuppressedIndexEntries,
   parseGitStatusPorcelainV2,
 } from "../adapters/git/status.js";
-import { listGitRefsForCommit } from "../adapters/git/refs.js";
+import { isPushedHead } from "../adapters/git/refs.js";
 import type { WorktreeQuarantineAction } from "../contracts/action.js";
 import {
   quarantineEntryIdSchema,
@@ -367,16 +367,15 @@ async function assertCleanPushedGitState(
       { diagnosticCode: "WORKTREE_IDENTITY_CHANGED" },
     );
   }
-  const { containingRefs } = await listGitRefsForCommit(
-    (args) => runGit(["--git-dir", action.target.repositoryCommonDir, ...args]),
-    action.target.head,
-  );
-  if (
-    status.ahead > 0 ||
-    action.target.branch === undefined ||
-    !containingRefs.includes(action.target.branch) ||
-    !containingRefs.some((ref) => ref.startsWith("refs/remotes/"))
-  ) {
+  const remoteConfigured = (await runGit(["-C", worktreePath, "remote"])).trim() !== "";
+  const pushed = await isPushedHead((args) => runGit(["-C", worktreePath, ...args]), {
+    head: action.target.head,
+    ...(status.upstream === undefined ? {} : { upstream: status.upstream }),
+    ahead: status.ahead,
+    remoteConfigured,
+    detached: status.branch === undefined,
+  }).catch(() => false);
+  if (action.target.branch === undefined || !pushed) {
     throw new WorktreeExecutionError(
       "worktree HEAD is no longer proven pushed before quarantine",
       "skipped-stale",

--- a/src/core/worktree-revalidation.ts
+++ b/src/core/worktree-revalidation.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
-import { listGitRefsForCommit } from "../adapters/git/refs.js";
+import { matchingGitRefPins } from "../adapters/git/refs.js";
 import { createAuditAdapters } from "../adapters/registry.js";
 import { PROVIDER_SPECS } from "../adapters/provider-specs.js";
 import type { AgentRinseConfig } from "../config/schema.js";
@@ -74,17 +74,29 @@ export async function currentWorktreeProtectionRoots(
     path: action.target.path,
   };
   const observedAt = now.toISOString();
-  const currentRefs = config.pins.some((pin) => "gitRef" in pin)
-    ? await listGitRefsForCommit(
-        (args) => runGit(["--git-dir", action.target.repositoryCommonDir, ...args]),
-        action.target.head,
-      )
-    : { gitRefs: [] };
+  const configuredRefs = reachability.activeGitRefs(observedAt);
+  let matchingRefs: string[] = [];
+  let refInspectionComplete = true;
+  try {
+    matchingRefs = await matchingGitRefPins(
+      (args) => runGit(["--git-dir", action.target.repositoryCommonDir, ...args]),
+      action.target.head,
+      configuredRefs,
+    );
+  } catch {
+    refInspectionComplete = false;
+  }
+  reachability.bindGitRefsToPath(
+    action.target.path,
+    matchingRefs,
+    observedAt,
+    refInspectionComplete,
+  );
   const facts = {
     ...(action.target.branch === undefined ? {} : { branch: action.target.branch }),
     gitRefs: [
       ...(action.target.branch === undefined ? [] : [action.target.branch]),
-      ...currentRefs.gitRefs,
+      ...matchingRefs,
     ],
   };
   const roots = [
@@ -139,7 +151,9 @@ export async function revalidateWorktreeQuarantine(
         ? await runAudit({
             home,
             config,
-            adapters: createAuditAdapters(config, platform),
+            adapters: createAuditAdapters(config, platform, {
+              gitRepositories: [{ root: action.target.path }],
+            }),
             ...(dependencies.now === undefined ? {} : { now: dependencies.now }),
           })
         : await dependencies.audit({ home, config, platform });

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ import { CommandInterruptedError } from "./core/interruption.js";
 import { VERSION } from "./version.js";
 
 export function buildProgram(): Command {
+  const collectOption = (value: string, previous: string[]): string[] => [...previous, value];
   const program = new Command()
     .name("agentrinse")
     .description("Safe cleanup for agentic development.")
@@ -99,16 +100,23 @@ export function buildProgram(): Command {
     .command("clean")
     .description("Audit and plan repository-scoped agent cleanup.")
     .option("--profile <name>", "cleanup profile", "closeout")
+    .option(
+      "--repo <root>",
+      "explicit repository root; repeat for fleet cleanup",
+      collectOption,
+      [],
+    )
     .option("--home <path>", "home directory to audit")
     .option("--config <path>", "explicit JSON config")
     .option("--state-dir <path>", "override the AgentRinse state directory")
     .option("--max-risk <risk>", "safe, recoverable, destructive, or experimental")
     .option("--apply", "apply the fresh plan after confirmation", false)
     .option("--yes", "authorize non-interactive apply", false)
-    .option("--json", "emit a compact versioned closeout summary", false)
+    .option("--json", "emit a compact versioned cleanup summary", false)
     .action(
       async (options: {
         profile: string;
+        repo: string[];
         home?: string;
         config?: string;
         stateDir?: string;
@@ -117,7 +125,7 @@ export function buildProgram(): Command {
         yes: boolean;
         json: boolean;
       }) => {
-        if (options.profile !== "closeout") {
+        if (!["closeout", "fleet"].includes(options.profile)) {
           throw new Error(`unsupported clean profile: ${options.profile}`);
         }
         const controller = new AbortController();
@@ -126,12 +134,22 @@ export function buildProgram(): Command {
         };
         process.on("SIGINT", interrupt);
         try {
-          const result = await executeCleanCommand({
+          const input = {
             ...options,
-            profile: "closeout",
             home: options.home ?? homedir(),
             signal: controller.signal,
-          });
+          };
+          const result =
+            options.profile === "fleet"
+              ? await executeCleanCommand({
+                  ...input,
+                  profile: "fleet",
+                  repos: options.repo,
+                })
+              : await executeCleanCommand({
+                  ...input,
+                  profile: "closeout",
+                });
           process.stdout.write(result.output);
           const exitCode = cleanCommandExitCode(result);
           if (exitCode !== undefined) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -128,6 +128,9 @@ export function buildProgram(): Command {
         if (!["closeout", "fleet"].includes(options.profile)) {
           throw new Error(`unsupported clean profile: ${options.profile}`);
         }
+        if (options.profile === "closeout" && options.repo.length > 0) {
+          throw new Error("clean --profile closeout does not accept --repo; use --profile fleet");
+        }
         const controller = new AbortController();
         const interrupt = () => {
           controller.abort(new CommandInterruptedError("interrupted by SIGINT"));

--- a/test/adapters/git-adapter.test.ts
+++ b/test/adapters/git-adapter.test.ts
@@ -183,12 +183,12 @@ describe("GitWorktreeAuditAdapter", () => {
         return "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n";
       }
       if (command === "for-each-ref") {
-        if (args.includes("--points-at")) {
-          return worktree === linked ? "refs/tags/v0.2.0\n" : "";
-        }
-        return worktree === linked
-          ? "refs/heads/task\nrefs/remotes/origin/task\n"
-          : "refs/heads/main\nrefs/remotes/origin/main\n";
+        const refs =
+          worktree === linked
+            ? ["refs/heads/task", "refs/remotes/origin/task", "refs/tags/v0.2.0"]
+            : ["refs/heads/main", "refs/remotes/origin/main"];
+        const requested = args.at(-1);
+        return requested !== undefined && refs.includes(requested) ? `${requested}\n` : "";
       }
       if (command === "rev-parse" && args.includes("--git-path")) {
         return `.git/${args.at(-1)!}`;
@@ -408,12 +408,18 @@ describe("GitWorktreeAuditAdapter", () => {
       }
       throw new Error(`unexpected Git command: ${args.join(" ")}`);
     };
+    const reachability = new ReachabilityIndex();
+    reachability.addGitRef("refs/tags/missing", {
+      code: "user-pin",
+      source: "config",
+      detail: "User configuration pins this resource.",
+    });
     const adapter = new GitWorktreeAuditAdapter(
       main,
       runner,
       async () => false,
       async () => ({ status: "idle", matches: [] }),
-      undefined,
+      reachability,
       {
         maxEntries: 100,
         measureBytes: true,

--- a/test/adapters/git-adapter.test.ts
+++ b/test/adapters/git-adapter.test.ts
@@ -24,6 +24,97 @@ describe("GitWorktreeAuditAdapter", () => {
     expect((await adapter.probe(context)).status).toBe("degraded");
   });
 
+  it("contains repository collection failures as diagnostics", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-git-"));
+    const context: AuditContext = {
+      home,
+      now: new Date("2026-07-23T00:00:00.000Z"),
+      auditId: "audit-git-failure",
+    };
+    const adapter = new GitWorktreeAuditAdapter(home, async (args) => {
+      if (args.includes("--show-toplevel")) {
+        return `${home}\n`;
+      }
+      throw new Error("repository changed during collection");
+    });
+
+    const collection = await adapter.collect(context, await adapter.probe(context));
+
+    expect(collection.resources).toEqual([]);
+    expect(collection.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "GIT_REPOSITORY_INSPECTION_FAILED",
+        message: "repository changed during collection",
+      }),
+    ]);
+  });
+
+  it("contains malformed fleet discovery without returning partial resources", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-git-"));
+    const context: AuditContext = {
+      home,
+      now: new Date("2026-07-23T00:00:00.000Z"),
+      auditId: "audit-git-parse-failure",
+    };
+    const adapter = new GitWorktreeAuditAdapter(
+      home,
+      async (args) => {
+        if (args.includes("--show-toplevel")) {
+          return `${home}\n`;
+        }
+        return "HEAD before-worktree\0";
+      },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { isolateRepositoryFailure: true },
+    );
+
+    const collection = await adapter.collect(context, await adapter.probe(context));
+
+    expect(collection.resources).toEqual([]);
+    expect(collection.diagnostics).toEqual([
+      expect.objectContaining({ code: "GIT_REPOSITORY_INSPECTION_FAILED" }),
+    ]);
+  });
+
+  it("contains fleet path inspection failures without returning partial resources", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agentrinse-git-"));
+    const context: AuditContext = {
+      home,
+      now: new Date("2026-07-23T00:00:00.000Z"),
+      auditId: "audit-git-path-failure",
+    };
+    const adapter = new GitWorktreeAuditAdapter(
+      home,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        isolateRepositoryFailure: true,
+        discovery: {
+          records: [{ path: home, detached: false, bare: false }],
+        },
+        inspect: async () => {
+          throw new Error("path inspection failed");
+        },
+      },
+    );
+
+    const collection = await adapter.collect(context, await adapter.probe(context));
+
+    expect(collection.resources).toEqual([]);
+    expect(collection.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "GIT_REPOSITORY_INSPECTION_FAILED",
+        message: "path inspection failed",
+      }),
+    ]);
+  });
+
   it("inventories worktrees as protected using a fake Git runner", async () => {
     const home = await mkdtemp(join(tmpdir(), "agentrinse-git-"));
     const main = join(home, "repo");
@@ -76,6 +167,20 @@ describe("GitWorktreeAuditAdapter", () => {
       }
       if (command === "ls-files") {
         return "";
+      }
+      if (command === "rev-list") {
+        const gitRef = args.at(-1);
+        if (
+          (worktree === main && gitRef === "refs/remotes/origin/main") ||
+          (worktree === linked &&
+            ["refs/heads/task", "refs/remotes/origin/task"].includes(gitRef ?? ""))
+        ) {
+          return "";
+        }
+        return `${args[3]}\n`;
+      }
+      if (command === "rev-parse" && args.at(-1) === "refs/tags/v0.2.0^{commit}") {
+        return "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n";
       }
       if (command === "for-each-ref") {
         if (args.includes("--points-at")) {
@@ -152,7 +257,7 @@ describe("GitWorktreeAuditAdapter", () => {
       dirty: true,
       ahead: 1,
       localReachable: true,
-      remoteReachable: true,
+      remoteReachable: false,
       unpushed: true,
       operations: ["merge"],
       processOwnership: "busy",
@@ -207,6 +312,9 @@ describe("GitWorktreeAuditAdapter", () => {
         return "";
       }
       if (command === "ls-files") {
+        return "";
+      }
+      if (command === "rev-list") {
         return "";
       }
       if (command === "rev-parse" && args.includes("--git-path")) {
@@ -280,6 +388,9 @@ describe("GitWorktreeAuditAdapter", () => {
         return "origin\n";
       }
       if (command === "ls-files") {
+        return "";
+      }
+      if (command === "rev-list") {
         return "";
       }
       if (command === "for-each-ref") {
@@ -417,6 +528,29 @@ describe("GitWorktreeAuditAdapter", () => {
         branch: "refs/heads/task",
       },
     });
+    await execFileAsync("git", ["-C", linked, "branch", "--unset-upstream"]);
+    const noUpstreamCollection = await adapter.collect(context, await adapter.probe(context));
+    const noUpstreamResource = noUpstreamCollection.resources.find(
+      (resource) => resource.facts.isMain === false,
+    );
+    expect(noUpstreamResource?.facts).toMatchObject({
+      upstream: undefined,
+      remoteConfigured: true,
+      remoteReachable: true,
+      unpushed: false,
+    });
+    expect(await adapter.classify(context, noUpstreamResource!)).toMatchObject({
+      state: "eligible",
+    });
+    expect(
+      await adapter.classify(context, {
+        ...noUpstreamResource!,
+        facts: { ...noUpstreamResource!.facts, detached: true },
+      }),
+    ).toMatchObject({
+      state: "protected",
+      roots: expect.arrayContaining([expect.objectContaining({ code: "detached-worktree" })]),
+    });
     const reservedFinding = await adapter.classify(context, {
       ...linkedResource!,
       resource: {
@@ -440,7 +574,9 @@ describe("GitWorktreeAuditAdapter", () => {
     const ignoredFinding = await adapter.classify(context, ignoredResource!);
     expect(ignoredFinding).toMatchObject({
       state: "protected",
-      roots: expect.arrayContaining([expect.objectContaining({ code: "dirty-worktree" })]),
+      roots: expect.arrayContaining([
+        expect.objectContaining({ code: "ignored-worktree-content" }),
+      ]),
     });
 
     await rm(join(linked, ".env"));

--- a/test/adapters/git-refs.test.ts
+++ b/test/adapters/git-refs.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { isPushedHead, matchingGitRefPins } from "../../src/adapters/git/refs.js";
+
+describe("bounded Git ref inspection", () => {
+  it("proves remote reachability without enumerating containing refs", async () => {
+    const commands: string[][] = [];
+    const reachable = await isPushedHead(
+      async (args) => {
+        commands.push(args);
+        return "";
+      },
+      {
+        head: "a".repeat(40),
+        ahead: 0,
+        remoteConfigured: true,
+        detached: false,
+      },
+    );
+
+    expect(reachable).toBe(true);
+    expect(commands).toEqual([["rev-list", "--max-count=1", "a".repeat(40), "--not", "--remotes"]]);
+  });
+
+  it("checks an upstream directly and refuses ahead or detached heads", async () => {
+    const head = "c".repeat(40);
+    const commands: string[][] = [];
+    const runGit = async (args: string[]) => {
+      commands.push(args);
+      return "";
+    };
+
+    await expect(
+      isPushedHead(runGit, {
+        head,
+        upstream: "origin/task",
+        ahead: 0,
+        remoteConfigured: true,
+        detached: false,
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      isPushedHead(runGit, {
+        head,
+        upstream: "origin/task",
+        ahead: 1,
+        remoteConfigured: true,
+        detached: false,
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      isPushedHead(runGit, {
+        head,
+        ahead: 0,
+        remoteConfigured: true,
+        detached: true,
+      }),
+    ).resolves.toBe(false);
+
+    expect(commands).toEqual([
+      ["rev-list", "--max-count=1", head, "--not", "refs/remotes/origin/task"],
+    ]);
+  });
+
+  it("checks branch ancestry and exact tag targets only", async () => {
+    const head = "b".repeat(40);
+    const commands: string[][] = [];
+    const matches = await matchingGitRefPins(
+      async (args) => {
+        commands.push(args);
+        if (args[0] === "rev-parse") {
+          return `${head}\n`;
+        }
+        return args.at(-1) === "refs/heads/keep" ? "" : `${head}\n`;
+      },
+      head,
+      ["refs/heads/keep", "refs/remotes/origin/drop", "refs/tags/v1"],
+    );
+
+    expect(matches).toEqual(["refs/heads/keep", "refs/tags/v1"]);
+    expect(commands.every((args) => !args.includes("for-each-ref"))).toBe(true);
+  });
+});

--- a/test/adapters/git-refs.test.ts
+++ b/test/adapters/git-refs.test.ts
@@ -27,6 +27,9 @@ describe("bounded Git ref inspection", () => {
     const commands: string[][] = [];
     const runGit = async (args: string[]) => {
       commands.push(args);
+      if (args[0] === "for-each-ref") {
+        return `${args.at(-1)}\n`;
+      }
       return "";
     };
 
@@ -58,6 +61,7 @@ describe("bounded Git ref inspection", () => {
     ).resolves.toBe(false);
 
     expect(commands).toEqual([
+      ["for-each-ref", "--format=%(refname)", "--", "refs/remotes/origin/task"],
       ["rev-list", "--max-count=1", head, "--not", "refs/remotes/origin/task"],
     ]);
   });
@@ -68,6 +72,9 @@ describe("bounded Git ref inspection", () => {
     const matches = await matchingGitRefPins(
       async (args) => {
         commands.push(args);
+        if (args[0] === "for-each-ref") {
+          return `${args.at(-1)}\n`;
+        }
         if (args[0] === "rev-parse") {
           return `${head}\n`;
         }
@@ -78,6 +85,21 @@ describe("bounded Git ref inspection", () => {
     );
 
     expect(matches).toEqual(["refs/heads/keep", "refs/tags/v1"]);
-    expect(commands.every((args) => !args.includes("for-each-ref"))).toBe(true);
+    expect(commands.every((args) => !args.includes("--contains"))).toBe(true);
+  });
+
+  it("treats a missing exact ref as a non-match", async () => {
+    const commands: string[][] = [];
+    const matches = await matchingGitRefPins(
+      async (args) => {
+        commands.push(args);
+        return "";
+      },
+      "d".repeat(40),
+      ["refs/tags/missing"],
+    );
+
+    expect(matches).toEqual([]);
+    expect(commands).toEqual([["for-each-ref", "--format=%(refname)", "--", "refs/tags/missing"]]);
   });
 });

--- a/test/commands/clean.test.ts
+++ b/test/commands/clean.test.ts
@@ -10,6 +10,7 @@ import {
   cleanCommandExitCode,
   cleanCommandStatus,
   executeCleanCommand,
+  type FleetSummary,
 } from "../../src/commands/clean.js";
 import { DEFAULT_CONFIG } from "../../src/config/defaults.js";
 import { commandEnvelopeSchema } from "../../src/contracts/output.js";
@@ -51,6 +52,23 @@ async function gitFixture(): Promise<{
   ]);
   await run("git", ["-C", main, "worktree", "add", "-b", "task", linked]);
   return { home, main, linked, configPath, stateDir };
+}
+
+async function pushedGitFixture(): Promise<{
+  home: string;
+  main: string;
+  linked: string;
+  configPath: string;
+  stateDir: string;
+}> {
+  const value = await gitFixture();
+  const remote = join(value.home, "remote.git");
+  await run("git", ["init", "--bare", remote]);
+  await run("git", ["-C", value.main, "remote", "add", "origin", remote]);
+  await run("git", ["-C", value.main, "push", "-u", "origin", "main"]);
+  await run("git", ["-C", value.main, "push", "-u", "origin", "task"]);
+  await run("git", ["-C", value.linked, "branch", "--set-upstream-to", "origin/task"]);
+  return value;
 }
 
 function fixtureConfig(projects: { root: string; names: ["node_modules"] }[]) {
@@ -144,7 +162,7 @@ describe("clean closeout profile", () => {
     expect(scopedConfig.artifacts.projects).toEqual([
       { root: value.linked, names: ["node_modules"] },
     ]);
-  });
+  }, 30_000);
 
   it("marks incomplete provider reachability as degraded", async () => {
     const value = await gitFixture();
@@ -177,7 +195,7 @@ describe("clean closeout profile", () => {
     expect(result.audit.diagnostics.map((item) => item.code)).toContain(
       "CODEX_WORKSPACE_METADATA_MISSING",
     );
-  });
+  }, 30_000);
 
   it("applies only an existing safe artifact action from a fresh closeout plan", async () => {
     const value = await gitFixture();
@@ -213,5 +231,176 @@ describe("clean closeout profile", () => {
     expect(result.run?.actions[0]?.status).toBe("applied");
     await expect(access(artifact)).rejects.toMatchObject({ code: "ENOENT" });
     await expect(readFile(join(value.main, "README.md"), "utf8")).resolves.toBe("fixture\n");
+  }, 30_000);
+});
+
+describe("clean fleet profile", () => {
+  it("requires explicit repositories and a bounded risk ceiling", async () => {
+    const value = await gitFixture();
+    const base = {
+      home: value.home,
+      config: value.configPath,
+      stateDir: value.stateDir,
+      profile: "fleet" as const,
+      apply: false,
+      yes: false,
+      json: true,
+    };
+
+    await expect(executeCleanCommand({ ...base, repos: [] })).rejects.toThrow(
+      "requires at least one --repo",
+    );
+    await expect(executeCleanCommand({ ...base, repos: [value.main] })).rejects.toThrow(
+      "requires --max-risk safe or recoverable",
+    );
+    await expect(
+      executeCleanCommand({
+        ...base,
+        repos: [value.main],
+        maxRisk: "destructive",
+      }),
+    ).rejects.toThrow("supports only --max-risk safe or recoverable");
+    await expect(
+      executeCleanCommand({
+        ...base,
+        repos: ["relative/repo"],
+        maxRisk: "safe",
+      }),
+    ).rejects.toThrow("requires absolute --repo paths");
   });
+
+  it("deduplicates linked roots by common directory and skips empty apply state", async () => {
+    const value = await gitFixture();
+    const config = fixtureConfig([]);
+    config.audit.measureBytes = false;
+    await writeJsonAtomic(value.configPath, config);
+
+    let worktreeListCalls = 0;
+    const result = await executeCleanCommand({
+      home: value.home,
+      config: value.configPath,
+      stateDir: value.stateDir,
+      profile: "fleet",
+      repos: [value.linked, value.main, value.linked],
+      maxRisk: "safe",
+      apply: true,
+      yes: true,
+      json: true,
+      dependencies: {
+        platform: "linux",
+        now: () => new Date(),
+        runCommand: async (command, args) => {
+          if (command === "git" && args.includes("worktree") && args.includes("list")) {
+            worktreeListCalls += 1;
+          }
+          return run(command, args);
+        },
+      },
+    });
+    const envelope = commandEnvelopeSchema.parse(JSON.parse(result.output));
+    const summary = envelope.data as FleetSummary;
+
+    expect(result.summary).toMatchObject({
+      profile: "fleet",
+      repositoryCount: 1,
+      riskCeiling: "safe",
+      candidateActions: 0,
+      selectedActions: 0,
+      excludedByRisk: 0,
+      candidateQuarantineBytes: 0,
+      selectedQuarantineBytes: 0,
+    });
+    expect(summary.candidatesByRisk).toEqual({
+      safe: 0,
+      recoverable: 0,
+      destructive: 0,
+      experimental: 0,
+    });
+    expect(result.run).toBeUndefined();
+    expect(worktreeListCalls).toBe(1);
+    await expect(access(join(value.stateDir, "locks"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(access(join(value.stateDir, "runs"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  }, 30_000);
+
+  it("applies safe artifacts and recoverable worktrees only at that ceiling", async () => {
+    const safe = await gitFixture();
+    const artifact = join(safe.main, "node_modules");
+    await mkdir(artifact);
+    await writeFile(join(artifact, "cache.bin"), "remove");
+    await writeJsonAtomic(
+      safe.configPath,
+      fixtureConfig([{ root: safe.main, names: ["node_modules"] }]),
+    );
+    const safeResult = await executeCleanCommand({
+      home: safe.home,
+      config: safe.configPath,
+      stateDir: safe.stateDir,
+      profile: "fleet",
+      repos: [safe.main],
+      maxRisk: "safe",
+      apply: true,
+      yes: true,
+      json: true,
+      dependencies: {
+        platform: "linux",
+        now: () => new Date(),
+        runCommand: run,
+      },
+    });
+    expect(safeResult.run?.actions[0]?.status).toBe("applied");
+    await expect(access(artifact)).rejects.toMatchObject({ code: "ENOENT" });
+
+    const recoverable = await pushedGitFixture();
+    await writeFile(join(recoverable.main, "KEEP.md"), "keep\n");
+    await run("git", ["-C", recoverable.main, "add", "KEEP.md"]);
+    await run("git", [
+      "-C",
+      recoverable.main,
+      "-c",
+      "user.name=AgentRinse",
+      "-c",
+      "user.email=fixture@example.invalid",
+      "commit",
+      "-m",
+      "pin main",
+    ]);
+    await run("git", ["-C", recoverable.main, "tag", "--no-sign", "keep"]);
+    const config = fixtureConfig([]);
+    config.worktrees.minAgeMinutes = 0;
+    config.pins = [{ gitRef: "refs/tags/keep" }];
+    await writeJsonAtomic(recoverable.configPath, config);
+    const recoverableResult = await executeCleanCommand({
+      home: recoverable.home,
+      config: recoverable.configPath,
+      stateDir: recoverable.stateDir,
+      profile: "fleet",
+      repos: [join(recoverable.home, "missing"), recoverable.main],
+      maxRisk: "recoverable",
+      apply: true,
+      yes: true,
+      json: false,
+      dependencies: {
+        platform: process.platform === "linux" ? "linux" : "darwin",
+        now: () => new Date(),
+        runCommand: run,
+      },
+    });
+
+    expect(recoverableResult.summary.candidatesByRisk.recoverable).toBe(1);
+    expect(recoverableResult.run?.actions).toEqual([
+      expect.objectContaining({
+        type: "worktree.quarantine",
+        status: "applied",
+      }),
+    ]);
+    expect(recoverableResult.audit.diagnostics.map((diagnostic) => diagnostic.code)).toContain(
+      "GIT_PROBE_FAILED",
+    );
+    expect(recoverableResult.output).toContain("GIT_PROBE_FAILED:");
+    await expect(access(recoverable.linked)).rejects.toMatchObject({ code: "ENOENT" });
+  }, 120_000);
 });

--- a/test/commands/quarantine.test.ts
+++ b/test/commands/quarantine.test.ts
@@ -648,14 +648,10 @@ describe("purge command", () => {
         dependencies: {
           purge,
           runGit: async (args) => {
-            if (
-              args.includes("--points-at") &&
-              "gitRef" in pin &&
-              pin.gitRef.startsWith("refs/tags/")
-            ) {
-              return `${pin.gitRef}\n`;
+            if (args.includes("rev-parse")) {
+              return `${value.target.head}\n`;
             }
-            return args.includes("--contains") ? `${value.target.branch}\n` : "";
+            return "";
           },
         },
       }),

--- a/test/commands/quarantine.test.ts
+++ b/test/commands/quarantine.test.ts
@@ -648,6 +648,9 @@ describe("purge command", () => {
         dependencies: {
           purge,
           runGit: async (args) => {
+            if (args.includes("for-each-ref") && "gitRef" in pin) {
+              return `${pin.gitRef}\n`;
+            }
             if (args.includes("rev-parse")) {
               return `${value.target.head}\n`;
             }
@@ -658,6 +661,55 @@ describe("purge command", () => {
     ).rejects.toThrow("purge refused protected quarantine entry protected");
 
     expect(purge).not.toHaveBeenCalled();
+  });
+
+  it("does not protect purge with a missing configured Git ref", async () => {
+    const value = entry("missing-ref", "run-2", "2026-08-01T00:00:00.000Z");
+    const fixture = await stateFixture([value]);
+    const configPath = join(fixture.home, "agentrinse.json");
+    await writeFile(
+      configPath,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        adapters: {
+          codex: { enabled: false },
+          claude: { enabled: false },
+          cursor: { enabled: false },
+          copilot: { enabled: false },
+          zed: { enabled: false },
+          opencode: { enabled: false },
+          grok: { enabled: false },
+          git: { enabled: true },
+        },
+        pins: [{ gitRef: "refs/tags/missing" }],
+      })}\n`,
+    );
+    const purge = vi.fn(async (candidate: QuarantineEntry) => ({
+      entry: {
+        ...candidate,
+        status: "purged" as const,
+        purgedAt: "2026-07-24T00:00:00.000Z",
+      },
+      reclaimedBytes: candidate.target.measuredBytes,
+    }));
+
+    await executePurgeCommand({
+      home: fixture.home,
+      config: configPath,
+      stateDir: fixture.stateRoot,
+      expired: false,
+      runId: "run-2",
+      apply: true,
+      yes: true,
+      json: false,
+      now: new Date("2026-07-24T00:00:00.000Z"),
+      dependencies: {
+        purge,
+        runGit: async () => "",
+      },
+    });
+
+    expect(purge).toHaveBeenCalledOnce();
   });
 
   it("revalidates current provider workspace metadata before destructive purge", async () => {

--- a/test/core/audit.test.ts
+++ b/test/core/audit.test.ts
@@ -122,6 +122,29 @@ describe("runAudit", () => {
     expect(adapters.indexOf("git")).toBeLessThan(adapters.indexOf("artifacts"));
   });
 
+  it("runs providers once and Git once per explicit fleet repository", () => {
+    const config = structuredClone(DEFAULT_CONFIG);
+    config.adapters.git = {
+      enabled: true,
+      root: "/tmp/agentrinse-configured-repo",
+    };
+    config.artifacts.projects = [
+      {
+        root: "/tmp/agentrinse-artifact-project",
+        names: ["node_modules"],
+      },
+    ];
+
+    const adapters = createAuditAdapters(config, "linux", {
+      gitRepositories: [{ root: "/tmp/agentrinse-repo-a" }, { root: "/tmp/agentrinse-repo-b" }],
+    }).map((adapter) => adapter.id);
+
+    expect(adapters.filter((id) => id === "git")).toHaveLength(2);
+    expect(adapters.filter((id) => id === "codex")).toHaveLength(1);
+    expect(adapters.filter((id) => id === "claude")).toHaveLength(1);
+    expect(adapters.filter((id) => id === "artifacts")).toHaveLength(1);
+  });
+
   it("adds Docker only when explicitly enabled", () => {
     const config = structuredClone(DEFAULT_CONFIG);
     config.adapters.docker = { enabled: true };

--- a/test/core/database-exclusion.test.ts
+++ b/test/core/database-exclusion.test.ts
@@ -42,17 +42,19 @@ describe("database exclusion", () => {
         "SELECT * FROM values_table;",
       ]),
     ).rejects.toMatchObject({ code: 5 });
-    const waitingWrite = execFileAsync("sqlite3", [
-      "-batch",
-      "-cmd",
-      ".timeout 2000",
-      path,
-      "INSERT INTO values_table VALUES(2);",
-    ]);
+    const waitingWriteRejection = expect(
+      execFileAsync("sqlite3", [
+        "-batch",
+        "-cmd",
+        ".timeout 2000",
+        path,
+        "INSERT INTO values_table VALUES(2);",
+      ]),
+    ).rejects.toBeDefined();
     await new Promise((resolve) => setTimeout(resolve, 50));
 
     await exclusion.release();
-    await expect(waitingWrite).rejects.toBeDefined();
+    await waitingWriteRejection;
     expect((await lstat(path)).mode & 0o7777).toBe(originalMode);
     await expect(
       execFileAsync("sqlite3", ["-batch", path, "SELECT count(*) FROM values_table;"]),

--- a/test/core/reachability.test.ts
+++ b/test/core/reachability.test.ts
@@ -156,4 +156,68 @@ describe("ReachabilityIndex", () => {
       },
     ]);
   });
+
+  it("keeps exact current-worktree protection from leaking to nested worktrees", () => {
+    const index = new ReachabilityIndex();
+    index.add({
+      path: "/tmp/repo",
+      code: "current-worktree",
+      source: "closeout",
+      detail: "current",
+      scope: "exact",
+      resourceKinds: ["git-worktree"],
+    });
+    index.add({
+      path: "/tmp/repo",
+      code: "current-worktree",
+      source: "closeout",
+      detail: "current artifacts",
+      scope: "subtree",
+      resourceKinds: ["build-artifact"],
+    });
+    const observedAt = "2026-07-24T00:00:00.000Z";
+
+    expect(
+      index.rootsForResource(
+        {
+          id: "git:current",
+          adapter: "git",
+          kind: "git-worktree",
+          canonicalKey: "git:/tmp/repo",
+          displayName: "Current",
+          path: "/tmp/repo",
+        },
+        {},
+        observedAt,
+      ),
+    ).toHaveLength(1);
+    expect(
+      index.rootsForResource(
+        {
+          id: "git:nested",
+          adapter: "git",
+          kind: "git-worktree",
+          canonicalKey: "git:/tmp/repo/.worktrees/task",
+          displayName: "Nested",
+          path: "/tmp/repo/.worktrees/task",
+        },
+        {},
+        observedAt,
+      ),
+    ).toEqual([]);
+    expect(
+      index.rootsForResource(
+        {
+          id: "artifact:nested",
+          adapter: "artifacts",
+          kind: "build-artifact",
+          canonicalKey: "artifact:/tmp/repo/.worktrees/task/node_modules",
+          displayName: "node_modules",
+          path: "/tmp/repo/.worktrees/task/node_modules",
+        },
+        {},
+        observedAt,
+      ),
+    ).toHaveLength(1);
+  });
 });

--- a/test/core/worktree-revalidation.test.ts
+++ b/test/core/worktree-revalidation.test.ts
@@ -6,7 +6,7 @@ import { promisify } from "node:util";
 
 import { describe, expect, it, vi } from "vitest";
 
-import { createAuditAdapters } from "../../src/adapters/registry.js";
+import { GitWorktreeAuditAdapter } from "../../src/adapters/git/adapter.js";
 import { DEFAULT_CONFIG } from "../../src/config/defaults.js";
 import type { AgentRinseConfig } from "../../src/config/schema.js";
 import type { WorktreeQuarantineAction } from "../../src/contracts/action.js";
@@ -145,12 +145,25 @@ describe("revalidateWorktreeQuarantine", () => {
     config.adapters.codex = { enabled: true, root: codexRoot };
     config.adapters.git = { enabled: true, root: main };
     config.worktrees = { ...config.worktrees, minAgeMinutes: 0 };
-    config.pins = [{ gitRef: "refs/tags/keep" }];
+    config.pins = [];
     const platform = process.platform === "linux" ? "linux" : "darwin";
     const initial = await runAudit({
       home,
       config,
-      adapters: createAuditAdapters(config, platform),
+      adapters: [
+        new GitWorktreeAuditAdapter(
+          main,
+          undefined,
+          undefined,
+          async () => ({ status: "idle", matches: [] }),
+          undefined,
+          {
+            ...config.audit,
+            ...config.worktrees,
+            platform,
+          },
+        ),
+      ],
     });
     const action = initial.findings
       .flatMap((finding) => finding.candidateActions)
@@ -160,6 +173,10 @@ describe("revalidateWorktreeQuarantine", () => {
       );
     expect(action).toBeDefined();
 
+    const otherRepository = join(home, "other-repo");
+    await execFileAsync("git", ["init", "-b", "main", otherRepository]);
+    config.adapters.git = { enabled: true, root: otherRepository };
+    config.pins = [{ gitRef: "refs/tags/keep" }];
     await execFileAsync("git", ["-C", linked, "tag", "--no-sign", "keep"]);
     await writeFile(
       metadataPath,
@@ -185,7 +202,7 @@ describe("revalidateWorktreeQuarantine", () => {
         expect.objectContaining({ code: "user-pin" }),
       ]),
     );
-  });
+  }, 30_000);
 
   it("blocks mutation on native Windows", async () => {
     const audit = vi.fn(async () => report());

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { buildProgram } from "../src/main.js";
+
+describe("clean CLI", () => {
+  it("rejects repository inputs for the default closeout profile", async () => {
+    const program = buildProgram().exitOverride();
+
+    await expect(
+      program.parseAsync(
+        ["node", "agentrinse", "clean", "--repo", "/tmp/repo", "--apply", "--yes"],
+        { from: "node" },
+      ),
+    ).rejects.toThrow("clean --profile closeout does not accept --repo; use --profile fleet");
+  });
+});


### PR DESCRIPTION
## Summary

- add explicit `clean --profile fleet --repo <absolute-path>... --max-risk <safe|recoverable>` campaigns
- reject `--repo` for the default/closeout profile before any cleanup can run
- deduplicate repositories by Git common directory and isolate expected discovery, parse, and path failures per repository
- preserve closeout output while adding fleet-only diagnostics, blocker/risk summaries, and zero-action no-op apply behavior
- replace broad ref-containment scans with shared bounded pushed-HEAD and configured-pin proof across audit, revalidation, execution, and purge
- constrain current-worktree protection to the exact Git worktree while retaining artifact-subtree protection

## Why

AgentRinse's closeout path was intentionally single-repository, but that left operators without a safe explicit multi-repository cleanup mode. The existing Git protection path also scanned all containing refs, which could exceed the executor timeout in repositories with large ref sets. Fleet discovery failures could abort unrelated repositories, and broad current-root overlap could protect nested worktrees unintentionally.

This change adds an explicit fleet capability without cwd/home inference, keeps provider discovery once per campaign, runs Git discovery once per physical repository, and keeps artifact discovery once.

## Safety

- fleet mode requires absolute `--repo` inputs and an explicit `--max-risk`
- only `safe` and `recoverable` ceilings are accepted
- recoverable worktrees retain quarantine and existing undo/purge behavior
- detached heads remain protected
- upstream branches require zero ahead commits plus targeted remote ancestry proof
- branches without upstreams require bounded proof against remote refs
- configured branch/remote/tag pins are checked directly; incomplete inspection fails closed
- missing configured refs are proven absent by an exact targeted query and do not create permanent protection
- ignored content remains a distinct blocker
- apply revalidates the exact action target
- a zero-action apply creates no apply lock, run, or journal

## Validation

- `oxfmt --check .`
- `oxlint src test`
- `tsc --noEmit`
- `vitest run` (`70` files, `533` passed, `1` skipped)
- `tsc -p tsconfig.build.json`
- `node scripts/generate-schemas.mjs --check`
- `node scripts/check-package-manifest.mjs`
- `publint`
- `npm pack --dry-run`

## LOC

- production: `+635 -171` (net `+464`)
- tests: `+637 -31` (net `+606`)
- docs/changelog: `+127 -5` (net `+122`)

Positive production growth is the explicit fleet capability plus repository isolation, targeted revalidation, unambiguous CLI scoping, and stale-ref safety boundaries. The old global ref scanner and duplicate fleet discovery path are removed.
