### PR TITLE
fix(state): batch Windows private directory hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The project follows semantic versioning after its first supported release.
   protection is exact for worktrees and subtree-scoped for artifacts, ignored
   content has its own hard blocker, failed fleet repositories remain isolated,
   and empty applies create no lock or journal.
+- Private state directories are now preflighted as a complete batch before any
+  permission repair, with one verified Windows ACL update for the full batch.
 
 ## [0.7.0] - 2026-08-07
 

--- a/src/core/apply.ts
+++ b/src/core/apply.ts
@@ -11,7 +11,7 @@ import type { CleanupPlan } from "../contracts/plan.js";
 import type { CleanupRun } from "../contracts/run.js";
 import { acquireApplyLock } from "../state/lock.js";
 import { stateLayout } from "../state/layout.js";
-import { ensurePrivateDirectory } from "../state/json-file.js";
+import { ensurePrivateDirectories } from "../state/json-file.js";
 import { createRunJournal } from "../state/run-journal.js";
 import {
   ArtifactExecutionError,
@@ -153,12 +153,14 @@ export async function applyCleanupPlan(options: ApplyCleanupPlanOptions): Promis
     }
   }
   const runId = randomUUID();
-  await ensurePrivateDirectory(layout.root);
-  await ensurePrivateDirectory(layout.locks);
-  await ensurePrivateDirectory(layout.runs);
-  await ensurePrivateDirectory(layout.quarantine);
-  await ensurePrivateDirectory(layout.providerQuarantine);
-  await ensurePrivateDirectory(layout.databaseBackups);
+  await ensurePrivateDirectories([
+    layout.root,
+    layout.locks,
+    layout.runs,
+    layout.quarantine,
+    layout.providerQuarantine,
+    layout.databaseBackups,
+  ]);
   const lock = await acquireApplyLock(layout.locks, {
     planId: plan.planId,
     runId,

--- a/src/core/worktree-executor.ts
+++ b/src/core/worktree-executor.ts
@@ -18,7 +18,11 @@ import {
   quarantineRecoveryRef,
   type QuarantineEntry,
 } from "../contracts/quarantine.js";
-import { ensurePrivateDirectory, writeJsonAtomic } from "../state/json-file.js";
+import {
+  ensurePrivateDirectories,
+  ensurePrivateDirectory,
+  writeJsonAtomic,
+} from "../state/json-file.js";
 import { findGitOperations } from "./git-operation-state.js";
 import { measurePath, type Measurement, type MeasureOptions } from "./measure.js";
 import { findMountBoundaries, type MountBoundaryResult } from "./mount-boundaries.js";
@@ -309,8 +313,7 @@ async function reserveQuarantineContainer(
       { diagnosticCode: "QUARANTINE_CONTAINER_UNSAFE" },
     );
   }
-  await ensurePrivateDirectory(quarantineParent);
-  await ensurePrivateDirectory(ownerDirectory);
+  await ensurePrivateDirectories([quarantineParent, ownerDirectory]);
   const [container, owner] = await Promise.all([
     inspect(quarantineParent),
     inspect(ownerDirectory),

--- a/src/state/json-file.ts
+++ b/src/state/json-file.ts
@@ -5,34 +5,63 @@ import { dirname, join, win32 as windowsPath } from "node:path";
 import { randomUUID } from "node:crypto";
 
 const execFileAsync = promisify(execFile);
-const windowsPrivateDirectoryPathEnvironmentVariable = "AGENTRINSE_PRIVATE_DIRECTORY";
+const windowsPrivateDirectoriesEnvironmentVariable = "AGENTRINSE_PRIVATE_DIRECTORIES";
+const windowsPrivateDirectoriesMaxJsonLength = 16_384;
 
 const secureWindowsPrivateDirectoryCommand = `
-$directory = [System.IO.DirectoryInfo]::new([Environment]::GetEnvironmentVariable('${windowsPrivateDirectoryPathEnvironmentVariable}'))
+$ErrorActionPreference = 'Stop'
+$decodedPaths = ConvertFrom-Json -InputObject ([Environment]::GetEnvironmentVariable('${windowsPrivateDirectoriesEnvironmentVariable}'))
 $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
 $system = [System.Security.Principal.SecurityIdentifier]::new('S-1-5-18')
 $administrators = [System.Security.Principal.SecurityIdentifier]::new('S-1-5-32-544')
 $identities = @($currentUser, $system, $administrators) | Group-Object Value | ForEach-Object { $_.Group[0] }
 $allowedSids = @($identities | ForEach-Object { $_.Value })
-$acl = $directory.GetAccessControl()
-$owner = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
-if (-not ($owner.Equals($currentUser) -or $owner.Equals($administrators))) { throw "private state directory is not owned by the current user or local Administrators: $($directory.FullName)" }
-$acl.SetAccessRuleProtection($true, $false)
-foreach ($rule in @($acl.Access)) { [void] $acl.RemoveAccessRuleAll($rule) }
 $inheritance = [System.Security.AccessControl.InheritanceFlags]::ObjectInherit -bor [System.Security.AccessControl.InheritanceFlags]::ContainerInherit
 $propagation = [System.Security.AccessControl.PropagationFlags]::None
 $allow = [System.Security.AccessControl.AccessControlType]::Allow
 $full = [System.Security.AccessControl.FileSystemRights]::FullControl
-foreach ($sid in $identities) { $acl.AddAccessRule([System.Security.AccessControl.FileSystemAccessRule]::new($sid, $full, $inheritance, $propagation, $allow)) }
-$directory.SetAccessControl($acl)
-$verified = $directory.GetAccessControl()
-$verifiedOwner = $verified.GetOwner([System.Security.Principal.SecurityIdentifier])
-if (-not ($verifiedOwner.Equals($currentUser) -or $verifiedOwner.Equals($administrators))) { throw "private state directory has an unexpected owner after ACL update: $($directory.FullName)" }
-$rules = @($verified.Access)
-if ($rules.Count -ne $allowedSids.Count) { throw "private state directory has unexpected access rules after ACL update: $($directory.FullName)" }
-foreach ($rule in $rules) {
-  $sid = $rule.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier])
-  if ($rule.AccessControlType -ne $allow -or $allowedSids -notcontains $sid.Value -or $rule.FileSystemRights -ne $full -or $rule.InheritanceFlags -ne $inheritance -or $rule.PropagationFlags -ne $propagation -or $rule.IsInherited) { throw "private state directory ACL verification failed: $($directory.FullName)" }
+
+function Resolve-PrivateDirectory {
+  param([string] $Path, [switch] $AllowMissing)
+  try {
+    $item = Get-Item -LiteralPath $Path -Force -ErrorAction Stop
+  } catch [System.Management.Automation.ItemNotFoundException] {
+    if ($AllowMissing) { return $null }
+    throw "private state directory was not created: $Path"
+  }
+  if (-not ($item -is [System.IO.DirectoryInfo]) -or (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) { throw "private state path is not a real directory: $Path" }
+  $directory = [System.IO.DirectoryInfo] $item
+  $acl = $directory.GetAccessControl()
+  $owner = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
+  if (-not ($owner.Equals($currentUser) -or $owner.Equals($administrators))) { throw "private state directory is not owned by the current user or local Administrators: $($directory.FullName)" }
+  [pscustomobject]@{ Directory = $directory; Acl = $acl }
+}
+
+$missingPaths = @(foreach ($path in $decodedPaths) {
+  $entry = Resolve-PrivateDirectory -Path ([string] $path) -AllowMissing
+  if ($null -eq $entry) { [string] $path }
+})
+foreach ($path in $missingPaths) {
+  [void] [System.IO.Directory]::CreateDirectory($path)
+}
+$entries = @(foreach ($path in $decodedPaths) {
+  Resolve-PrivateDirectory -Path ([string] $path)
+})
+foreach ($entry in $entries) {
+  $entry.Acl.SetAccessRuleProtection($true, $false)
+  foreach ($rule in @($entry.Acl.Access)) { [void] $entry.Acl.RemoveAccessRuleAll($rule) }
+  foreach ($sid in $identities) { $entry.Acl.AddAccessRule([System.Security.AccessControl.FileSystemAccessRule]::new($sid, $full, $inheritance, $propagation, $allow)) }
+  $entry.Directory.SetAccessControl($entry.Acl)
+}
+foreach ($entry in $entries) {
+  $verified = $entry.Directory.GetAccessControl()
+  $verifiedOwner = $verified.GetOwner([System.Security.Principal.SecurityIdentifier])
+  $rules = @($verified.Access)
+  if (-not ($verifiedOwner.Equals($currentUser) -or $verifiedOwner.Equals($administrators)) -or -not $verified.AreAccessRulesProtected -or $rules.Count -ne $allowedSids.Count) { throw "private state directory ACL verification failed: $($entry.Directory.FullName)" }
+  foreach ($sidValue in $allowedSids) {
+    $matching = @($rules | Where-Object { $_.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier]).Value -eq $sidValue })
+    if ($matching.Count -ne 1 -or $matching[0].AccessControlType -ne $allow -or $matching[0].FileSystemRights -ne $full -or $matching[0].InheritanceFlags -ne $inheritance -or $matching[0].PropagationFlags -ne $propagation -or $matching[0].IsInherited) { throw "private state directory ACL verification failed: $($entry.Directory.FullName)" }
+  }
 }
 `;
 
@@ -68,7 +97,11 @@ export type JsonWriteOptions = {
   privateDirectories?: string[];
 };
 
-async function secureWindowsPrivateDirectory(directory: string): Promise<void> {
+async function secureWindowsPrivateDirectories(directories: readonly string[]): Promise<void> {
+  const serialized = JSON.stringify(directories);
+  if (serialized.length > windowsPrivateDirectoriesMaxJsonLength) {
+    throw new Error("private state directory batch exceeds the Windows environment limit");
+  }
   await execFileAsync(
     windowsPowerShellExecutable(),
     ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", secureWindowsPrivateDirectoryCommand],
@@ -76,16 +109,27 @@ async function secureWindowsPrivateDirectory(directory: string): Promise<void> {
       encoding: "utf8",
       env: {
         ...process.env,
-        [windowsPrivateDirectoryPathEnvironmentVariable]: directory,
+        [windowsPrivateDirectoriesEnvironmentVariable]: serialized,
       },
       windowsHide: true,
     },
   );
 }
 
-export async function ensurePrivateDirectory(directory: string): Promise<void> {
-  await mkdir(directory, { recursive: true, mode: 0o700 });
-  const stats = await lstat(directory);
+async function inspectPrivateDirectory(directory: string): Promise<boolean> {
+  let stats;
+  try {
+    stats = await lstat(directory);
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      (error as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      return false;
+    }
+    throw error;
+  }
   if (!stats.isDirectory() || stats.isSymbolicLink()) {
     throw new Error(`private state path is not a real directory: ${directory}`);
   }
@@ -93,11 +137,35 @@ export async function ensurePrivateDirectory(directory: string): Promise<void> {
   if (uid !== undefined && stats.uid !== uid) {
     throw new Error(`private state directory is not owned by the current user: ${directory}`);
   }
-  if (process.platform === "win32") {
-    await secureWindowsPrivateDirectory(directory);
+  return true;
+}
+
+export async function ensurePrivateDirectories(directories: readonly string[]): Promise<void> {
+  const uniqueDirectories = [...new Set(directories)];
+  if (uniqueDirectories.length === 0) {
     return;
   }
-  await chmod(directory, 0o700);
+  if (process.platform === "win32") {
+    await secureWindowsPrivateDirectories(uniqueDirectories);
+    return;
+  }
+  const existingDirectories = await Promise.all(uniqueDirectories.map(inspectPrivateDirectory));
+  for (const [index, directory] of uniqueDirectories.entries()) {
+    if (!existingDirectories[index]) {
+      await mkdir(directory, { recursive: true, mode: 0o700 });
+    }
+  }
+  const verifiedDirectories = await Promise.all(uniqueDirectories.map(inspectPrivateDirectory));
+  for (const [index, exists] of verifiedDirectories.entries()) {
+    if (!exists) {
+      throw new Error(`private state directory was not created: ${uniqueDirectories[index]}`);
+    }
+  }
+  await Promise.all(uniqueDirectories.map((directory) => chmod(directory, 0o700)));
+}
+
+export async function ensurePrivateDirectory(directory: string): Promise<void> {
+  await ensurePrivateDirectories([directory]);
 }
 
 export async function writeJsonAtomic(
@@ -106,9 +174,7 @@ export async function writeJsonAtomic(
   options: JsonWriteOptions = {},
 ): Promise<void> {
   const directory = dirname(path);
-  for (const privateDirectory of new Set(options.privateDirectories ?? [])) {
-    await ensurePrivateDirectory(privateDirectory);
-  }
+  await ensurePrivateDirectories(options.privateDirectories ?? []);
   await mkdir(directory, { recursive: true, mode: 0o700 });
 
   const temporary = join(directory, `.${randomUUID()}.tmp`);

--- a/test/state/json-file.test.ts
+++ b/test/state/json-file.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { chmod, mkdtemp, stat } from "node:fs/promises";
+import { chmod, lstat, mkdir, mkdtemp, stat, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -7,6 +7,7 @@ import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 
 import {
+  ensurePrivateDirectories,
   readJsonFile,
   syncDirectory,
   windowsPowerShellExecutable,
@@ -20,50 +21,74 @@ type WindowsAclRule = {
   sid: string;
   type: string;
   rights: number;
+  inheritance: number;
+  propagation: number;
   inherited: boolean;
 };
 
 type WindowsAcl = {
   currentUserSid: string;
   ownerSid: string;
+  protected: boolean;
   access: WindowsAclRule[];
 };
 
 const inspectWindowsAclCommand = `
-$directory = [System.IO.DirectoryInfo]::new([Environment]::GetEnvironmentVariable('AGENTRINSE_TEST_DIRECTORY'))
+$ErrorActionPreference = 'Stop'
+$decodedDirectories = ConvertFrom-Json -InputObject ([Environment]::GetEnvironmentVariable('AGENTRINSE_TEST_DIRECTORIES'))
 $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
-$acl = $directory.GetAccessControl()
-[pscustomobject]@{
-  currentUserSid = $currentUser
-  ownerSid = $acl.GetOwner([System.Security.Principal.SecurityIdentifier]).Value
-  access = @($acl.Access | ForEach-Object {
-    [pscustomobject]@{
-      sid = $_.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier]).Value
-      type = $_.AccessControlType.ToString()
-      rights = [int]$_.FileSystemRights
-      inherited = $_.IsInherited
-    }
-  })
-} | ConvertTo-Json -Compress
+$results = @(foreach ($directory in $decodedDirectories) {
+  $acl = [System.IO.DirectoryInfo]::new([string]$directory).GetAccessControl()
+  [pscustomobject]@{
+    currentUserSid = $currentUser
+    ownerSid = $acl.GetOwner([System.Security.Principal.SecurityIdentifier]).Value
+    protected = $acl.AreAccessRulesProtected
+    access = @($acl.Access | ForEach-Object {
+      [pscustomobject]@{
+        sid = $_.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier]).Value
+        type = $_.AccessControlType.ToString()
+        rights = [int]$_.FileSystemRights
+        inheritance = [int]$_.InheritanceFlags
+        propagation = [int]$_.PropagationFlags
+        inherited = $_.IsInherited
+      }
+    })
+  }
+})
+ConvertTo-Json -InputObject $results -Depth 4 -Compress
 `;
+
+async function inspectWindowsAcls(directories: readonly string[]): Promise<WindowsAcl[]> {
+  const { stdout } = await execFileAsync(
+    windowsPowerShellExecutable(),
+    ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", inspectWindowsAclCommand],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        AGENTRINSE_TEST_DIRECTORIES: JSON.stringify(directories),
+      },
+      windowsHide: true,
+    },
+  );
+  return JSON.parse(stdout) as WindowsAcl[];
+}
+
+async function setWindowsDirectoryOwner(directory: string, ownerSid: string): Promise<void> {
+  const systemRoot = process.env.SystemRoot;
+  windowsPowerShellExecutable(systemRoot);
+  await execFileAsync(join(systemRoot!, "System32", "icacls.exe"), [
+    directory,
+    "/setowner",
+    `*${ownerSid}`,
+    "/Q",
+  ]);
+}
 
 async function expectPosixMode(path: string, expected: number): Promise<void> {
   if (process.platform !== "win32") {
     expect((await stat(path)).mode & 0o777).toBe(expected);
   }
-}
-
-async function inspectWindowsAcl(directory: string): Promise<WindowsAcl> {
-  const { stdout } = await execFileAsync(
-    "powershell.exe",
-    ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", inspectWindowsAclCommand],
-    {
-      encoding: "utf8",
-      env: { ...process.env, AGENTRINSE_TEST_DIRECTORY: directory },
-      windowsHide: true,
-    },
-  );
-  return JSON.parse(stdout) as WindowsAcl;
 }
 
 describe("atomic JSON files", () => {
@@ -124,8 +149,69 @@ describe("atomic JSON files", () => {
     process.platform === "win32" ? 30_000 : 10_000,
   );
 
+  it("preflights every private directory before changing existing permissions", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agentrinse-private-preflight-"));
+    const valid = join(root, "valid");
+    const target = join(root, "target");
+    const invalid = join(root, "invalid");
+    await mkdir(valid, { mode: 0o755 });
+    await mkdir(target);
+    await chmod(valid, 0o755);
+    await symlink(target, invalid, process.platform === "win32" ? "junction" : "dir");
+    const [before] = process.platform === "win32" ? await inspectWindowsAcls([valid]) : [];
+
+    await expect(ensurePrivateDirectories([valid, invalid, valid])).rejects.toThrow();
+
+    if (before === undefined) {
+      await expectPosixMode(valid, 0o755);
+    } else {
+      expect(await inspectWindowsAcls([valid])).toEqual([before]);
+    }
+  });
+
+  it("does not create missing directories when a later preflight entry is invalid", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agentrinse-private-create-preflight-"));
+    const missing = join(root, "missing");
+    const target = join(root, "target");
+    const invalid = join(root, "invalid");
+    await mkdir(target);
+    await symlink(target, invalid, process.platform === "win32" ? "junction" : "dir");
+
+    await expect(ensurePrivateDirectories([missing, invalid])).rejects.toThrow();
+
+    await expect(lstat(missing)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it.runIf(process.platform === "win32")(
-    "removes inherited access from private state directories",
+    "rejects a foreign-owned batch before creating any missing directory",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "agentrinse-private-owner-preflight-"));
+      const missingBefore = join(root, "missing-before");
+      const foreignOwned = join(root, "foreign-owned");
+      const missingAfter = join(root, "missing-after");
+      await mkdir(foreignOwned);
+      const [originalAcl] = await inspectWindowsAcls([foreignOwned]);
+      if (originalAcl === undefined) {
+        throw new Error("expected the synthetic Windows directory ACL");
+      }
+
+      try {
+        await setWindowsDirectoryOwner(foreignOwned, "S-1-5-18");
+
+        await expect(
+          ensurePrivateDirectories([missingBefore, foreignOwned, missingAfter]),
+        ).rejects.toThrow("not owned by the current user or local Administrators");
+        await expect(lstat(missingBefore)).rejects.toMatchObject({ code: "ENOENT" });
+        await expect(lstat(missingAfter)).rejects.toMatchObject({ code: "ENOENT" });
+      } finally {
+        await setWindowsDirectoryOwner(foreignOwned, originalAcl.ownerSid);
+      }
+    },
+    30_000,
+  );
+
+  it.runIf(process.platform === "win32")(
+    "repairs and verifies exact ACLs for a private directory batch",
     async () => {
       const root = await mkdtemp(join(tmpdir(), "agentrinse-private-state-windows-"));
       const plans = join(root, "plans");
@@ -136,15 +222,35 @@ describe("atomic JSON files", () => {
         { privateDirectories: [root, plans] },
       );
 
-      for (const directory of [root, plans]) {
-        const acl = await inspectWindowsAcl(directory);
+      const acls = await inspectWindowsAcls([root, plans]);
+      expect(acls).toHaveLength(2);
+      for (const acl of acls) {
         expect([acl.currentUserSid, "S-1-5-32-544"]).toContain(acl.ownerSid);
+        expect(acl.protected).toBe(true);
         expect(acl.access).toHaveLength(3);
         expect(acl.access).toEqual(
           expect.arrayContaining([
-            expect.objectContaining({ sid: acl.currentUserSid, type: "Allow", rights: 2_032_127 }),
-            expect.objectContaining({ sid: "S-1-5-18", type: "Allow", rights: 2_032_127 }),
-            expect.objectContaining({ sid: "S-1-5-32-544", type: "Allow", rights: 2_032_127 }),
+            expect.objectContaining({
+              sid: acl.currentUserSid,
+              type: "Allow",
+              rights: 2_032_127,
+              inheritance: 3,
+              propagation: 0,
+            }),
+            expect.objectContaining({
+              sid: "S-1-5-18",
+              type: "Allow",
+              rights: 2_032_127,
+              inheritance: 3,
+              propagation: 0,
+            }),
+            expect.objectContaining({
+              sid: "S-1-5-32-544",
+              type: "Allow",
+              rights: 2_032_127,
+              inheritance: 3,
+              propagation: 0,
+            }),
           ]),
         );
         expect(acl.access.every((rule) => !rule.inherited)).toBe(true);


### PR DESCRIPTION
## Summary

- batch AgentRinse-owned private directory checks before permission repair
- use one Windows PowerShell ACL update for each complete directory batch
- verify protected, exact ACLs for every directory after repair

## Why

Private state setup previously launched one PowerShell process per directory. The
main apply path performs six sequential checks, which made the Windows state
suite vulnerable to crossing its timeout even when each ACL repair succeeded.
Windows PowerShell 5.1 also preserves a decoded JSON array as one object when it
is wrapped in `@(...)`; the batch now enumerates decoded paths explicitly and
uses terminating error behavior.

`src/state/json-file.ts` owns this contract. This change gives it one canonical
batch operation, while preserving the single-directory wrapper for callers that
only own one path.

## Safety boundary

- resource owner: AgentRinse state and quarantine directory creation
- evidence: exact caller-provided paths, `lstat`, POSIX uid, or Windows owner SID
- protection roots: only the explicit state-layout or quarantine paths passed by
  the owning operation
- risk class: permission hardening only; no cleanup action, data movement, or
  deletion behavior changes
- revalidation: the complete existing batch must be real directories with
  accepted ownership before any missing path is created; the complete batch is
  rechecked before ACL mutation, and every resulting ACL is checked afterward
- recovery: no data is moved; a failed call remains retryable through the same
  preflight and exact ACL verification path

## Validation

- focused state/apply/worktree surfaces passed; worktree executor passed 52/52
  in isolation
- `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm schemas:check`
- local parallel suite: 69/70 files passed; four Git-fixture cases hit the
  unchanged 10-second timeout, then passed in the isolated 52/52 run
- `pnpm smoke`
- `pnpm pack:check`
- `pnpm smoke:package`
- fixture follow-up: `pnpm exec oxfmt --check test/state/json-file.test.ts`
- fixture follow-up: `pnpm exec oxlint test/state/json-file.test.ts`
- `git diff --check origin/main...HEAD`
- exact-head hosted CI: run `32493309635`, attempt 2, passed on
  `4e75c466e14bb23feef61bcf53b0c88238bbc034`
- unchanged-head Windows rerun: `windows-audit-state` job `96808327398` passed
- exact-head CodeQL: run `32493325505` passed
- independent exact-head review: no findings

Head: `4e75c466e14bb23feef61bcf53b0c88238bbc034`

Production delta: `+108/-37` (net `+71`). Tests: `+137/-31` (net `+106`).
Changelog: `+2/-0`.
