### PR TITLE
chore(release): prepare 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The project follows semantic versioning after its first supported release.
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-21
+
 ### Added
 
 - Added explicit multi-repository cleanup campaigns with

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ protected or eligible, creates a content-addressed plan, and revalidates the
 same facts immediately before mutation.
 
 agentrinse is not audit-only. audit establishes the evidence; apply performs
-the approved filesystem, Git metadata, and offline database changes. `0.7.0`
+the approved filesystem, Git metadata, and offline database changes. `0.8.0`
 removes exact configured rebuildable artifacts, quarantines proven inactive
 linked worktrees, repairs and locks their Git registrations, restores
 quarantined worktrees, permanently purges explicitly selected quarantine
@@ -49,7 +49,7 @@ optional external handoff for broader macOS and project debris.
 | 🔒 lock recovery       | operational  | removes only a stale AgentRinse lock after proving its process is gone         | rerun the interrupted command           |
 
 provider sessions, transcripts, credentials, configuration, and logical
-database records remain report-only. `0.7.0` supports explicit offline
+database records remain report-only. `0.8.0` supports explicit offline
 compaction for the exact current Codex `state_5`, `logs_2`, `goals_1`, and
 `memories_1` SQLite contracts. Claude cleanup is limited to exact old debug
 text files and its rebuildable changelog cache. AgentRinse also reports
@@ -112,7 +112,7 @@ brew install vincentkoc/tap/agentrinse
 one-off use:
 
 ```bash
-npx agentrinse@0.7.0 doctor
+npx agentrinse@0.8.0 doctor
 ```
 
 then:
@@ -248,7 +248,7 @@ agentrinse is built around refusal:
 
 there is no generic `--force` escape hatch.
 
-agentrinse `0.7.0` never removes:
+agentrinse `0.8.0` never removes:
 
 - provider sessions, transcripts, logical database rows, credentials, or configuration
 - unsupported provider databases or Codex databases with unknown migrations
@@ -371,7 +371,7 @@ it can be verified before apply.
 
 ## platform support
 
-| Platform       | `0.7.0` support                                                     |
+| Platform       | `0.8.0` support                                                     |
 | -------------- | ------------------------------------------------------------------- |
 | macOS          | audit, artifact/worktree/Claude/Zed cleanup, DB vacuum, undo, purge |
 | Linux          | audit, artifact/worktree/Claude/Zed cleanup, DB vacuum, undo, purge |
@@ -411,13 +411,16 @@ unreleased build at real developer state.
 
 ## status
 
-`0.7.0` ships the complete audit → plan → revalidate → apply loop, safe
+`0.8.0` ships the complete audit → plan → revalidate → apply loop, safe
 configured artifact cleanup, recoverable Git worktree, Claude file, and exact
 Zed rotated-log quarantine, plus recoverable offline Codex database
-compaction. It reports OpenCode's native maintenance contract, Cursor's owner
-database commands, Docker Buildx cache facts, and Grok's version-gated
-session-start memory GC. Exact-provider JSON and NDJSON audits can run without
-creating AgentRinse state and omit candidate actions. Grok Build, Docker, and
-all other Cursor, Zed, and OpenCode state remain non-mutating.
+compaction. Explicit fleet cleanup applies the same safety model across
+repeated absolute repository roots, deduplicates linked aliases by physical
+Git common directory, and isolates failed repositories. It reports OpenCode's
+native maintenance contract, Cursor's owner database commands, Docker Buildx
+cache facts, and Grok's version-gated session-start memory GC. Exact-provider
+JSON and NDJSON audits can run without creating AgentRinse state and omit
+candidate actions. Grok Build, Docker, and all other Cursor, Zed, and OpenCode
+state remain non-mutating.
 
 MIT licensed. built by [Vincent Koc](https://github.com/vincentkoc).

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -25,7 +25,7 @@ schemas.
 {
   "schemaVersion": 1,
   "command": "audit",
-  "agentrinseVersion": "0.7.0",
+  "agentrinseVersion": "0.8.0",
   "startedAt": "2026-07-24T00:00:00.000Z",
   "completedAt": "2026-07-24T00:00:01.000Z",
   "status": "ok",
@@ -121,7 +121,7 @@ resource is skipped rather than substituted.
 
 ## Exit Status
 
-Current `0.7.0` behavior:
+Current `0.8.0` behavior:
 
 | Code  | Meaning                                      |
 | ----- | -------------------------------------------- |

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -20,7 +20,7 @@ Run `agentrinse doctor` to verify the current machine without mutating it.
 
 ## macOS
 
-macOS is Tier 1 for `0.7.0`.
+macOS is Tier 1 for `0.8.0`.
 
 - provider, Git, Docker, and configured artifact inventory
 - `lsof` process ownership proof
@@ -38,7 +38,7 @@ cleanup.
 
 ## Linux
 
-Linux is Tier 2 for `0.7.0`.
+Linux is Tier 2 for `0.8.0`.
 
 - provider, Git, Docker, and configured artifact inventory
 - same-user `/proc` process ownership inspection
@@ -58,7 +58,7 @@ automatically.
 ## WSL
 
 WSL follows the Linux contract for paths and processes inside the WSL
-filesystem. Do not use `0.7.0` to mutate Windows-mounted project trees unless
+filesystem. Do not use `0.8.0` to mutate Windows-mounted project trees unless
 doctor and a disposable canary prove path identity, ownership, rename, and
 mount behavior for that exact setup.
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -2,11 +2,11 @@
 
 Status: active implementation
 
-Target version: 0.7.0
+Target version: 0.8.0
 
 Created: 2026-07-23
 
-Updated: 2026-08-07
+Updated: 2026-08-21
 
 Owner: Vincent Koc
 
@@ -3221,6 +3221,29 @@ Exit criteria:
 - repository synthetic permission smoke verifies the denials supported by the
   active Node runtime; unsupported network and FFI controls require the
   documented external sandbox
+
+### `0.8.0`: explicit fleet cleanup
+
+Deliver:
+
+- `clean --profile fleet` audits only repeated absolute `--repo` roots under
+  an explicit `safe` or `recoverable` risk ceiling
+- repository aliases are deduplicated by their physical Git common directory
+- provider reachability runs once, Git collection runs once per unique
+  repository, and artifact collection runs once across discovered worktrees
+- failed repositories remain isolated while unknown provider ownership keeps
+  its global protection
+- machine and human summaries report fleet actions, risk exclusions,
+  quarantine bytes, blockers, unknown findings, and diagnostics
+
+Exit criteria:
+
+- missing, relative, unsupported-risk, and incompatible profile arguments fail
+  before discovery
+- current worktrees, ignored content, failed pin checks, and incomplete
+  repository inspection remain protected
+- duplicate repository aliases do not duplicate discovery or actions
+- an apply with no selected actions creates no lock or run journal
 
 ### `1.0.0`: stable contracts
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -83,7 +83,7 @@ Shipped:
 
 ## 0.7: Stateless Exact-Provider Audits
 
-Current:
+Shipped:
 
 - `audit --no-state --providers <exact-list>` emits JSON or NDJSON only
 - no AgentRinse state is resolved, created, or written
@@ -95,6 +95,20 @@ Current:
 - repository synthetic permission smoke verifies the denials supported by the
   active Node runtime; unsupported network and FFI controls require the
   documented external sandbox
+
+## 0.8: Explicit Fleet Cleanup
+
+Current:
+
+- repeated absolute `--repo` roots with an explicit `safe` or `recoverable`
+  risk ceiling
+- physical Git common-directory deduplication across main and linked paths
+- provider collection once, Git collection once per unique repository, and
+  artifact collection once across discovered worktrees
+- isolated repository failures with global unknown-provider protection
+- fleet action, risk, quarantine-byte, blocker, unknown-state, and diagnostic
+  summaries
+- no apply lock or run journal when no actions are selected
 
 ## Later
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentrinse",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": false,
   "description": "Safe, local-first cleanup for agentic development.",
   "keywords": [

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.7.0";
+export const VERSION = "0.8.0";


### PR DESCRIPTION
## Summary

- prepare AgentRinse `0.8.0` from qualified `main` commit `55def677fb9fca06bf11a1fd1f0836f78e1b0ac0`
- promote the fleet cleanup campaign and safety changes from `Unreleased`
- update current-release references, platform status, product specification, and roadmap

## Scope

- exactly eight release files changed
- no lockfile, workflow, schema, release-process, runtime, or test changes

## Validation

- qualified base CI `32494288304` attempt 2: success, including the second Windows run
- qualified base CodeQL `32494288136`: success
- `git diff --check`
- targeted `oxfmt --check`
- `pnpm check`: 70 test files passed, 535 tests passed, 2 skipped
- `pnpm smoke`
- `pnpm pack:check`
- exact `agentrinse-0.8.0.tgz` install and `pnpm smoke:package`
- SHA-256: `3b74bc6deef82d1bb307e27ca03531124c69bb5c893cce8d369dad3b2bd0c6da`

## Exact-head qualification

- head `20825a21ae807a3ae7e043806710b8b9dc32e02b` remains based directly on `55def677fb9fca06bf11a1fd1f0836f78e1b0ac0`
- hosted CI run `32495309593`: success, including `test` and `windows-audit-state`
- hosted CodeQL run `32495307460`: success for Actions and JavaScript/TypeScript
- independent exact-head review: landable with no findings
